### PR TITLE
Make sassert not hijack else statements

### DIFF
--- a/include/seahorn/seahorn.h
+++ b/include/seahorn/seahorn.h
@@ -10,5 +10,5 @@ extern void __VERIFIER_assume (int);
 #endif
 
 #define assume __VERIFIER_assume
-#define sassert(X) if(!(X)) __VERIFIER_error ()
+#define sassert(X) (void)((X) || (__VERIFIER_error (), 0))
 #endif

--- a/test/simple/sassert.c
+++ b/test/simple/sassert.c
@@ -1,0 +1,19 @@
+// RUN: %sea pf "%s"  2>&1 | OutputCheck %s
+// CHECK: ^unsat$
+
+#include "seahorn/seahorn.h"
+
+int main() {
+  int x = 0, y = 1, z = 2;
+  
+  sassert(x == 0);
+  //  Check if sassert works with the comma operator. 
+  while (sassert(y == 1), 0);
+
+  if (z > 0)
+  	sassert(z > 1);
+  else // Ensure that sassert doesn't 'hijack' the next else statement.
+  	sassert(z < 1); // This else is supposed to be dead.
+
+  sassert(y >= 1 && (0, !x)); // Check if sassert handles commas in conditions.
+}


### PR DESCRIPTION
This improves the sassert macro by making it an expression and not an if statement.

Consider this snippet:
``` c
if (cond1)
  sassert(cond2);
else
  foo();
```
The problem with sassert being defined as if statement is that it hijacks else statements that follow it and changes user's intended control flow. One of the solutions would be to put the if inside a block `#define sassert(X) { if ... }`, but that makes it a compound statement and it would make it impossible to use with an else following it. The other idiomatic C solution would be to put it inside `do { if ... } while(0)`, but the problem is that the C frontend could generate a new loop when compiling with `-O0`.

This path comes with a regression test for using sassert within expressions and with else block.