### PR TITLE
use MBP based QE tactic

### DIFF
--- a/include/ufo/Smt/Z3n.hpp
+++ b/include/ufo/Smt/Z3n.hpp
@@ -148,7 +148,7 @@ namespace ufo
     z3::goal goal (ctx);
     Z3_goal_assert (ctx, goal, qexpr);
 
-    z3::tactic qe (ctx, "qe");
+    z3::tactic qe (ctx, "qe2");
     ctx.check_error ();
 
     z3::apply_result ares = qe (goal);


### PR DESCRIPTION
Z3 4.5 has a new tactic[1] for quantifier elimination called "qe2", which outperforms 
the "qe" tactic.  "qe2" is built on top of a recent technique "model based projection"[2].

[1] Playing with Quantified Satisfaction, N Bjørner et al, LPAR 15
[2] SMT-based model checking for recursive programs, CAV 14