### PR TITLE
Add initial SimpleMemoryCheck pass implementation

### DIFF
--- a/include/seahorn/Transforms/Instrumentation/SimpleMemoryCheck.hh
+++ b/include/seahorn/Transforms/Instrumentation/SimpleMemoryCheck.hh
@@ -1,0 +1,12 @@
+#ifndef SIMPLE_MEMORY_CHECK__HH
+#define SIMPLE_MEMORY_CHECK__HH
+
+namespace llvm {
+class ModulePass;
+}
+
+namespace seahorn {
+llvm::ModulePass *CreateSimpleMemoryCheckPass();
+}
+
+#endif

--- a/lib/Transforms/Instrumentation/CMakeLists.txt
+++ b/lib/Transforms/Instrumentation/CMakeLists.txt
@@ -12,6 +12,7 @@ add_llvm_library(SeaInstrumentation
   RenameNondet.cc
   NullCheck.cc
   BufferBoundsCheck.cc
+  SimpleMemoryCheck.cc
   )
 
 if (HAVE_DSA)

--- a/lib/Transforms/Instrumentation/SimpleMemoryCheck.cc
+++ b/lib/Transforms/Instrumentation/SimpleMemoryCheck.cc
@@ -1,0 +1,62 @@
+#include "seahorn/Transforms/Instrumentation/SimpleMemoryCheck.hh"
+
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallSet.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Analysis/CallGraph.h"
+#include "llvm/Analysis/MemoryBuiltins.h"
+#include "llvm/Analysis/TargetLibraryInfo.h"
+#include "llvm/IR/DataLayout.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/Pass.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Transforms/Utils/BasicBlockUtils.h"
+#include "llvm/Transforms/Utils/Cloning.h"
+#include "llvm/Transforms/Utils/Local.h"
+#include "llvm/Transforms/Utils/UnifyFunctionExitNodes.h"
+
+#include "avy/AvyDebug.h"
+#include "sea_dsa/DsaAnalysis.hh"
+
+#define SMC_LOG(...) LOG("smc", __VA_ARGS__)
+
+using namespace llvm;
+
+namespace seahorn {
+
+class SimpleMemoryCheck : public llvm::ModulePass {
+public:
+  static char ID;
+  SimpleMemoryCheck() : llvm::ModulePass(ID) {}
+  virtual bool runOnModule(llvm::Module &M);
+  virtual void getAnalysisUsage(llvm::AnalysisUsage &AU) const;
+  virtual const char *getPassName() const { return "SimpleMemoryCheck"; }
+
+private:
+};
+
+llvm::ModulePass *CreateSimpleMemoryCheckPass() {
+  return new SimpleMemoryCheck();
+}
+
+bool SimpleMemoryCheck::runOnModule(llvm::Module &M) {
+  return true;
+}
+
+void SimpleMemoryCheck::getAnalysisUsage(llvm::AnalysisUsage &AU) const {
+  AU.setPreservesAll();
+  AU.addRequired<sea_dsa::DsaInfoPass>(); // run seahorn dsa
+  AU.addRequired<llvm::TargetLibraryInfoWrapperPass>();
+  AU.addRequired<llvm::UnifyFunctionExitNodes>();
+  AU.addRequired<llvm::CallGraphWrapperPass>();
+  // for debugging
+  // AU.addRequired<ufo::NameValues> ();
+}
+
+char SimpleMemoryCheck::ID = 0;
+
+static llvm::RegisterPass<SimpleMemoryCheck>
+    Y("smc", "Insert array buffer checks using simple encoding");
+
+} // end namespace seahorn

--- a/lib/Transforms/Scalar/LowerGvInitializers.cc
+++ b/lib/Transforms/Scalar/LowerGvInitializers.cc
@@ -1,6 +1,7 @@
 #include "seahorn/Transforms/Scalar/LowerGvInitializers.hh"
 
 #include "boost/format.hpp"
+#include "boost/range.hpp"
 
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/Support/raw_ostream.h"

--- a/lib/Transforms/Scalar/LowerGvInitializers.cc
+++ b/lib/Transforms/Scalar/LowerGvInitializers.cc
@@ -1,7 +1,6 @@
 #include "seahorn/Transforms/Scalar/LowerGvInitializers.hh"
 
 #include "boost/format.hpp"
-#include "boost/range.hpp"
 
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/Support/raw_ostream.h"

--- a/py/seapy
+++ b/py/seapy
@@ -37,7 +37,9 @@ def main (argv):
             sea.commands.WrapMem(),
             sea.commands.Exe,
             sea.commands.SeaInspect(),
-            sea.commands.feInspect
+            sea.commands.feInspect,
+            sea.commands.SimpleMemoryChecks(),
+            sea.commands.Smc
     ]
 
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -34,6 +34,15 @@ add_lit_testsuite(test-abc "Regression test for Array Bounds Checks"
   DEPENDS seahorn
   )
 
+add_lit_testsuite(test-smc "Regression test for Simple Memory Safety Checks"
+  -v
+  ${CMAKE_CURRENT_SOURCE_DIR}/smc
+  PARAMS
+  test_dir=${CMAKE_CURRENT_BINARY_DIR}
+  DEPENDS seahorn
+  )
+
+
 add_lit_testsuite(test-inc "Regression test for Inconsistency Analysis"
   -v
   ${CMAKE_CURRENT_SOURCE_DIR}/inc

--- a/test/smc/list1_check.c
+++ b/test/smc/list1_check.c
@@ -1,0 +1,135 @@
+// RUN: %sea pf -O0 --inline "%s" 2>&1 | OutputCheck %s
+// CHECK: ^unsat$
+#include <seahorn/seahorn.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#define FOO_TAG 100
+#define BAR_TAG 200
+
+static int8_t *g_bgn;
+static int8_t *g_end;
+static int g_active;
+
+extern int nd(void);
+extern int8_t *nd_ptr(void);
+
+typedef struct Foo {
+  int tag;
+  int x;
+} Foo;
+
+typedef struct Bar {
+  struct Foo foo;
+  int y;
+} Bar;
+
+void *xmalloc(size_t sz) {
+  void *p;
+  p = malloc(sz);
+  assume(((ptrdiff_t)p) > 0);
+  return p;
+}
+Foo *mk_foo(int x) {
+  Foo *res = (Foo *)xmalloc(sizeof(struct Foo));
+  res->tag = FOO_TAG;
+  res->x = x;
+
+  if (!g_active && nd()) {
+    g_active = !g_active;
+    assume((int8_t *)res == g_bgn);
+    assume(g_bgn + sizeof(struct Foo) == g_end);
+  } else {
+    assume((int8_t *)res > g_end);
+  }
+
+  return res;
+}
+
+Bar *mk_bar(int x, int y) {
+  Bar *res = (Bar *)xmalloc(sizeof(struct Bar));
+  res->foo.tag = BAR_TAG;
+  res->foo.x = x;
+  res->y = y;
+
+  assume((int8_t *)res > g_end);
+  return res;
+}
+
+Foo *to_foo(Bar *b) { return (Foo *)b; }
+int is_bar(Foo *b) { return b->tag == BAR_TAG; }
+int is_foo(Foo *b) { return b->tag == FOO_TAG; }
+Bar *to_bar(Foo *b) { return (Bar *)b; }
+
+typedef struct Entry {
+  void *data;
+  struct Entry *next;
+} Entry;
+
+typedef struct List {
+  Entry *head;
+} List;
+
+Entry *mk_entry(void *data) {
+  Entry *res = (Entry *)xmalloc(sizeof(struct Entry));
+  res->data = data;
+  res->next = NULL;
+  assume((int8_t *)res > g_end);
+  return res;
+}
+
+List *mk_list() {
+  List *res = (List *)xmalloc(sizeof(struct List));
+  res->head = NULL;
+
+  assume((int8_t *)res > g_end);
+  return res;
+}
+
+void insert(List *lst, void *data) {
+  Entry *en = mk_entry(data);
+  en->next = lst->head;
+  lst->head = en;
+}
+
+int main(void) {
+  List *lst;
+  Entry *it;
+
+  g_bgn = nd_ptr();
+  g_end = nd_ptr();
+  assume(g_bgn > 0);
+  assume(g_end > g_bgn);
+
+  g_active = 0;
+
+  lst = mk_list();
+  insert(lst, mk_foo(2));
+  insert(lst, mk_bar(3, 4));
+  insert(lst, mk_foo(5));
+
+  unsigned cnt;
+  cnt = 0;
+  for (it = lst->head; it != NULL; it = it->next) {
+    Foo *v = (Foo *)(it->data);
+    if (is_bar(v)) {
+      Bar *b;
+
+      if (g_active) {
+        sassert((int8_t *)v != g_bgn);
+      }
+
+      b = to_bar(v);
+      printf("bar: x=%d, y=%d\n", v->x, b->y);
+    } else {
+      printf("foo: x=%d\n", v->x);
+    }
+    cnt++;
+    if (cnt > 3)
+      break;
+  }
+  return 0;
+}

--- a/test/smc/list1_global_sat.c
+++ b/test/smc/list1_global_sat.c
@@ -1,0 +1,96 @@
+// RUN: %sea smc -O3 --inline --horn-sea-dsa "%s" 2>&1 | OutputCheck %s
+// CHECK: ^sat$
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#define FOO_TAG 123
+#define BAR_TAG 234
+
+typedef struct Foo {
+  int tag;
+  int x;
+} Foo;
+
+typedef struct Bar {
+  struct Foo foo;
+  int y;
+} Bar;
+
+Foo *mk_foo(int x) {
+  Foo *res = (Foo *)malloc(sizeof(struct Foo));
+  res->tag = FOO_TAG;
+  res->x = x;
+  return res;
+}
+
+Bar *mk_bar(int x, int y) {
+  Bar *res = (Bar *)malloc(sizeof(struct Bar));
+  res->foo.tag = BAR_TAG;
+  res->foo.x = x;
+  res->y = y;
+  return res;
+}
+
+struct Foo g_bad_foo = {BAR_TAG, 5};
+
+Foo *to_foo(Bar *b) { return (Foo *)b; }
+int is_bar(Foo *b) { return b->tag == BAR_TAG; }
+Bar *to_bar(Foo *b) { return (Bar *)b; }
+
+typedef struct Entry {
+  void *data;
+  struct Entry *next;
+} Entry;
+
+typedef struct List {
+  Entry *head;
+} List;
+
+Entry *mk_entry(void *data) {
+  Entry *res = (Entry *)malloc(sizeof(struct Entry));
+  res->data = data;
+  res->next = NULL;
+  return res;
+}
+
+List *mk_list() {
+  List *res = (List *)malloc(sizeof(struct List));
+  res->head = NULL;
+  return res;
+}
+
+void insert(List *lst, void *data) {
+  Entry *en = mk_entry(data);
+  en->next = lst->head;
+  lst->head = en;
+}
+
+int main(void) {
+  List *lst;
+  Entry *it;
+
+  lst = mk_list();
+  void *a_foo = mk_foo(2);
+  void *b_bar = mk_bar(3, 4);
+
+  insert(lst, &g_bad_foo);
+  insert(lst, a_foo);
+  insert(lst, b_bar);
+
+  int c = 0;
+  for (it = lst->head; it != NULL; it = it->next) {
+    Foo *v = (Foo *)(it->data);
+    if (is_bar(v)) {
+      Bar *b;
+      b = to_bar(v);
+      printf("bar: x=%d, y=%d\n", v->x, b->y);
+    } else {
+      printf("foo: x=%d\n", v->x);
+    }
+
+    if (++c > 3)
+      break;
+  }
+  return 0;
+}

--- a/test/smc/list1_global_unsat3.c
+++ b/test/smc/list1_global_unsat3.c
@@ -1,0 +1,94 @@
+// RUN: %sea smc -O3 --inline --horn-sea-dsa "%s" 2>&1 | OutputCheck %s
+// CHECK: ^unsat$
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#define FOO_TAG 123
+#define BAR_TAG 234
+
+typedef struct Foo {
+  int tag;
+  int x;
+} Foo;
+
+typedef struct Bar {
+  struct Foo foo;
+  int y;
+} Bar;
+
+Foo *mk_foo(int x) {
+  Foo *res = (Foo *)malloc(sizeof(struct Foo));
+  res->tag = FOO_TAG;
+  res->x = x;
+  return res;
+}
+
+Bar *mk_bar(int x, int y) {
+  Bar *res = (Bar *)malloc(sizeof(struct Bar));
+  res->foo.tag = BAR_TAG;
+  res->foo.x = x;
+  res->y = y;
+  return res;
+}
+
+struct Foo g_foo = {FOO_TAG, 5};
+
+Foo *to_foo(Bar *b) { return (Foo *)b; }
+int is_bar(Foo *b) { return b->tag == BAR_TAG; }
+Bar *to_bar(Foo *b) { return (Bar *)b; }
+
+typedef struct Entry {
+  void *data;
+  struct Entry *next;
+} Entry;
+
+typedef struct List {
+  Entry *head;
+} List;
+
+Entry *mk_entry(void *data) {
+  Entry *res = (Entry *)malloc(sizeof(struct Entry));
+  res->data = data;
+  res->next = NULL;
+  return res;
+}
+
+List *mk_list() {
+  List *res = (List *)malloc(sizeof(struct List));
+  res->head = NULL;
+  return res;
+}
+
+void insert(List *lst, void *data) {
+  Entry *en = mk_entry(data);
+  en->next = lst->head;
+  lst->head = en;
+}
+
+int main(void) {
+  List *lst;
+  Entry *it;
+
+  lst = mk_list();
+  void *a_foo = mk_foo(2);
+  void *b_bar = mk_bar(3, 4);
+
+  insert(lst, &g_foo);
+  insert(lst, b_bar);
+  insert(lst, a_foo);
+
+  int c = 0;
+  for (it = lst->head; it != NULL; it = it->next) {
+    Foo *v = (Foo *)(it->data);
+    if (is_bar(v)) {
+      Bar *b;
+      b = to_bar(v);
+      printf("bar: x=%d, y=%d\n", v->x, b->y);
+    }
+
+    if (++c > 3)
+      break;
+  }
+  return 0;
+}

--- a/test/smc/list1_sat.c
+++ b/test/smc/list1_sat.c
@@ -1,0 +1,92 @@
+// RUN: %sea smc -O3 --inline --horn-sea-dsa "%s" 2>&1 | OutputCheck %s
+// CHECK: ^sat$
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#define FOO_TAG 123
+#define BAR_TAG 234
+
+typedef struct Foo {
+  int tag;
+  int x;
+} Foo;
+
+typedef struct Bar {
+  struct Foo foo;
+  int y;
+} Bar;
+
+Foo *mk_foo(int x) {
+  Foo *res = (Foo *)malloc(sizeof(struct Foo));
+  res->tag = FOO_TAG;
+  res->x = x;
+  return res;
+}
+
+Bar *mk_bar(int x, int y) {
+  Bar *res = (Bar *)malloc(sizeof(struct Bar));
+  res->foo.tag = BAR_TAG;
+  res->foo.x = x;
+  res->y = y;
+  return res;
+}
+
+Foo *to_foo(Bar *b) { return (Foo *)b; }
+int is_bar(Foo *b) { return b->tag == BAR_TAG; }
+Bar *to_bar(Foo *b) { return (Bar *)b; }
+
+typedef struct Entry {
+  void *data;
+  struct Entry *next;
+} Entry;
+
+typedef struct List {
+  Entry *head;
+} List;
+
+Entry *mk_entry(void *data) {
+  Entry *res = (Entry *)malloc(sizeof(struct Entry));
+  res->data = data;
+  res->next = NULL;
+  return res;
+}
+
+List *mk_list() {
+  List *res = (List *)malloc(sizeof(struct List));
+  res->head = NULL;
+  return res;
+}
+
+void insert(List *lst, void *data) {
+  Entry *en = mk_entry(data);
+  en->next = lst->head;
+  lst->head = en;
+}
+
+int main(void) {
+  List *lst;
+  Entry *it;
+
+  lst = mk_list();
+  void *a_foo = mk_foo(2);
+  void *b_bar = mk_bar(3, 4);
+
+  insert(lst, a_foo);
+  insert(lst, b_bar);
+  insert(lst, mk_foo(5));
+
+  int c = 0;
+  for (it = lst->head; it != NULL; it = it->next) {
+    Foo *v = (Foo *)(it->data);
+    if (1 || is_bar(v)) {
+      Bar *b;
+      b = to_bar(v);
+      printf("bar: x=%d, y=%d\n", v->x, b->y);
+    }
+
+    if (++c > 3)
+      break;
+  }
+  return 0;
+}

--- a/test/smc/list1_unsat2.c
+++ b/test/smc/list1_unsat2.c
@@ -1,0 +1,93 @@
+// RUN: %sea smc -O3 --inline --horn-sea-dsa "%s" 2>&1 | OutputCheck %s
+// CHECK: ^unsat$
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#define FOO_TAG 123
+#define BAR_TAG 234
+
+typedef struct Foo {
+  int tag;
+  int x;
+} Foo;
+
+typedef struct Bar {
+  struct Foo foo;
+  int y;
+} Bar;
+
+Foo *mk_foo(int x) {
+  Foo *res = (Foo *)malloc(sizeof(struct Foo));
+  res->tag = FOO_TAG;
+  res->x = x;
+  return res;
+}
+
+Bar *mk_bar(int x, int y) {
+  Bar *res = (Bar *)malloc(sizeof(struct Bar));
+  res->foo.tag = BAR_TAG;
+  res->foo.x = x;
+  res->y = y;
+  return res;
+}
+
+Foo *to_foo(Bar *b) { return (Foo *)b; }
+int is_bar(Foo *b) { return b->tag == BAR_TAG; }
+Bar *to_bar(Foo *b) { return (Bar *)b; }
+
+typedef struct Entry {
+  void *data;
+  struct Entry *next;
+} Entry;
+
+typedef struct List {
+  Entry *head;
+} List;
+
+Entry *mk_entry(void *data) {
+  Entry *res = (Entry *)malloc(sizeof(struct Entry));
+  res->data = data;
+  res->next = NULL;
+  return res;
+}
+
+List *mk_list() {
+  List *res = (List *)malloc(sizeof(struct List));
+  res->head = NULL;
+  return res;
+}
+
+void insert(List *lst, void *data) {
+  Entry *en = mk_entry(data);
+  en->next = lst->head;
+  lst->head = en;
+}
+
+int main(void) {
+  List *lst;
+  Entry *it;
+
+  lst = mk_list();
+  void *a_foo = mk_foo(2);
+  void *b_bar = mk_bar(3, 4);
+
+  insert(lst, a_foo);
+  insert(lst, b_bar);
+
+  int c = 0;
+  for (it = lst->head; it != NULL; it = it->next) {
+    Foo *v = (Foo *)(it->data);
+    if (is_bar(v)) {
+      Bar *b;
+      b = to_bar(v);
+      printf("bar: x=%d, y=%d\n", v->x, b->y);
+    } else {
+      printf("foo: x=%d\n", v->x);
+    }
+
+    if (++c > 3)
+      break;
+  }
+  return 0;
+}

--- a/test/smc/list1_unsat3.c
+++ b/test/smc/list1_unsat3.c
@@ -1,0 +1,94 @@
+// RUN: %sea smc -O3 --inline --horn-sea-dsa "%s" 2>&1 | OutputCheck %s
+// CHECK: ^unsat$
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#define FOO_TAG 123
+#define BAR_TAG 234
+
+typedef struct Foo {
+  int tag;
+  int x;
+} Foo;
+
+typedef struct Bar {
+  struct Foo foo;
+  int y;
+} Bar;
+
+Foo *mk_foo(int x) {
+  Foo *res = (Foo *)malloc(sizeof(struct Foo));
+  res->tag = FOO_TAG;
+  res->x = x;
+  return res;
+}
+
+Bar *mk_bar(int x, int y) {
+  Bar *res = (Bar *)malloc(sizeof(struct Bar));
+  res->foo.tag = BAR_TAG;
+  res->foo.x = x;
+  res->y = y;
+  return res;
+}
+
+Foo *to_foo(Bar *b) { return (Foo *)b; }
+int is_bar(Foo *b) { return b->tag == BAR_TAG; }
+Bar *to_bar(Foo *b) { return (Bar *)b; }
+
+typedef struct Entry {
+  void *data;
+  struct Entry *next;
+} Entry;
+
+typedef struct List {
+  Entry *head;
+} List;
+
+Entry *mk_entry(void *data) {
+  Entry *res = (Entry *)malloc(sizeof(struct Entry));
+  res->data = data;
+  res->next = NULL;
+  return res;
+}
+
+List *mk_list() {
+  List *res = (List *)malloc(sizeof(struct List));
+  res->head = NULL;
+  return res;
+}
+
+void insert(List *lst, void *data) {
+  Entry *en = mk_entry(data);
+  en->next = lst->head;
+  lst->head = en;
+}
+
+int main(void) {
+  List *lst;
+  Entry *it;
+
+  lst = mk_list();
+  void *a_foo = mk_foo(2);
+  void *b_bar = mk_bar(3, 4);
+
+  insert(lst, a_foo);
+  insert(lst, b_bar);
+  insert(lst, mk_foo(5));
+
+  int c = 0;
+  for (it = lst->head; it != NULL; it = it->next) {
+    Foo *v = (Foo *)(it->data);
+    if (is_bar(v)) {
+      Bar *b;
+      b = to_bar(v);
+      printf("bar: x=%d, y=%d\n", v->x, b->y);
+    } else {
+      printf("foo: x=%d\n", v->x);
+    }
+
+    if (++c > 3)
+      break;
+  }
+  return 0;
+}

--- a/test/smc/lit.cfg
+++ b/test/smc/lit.cfg
@@ -1,0 +1,76 @@
+# -*- Python -*-
+
+import os
+import sys
+import re
+import platform
+import lit.util
+import lit.formats
+
+config.name = 'Seahorn'
+
+config.test_format = lit.formats.ShTest(execute_external=False)
+config.suffixes = ['.c', '.cpp']
+config.excludes = [ # These are no tests
+                    'list1_check.c'
+                  ]
+config.test_source_root = os.path.dirname(__file__)
+config.test_exec_root = lit_config.params.get('test_dir', '.')
+config.useProgressBar= True
+config.showOutput= True
+config.timeout=30
+config.max_time=30
+
+repositoryRoot = os.path.dirname (os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+def addEnv(name):
+   if name in os.environ:
+      config.environment[name] = os.environ[name]
+
+def isexec (fpath):
+    if fpath == None: return False
+    return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
+
+def which(program):
+   if isinstance (program, str): 
+      choices = [program]
+   else:
+      choices = program
+   for p in choices:
+      fpath, fname = os.path.split(p)
+      if fpath:
+         if isexec (p): return p
+      else:
+         for path in os.environ["PATH"].split(os.pathsep):
+            exe_file = os.path.join(path, p)
+            if isexec (exe_file):
+               return exe_file
+   return None
+
+def getSea ():
+    seahorn = None
+    if 'SEAHORN' in os.environ: 
+       seahorn = os.environ ['SEAHORN']
+    if not isexec (seahorn):
+       seahorn = os.path.join (repositoryRoot, 'build', 'run', 'bin', 'sea')
+    if not isexec (seahorn):
+       seahorn = os.path.join (repositoryRoot, 'debug', 'run', 'bin', 'sea')
+    if not isexec (seahorn): 
+       seahorn = which ('sea')
+    return seahorn
+
+addEnv('HOME')
+addEnv('PWD')
+addEnv('C_INCLUDE_PATH')
+
+
+lit_config.note('Repository root is {}'.format(repositoryRoot))
+
+sea_cmd = getSea()
+if not isexec(sea_cmd):
+   lit_config.fatal('Could not find the Seahorn executable')
+
+config.substitutions.append(('%sea', sea_cmd))
+
+## seahorn options here
+config.substitutions.append(('%dsa', "--dsa=sea-cs"))


### PR DESCRIPTION
The patch adds initial implementation of the Simple Memory Safety Checks.

For each memory instruction (load or store), it gets tries to go up the def-use chain and track the pointer's origin and offset. It goes up and looks through GEPs and bitcasts, until it reaches a _barrier_ (load, function call, phi node, select instruction, etc.).
The assumption is that the barrier produces a zero-offset pointer from the allocation site.

Next, it uses Sea-DSA to gather or possible allocation sites (malloc, alloca, global variables), and divides them into two groups: ones that can cause unsafe memory access after applying the accumulated offset, and those that are known to result in a safe memory access.

The pass performs the analysis described above and emits instrumentation for each pair of <allocation site, memory instruction>, which allows us to detect whether or not it is possible to go from the allocation site to the memory instruction.

For now, the pass doesn't use any other alias analysis, and is limited to analyzing only the first 16 memory instructions, and instrumenting only the first pair <AS, MI>.