### PR TITLE
Minor fixes for Coverage build in CI 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ matrix:
           docker run -v $(pwd):/host -it seahorn_container /bin/sh -c "cd share/seahorn; lit test" ;
         fi
    - env: BUILD_TYPE=Coverage
+     if: type = cron
      script:
        - docker build --build-arg UBUNTU=xenial --build-arg BUILD_TYPE=$BUILD_TYPE --build-arg TRAVIS=true -t seahorn_xenial_build -f docker/seahorn-full-size-rel.Dockerfile .
        - >

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
        - docker build --build-arg UBUNTU=xenial --build-arg BUILD_TYPE=$BUILD_TYPE --build-arg TRAVIS=true -t seahorn_xenial_build -f docker/seahorn-full-size-rel.Dockerfile .
        - >
          docker run  -v $(pwd):/host -it seahorn_xenial_build /bin/sh -c 
-         "bash /seahorn/docker/run_and_collect_cov.sh && mv /seahorn/build/all.info /host"
+         "bash /seahorn/docker/run_and_collect_cov.sh && mv /seahorn/all.info /host"
          && bash <(curl -s https://codecov.io/bash) -Z -f all.info
 
 services:

--- a/docker/run_and_collect_cov.sh
+++ b/docker/run_and_collect_cov.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
-cd /seahorn/build && cmake --build . --target test-all
-lcov -c --directory /seahorn/build/lib/seahorn/CMakeFiles/seahorn.LIB.dir/ -o coverage.info
-lcov --extract coverage.info */lib/seahorn/* -o lib.info
-lcov --extract coverage.info */include/seahorn/* -o header.info
-cat header.info lib.info > all.info
+lit /seahorn/test
+lcov -c -d /seahorn/build/lib/ -b /seahorn/build/ -o coverage.info
+lcov -e coverage.info '/seahorn/lib/*' '/seahorn/include/*' -o all.info


### PR DESCRIPTION
- added condition in coverage job type to only run during `cron` builds
- improved script for running and collecting coverage to include more modules for codecov

example push build (no coverage job): https://travis-ci.org/danblitzhou/seahorn/builds/592067072
example cron build (with coverage job): https://travis-ci.org/danblitzhou/seahorn/builds/592151441 note that the `MinSizeRel` job was cancel due to lack of docker hub credentials to push nightly build
 