### PR TITLE
Added boost/functional/hash.hpp in HornClauseDB for undef'd ref.

### DIFF
--- a/include/seahorn/HornClauseDB.hh
+++ b/include/seahorn/HornClauseDB.hh
@@ -4,6 +4,7 @@
 
 #include "llvm/Support/raw_ostream.h"
 
+#include <boost/functional/hash.hpp>
 #include <boost/range.hpp>
 #include <boost/range/algorithm/copy.hpp>
 #include <boost/lexical_cast.hpp>


### PR DESCRIPTION
@agurfinkel `cmake --build . --target install` failed after pulling master. I can reproduce on a clean build. `clang` reports that `combine_hash` is undefined in `include/seahorn/HornClauseDB.hpp`. Including `boost/functional/hash.hpp` fixes this.

```
../../lib/libseahorn.a(HornClauseDBTransf.cc.o): In function `std::_Hashtable<expr::ENode*, expr::ENode*, std::allocator<expr::ENode*>, std::__detail::_Identity, expr::ENodeUniqueEqual, expr::ENodeUniqueHash, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<true, true, true> >::_M_erase(std::integral_constant<bool, true>, expr::ENode* const&) [clone .isra.151]':
/home/aswesley/Research/seahorn/include/seahorn/Expr/ExprCore.hh:196: undefined reference to `void boost::hash_combine<expr::ENode*>(unsigned long&, expr::ENode* const&)'
/home/aswesley/Research/seahorn/include/seahorn/Expr/ExprCore.hh:199: undefined reference to `unsigned long boost::hash_range<__gnu_cxx::__normal_iterator<expr::ENode* const*, std::vector<expr::ENode*, std::allocator<expr::ENode*> > > >(__gnu_cxx::__normal_iterator<expr::ENode* const*, std::vector<expr::ENode*, std::allocator<expr::ENode*> > >, __gnu_cxx::__normal_iterator<expr::ENode* const*, std::vector<expr::ENode*, std::allocator<expr::ENode*> > >)'
/home/aswesley/Research/seahorn/include/seahorn/Expr/ExprCore.hh:199: undefined reference to `void boost::hash_combine<unsigned long>(unsigned long&, unsigned long const&)'
../../lib/libseahorn.a(HornClauseDBTransf.cc.o): In function `seahorn::normalizeHornClauseHeads(seahorn::HornClauseDB&)':
/home/aswesley/Research/seahorn/include/seahorn/HornClauseDB.hh:61: undefined reference to `void boost::hash_combine<boost::intrusive_ptr<expr::ENode> >(unsigned long&, boost::intrusive_ptr<expr::ENode> const&)'
/home/aswesley/Research/seahorn/include/seahorn/HornClauseDB.hh:62: undefined reference to `unsigned long boost::hash_range<__gnu_cxx::__normal_iterator<boost::intrusive_ptr<expr::ENode> const*, std::vector<boost::intrusive_ptr<expr::ENode>, std::allocator<boost::intrusive_ptr<expr::ENode> > > > >(__gnu_cxx::__normal_iterator<boost::intrusive_ptr<expr::ENode> const*, std::vector<boost::intrusive_ptr<expr::ENode>, std::allocator<boost::intrusive_ptr<expr::ENode> > > >, __gnu_cxx::__normal_iterator<boost::intrusive_ptr<expr::ENode> const*, std::vector<boost::intrusive_ptr<expr::ENode>, std::allocator<boost::intrusive_ptr<expr::ENode> > > >)'
/home/aswesley/Research/seahorn/include/seahorn/HornClauseDB.hh:62: undefined reference to `void boost::hash_combine<unsigned long>(unsigned long&, unsigned long const&)'
/home/aswesley/Research/seahorn/include/seahorn/HornClauseDB.hh:61: undefined reference to `void boost::hash_combine<boost::intrusive_ptr<expr::ENode> >(unsigned long&, boost::intrusive_ptr<expr::ENode> const&)'
/home/aswesley/Research/seahorn/include/seahorn/HornClauseDB.hh:62: undefined reference to `unsigned long boost::hash_range<__gnu_cxx::__normal_iterator<boost::intrusive_ptr<expr::ENode> const*, std::vector<boost::intrusive_ptr<expr::ENode>, std::allocator<boost::intrusive_ptr<expr::ENode> > > > >(__gnu_cxx::__normal_iterator<boost::intrusive_ptr<expr::ENode> const*, std::vector<boost::intrusive_ptr<expr::ENode>, std::allocator<boost::intrusive_ptr<expr::ENode> > > >, __gnu_cxx::__normal_iterator<boost::intrusive_ptr<expr::ENode> const*, std::vector<boost::intrusive_ptr<expr::ENode>, std::allocator<boost::intrusive_ptr<expr::ENode> > > >)'
/home/aswesley/Research/seahorn/include/seahorn/HornClauseDB.hh:62: undefined reference to `void boost::hash_combine<unsigned long>(unsigned long&, unsigned long const&)'
collect2: error: ld returned 1 exit status
tools/seahorn/CMakeFiles/seahorn.dir/build.make:145: recipe for target 'bin/seahorn' failed
make[2]: *** [bin/seahorn] Error 1
CMakeFiles/Makefile2:3127: recipe for target 'tools/seahorn/CMakeFiles/seahorn.dir/all' failed
make[1]: *** [tools/seahorn/CMakeFiles/seahorn.dir/all] Error 2
Makefile:151: recipe for target 'all' failed
make: *** [all] Error 2
```

I am running `Ubuntu 18.04.3 LTS`.