### PR TITLE
Do not remove the content of --temp-dir if --save-temps was not specified

### DIFF
--- a/py/sea/__init__.py
+++ b/py/sea/__init__.py
@@ -90,8 +90,10 @@ def createWorkDir (dname=None, save=False, prefix='tmp-'):
         if not os.path.isdir (dname): os.mkdir (dname)
         workdir = dname
 
-    if not save:
+    if dname is None:
         atexit.register (shutil.rmtree, path=workdir)
+    else:
+        print "Warning: --temp-dir specified without the --save-temps option"
     return workdir
 
 def add_help_arg (ap):


### PR DESCRIPTION
I accidentally misspelled the option `--save-temps` and, as a result, all the content of the `--temp-dir` was removed, without any messages. This is really dangerous when running the option as, e.g., `--temp-dir .`, because `shutil.rmtree` will recursively remove everything in that directory.