### PR TITLE
mismatching calling conventions fix

### DIFF
--- a/lib/Transforms/Scalar/LowerGvInitializers.cc
+++ b/lib/Transforms/Scalar/LowerGvInitializers.cc
@@ -228,6 +228,8 @@ bool LowerGvInitializers::runOnModule(Module &M) {
         Args.push_back(Builder.CreateCall(ndf));
       }
       CallInst *CI = Builder.CreateCall(Fn, Args);
+      CallingConv::ID cc = Fn->getCallingConv();
+      CI->setCallingConv(cc);
       LOG("lower-gv-init",
           errs() << "LowerGvInitializers: created a call " << *CI << "\n");
     }

--- a/py/sea/commands.py
+++ b/py/sea/commands.py
@@ -316,6 +316,11 @@ class Seapp(sea.LimitedCmd):
                         help='Do not lower global initializers for structs',
                         default=False,
                         action='store_true')
+        ap.add_argument('--no-lower-gv-init',
+                        dest='no_lower_gv_init',
+                        help='Do not lower global initializers',
+                        default=False,
+                        action='store_true')
         ap.add_argument ('--devirt-functions',
                          help='Devirtualize indirect functions using only types',
                          dest='devirt_funcs', default=False,
@@ -402,6 +407,9 @@ class Seapp(sea.LimitedCmd):
 
             if args.no_lower_gv_init_structs:
                 argv.append('--lower-gv-init-struct=false')
+
+            if args.no_lower_gv_init:
+                argv.append('--lower-gv-init=false')
 
             if args.devirt_funcs_cha or args.devirt_funcs:
                 argv.append ('--devirt-functions')
@@ -1069,6 +1077,11 @@ class Seahorn(sea.LimitedCmd):
         ap.add_argument ('--max-depth',
                          help='Maximum depth of exploration',
                          dest='max_depth', default=sys.maxint)
+        ap.add_argument('--no-lower-gv-init',
+                        dest='no_lower_gv_init',
+                        help='Do not lower global initializers',
+                        default=False,
+                        action='store_true')
         return ap
 
     def run (self, args, extra):
@@ -1141,6 +1154,10 @@ class Seahorn(sea.LimitedCmd):
             for l in args.ztrace.split (':'): argv.extend (['-ztrace', l])
 
         if args.out_file is not None: argv.extend (['-o', args.out_file])
+
+        if args.no_lower_gv_init:
+            argv.append('--lower-gv-init=false')
+
         argv.extend (args.in_files)
 
         # pick out extra seahorn options

--- a/tools/seahorn/seahorn.cpp
+++ b/tools/seahorn/seahorn.cpp
@@ -189,6 +189,11 @@ static llvm::cl::opt<bool>
                "Print SeaHorn Dsa memory graph of a function to dot format"),
            llvm::cl::init(false));
 
+static llvm::cl::opt<bool>
+    LowerGlobalInitializers("lower-gv-init",
+                            llvm::cl::desc("Lower some global initializers"),
+                            llvm::cl::init(true));
+
 // removes extension from filename if there is one
 std::string getFileName(const std::string &str) {
   std::string filename = str;
@@ -311,7 +316,9 @@ int main(int argc, char **argv) {
   pass_manager.add(llvm::createGlobalDCEPass()); // kill unused internal global
 
   // -- initialize any global variables that are left
-  pass_manager.add(new seahorn::LowerGvInitializers());
+  if (LowerGlobalInitializers) {
+    pass_manager.add(new seahorn::LowerGvInitializers());
+  }
   if (SeaHornDsa) {
     pass_manager.add(seahorn::createShadowMemSeaDsaPass());
 #ifndef USE_NEW_SHADOW_SEA_DSA


### PR DESCRIPTION
- Fixed issue in `LowerGvInitializers` pass of not including calling convention of the initializer function in call instructions ( see similar issue [here](http://lists.llvm.org/pipermail/llvm-dev/2017-November/119130.html) seems like "manually calling `setCallingConv`" is the way to go)
- Added command line options in `seahorn` and `seapp` to optionally turn off the `LowerGvInitializers` pass; this is helpful when using the new opsem.