### PR TITLE
Fix in reduceToRegion (issue #242)

### DIFF
--- a/lib/Transforms/Utils/Local.cc
+++ b/lib/Transforms/Utils/Local.cc
@@ -41,7 +41,6 @@ void reduceToRegion(Function &F, DenseSet<const BasicBlock *> &region) {
       TerminatorInst *BBTerm = BB.getTerminator();
       for (unsigned i = 0, e = BBTerm->getNumSuccessors(); i != e; ++i)
         BBTerm->getSuccessor(i)->removePredecessor(&BB);
-      BB.dropAllReferences();
       continue;
     }
 
@@ -71,6 +70,10 @@ void reduceToRegion(Function &F, DenseSet<const BasicBlock *> &region) {
     }
   }
 
+  for (auto BB: dead) {
+    BB->dropAllReferences();
+  }
+  
   for (auto *bb : dead) {
     if (bb->hasNUses(0))
       bb->eraseFromParent();


### PR DESCRIPTION
Consider this code:

label A:
      phi (...) (..., B)
      goto B, ...
label B:
      phi (...,A) (...)
      goto A, ...

and both A and B are not in region so we want to remove them.

To remove A, we first go to B and remove the PHI incoming value from A
(... A) and drop all references to A.

To remove B, we first go to A and (**) remove PHI incoming value from B and
drop all references to B.

The problem is at (**) with the call A->removePredecessor(B). This
removes (..., B) from the PHI instruction at A. If it happens that the
PHI node at A has two entries and B is the second entry then all uses of
the PHI node are replaced with the first entry of the PHI node. For
some **unknown reason**, that first entry (PN->getIncomingValue(0)) is
null.

lib/IR/BasicBlock.cc, line 315:

      // If the PHI _HAD_ two uses, replace PHI node with its now *single* value
      if (max_idx == 2) {
        if (PN->getIncomingValue(0) != PN)
          PN->replaceAllUsesWith(PN->getIncomingValue(0));

PN->getIncomingValue(0) is null

I do not know why the pointer is dangling but postponing the drop of
references to a block to be deleted solves the problem.