### PR TITLE
make devirt func pass work for functions with different calling conv

### DIFF
--- a/lib/Transforms/Utils/DevirtFunctions.cc
+++ b/lib/Transforms/Utils/DevirtFunctions.cc
@@ -252,8 +252,10 @@ Function *DevirtualizeFunctions::mkBounceFn(CallSite &CS, CallSiteResolver *CSR,
     }
 
     // Create the direct function call
+    CallingConv::ID cc = FL->getCallingConv();
     CallInst *directCall =
         CallInst::Create(const_cast<Function *>(FL), fargs, "", BL);
+    directCall->setCallingConv(cc);
     // update call graph
     if (m_cg) {
       auto fl_cg = m_cg->getOrInsertFunction(const_cast<Function *>(FL));


### PR DESCRIPTION
To repro, create indirect calls that references functions with non-default calling conventions; 
this is a known issue with LLVM API: http://lists.llvm.org/pipermail/llvm-dev/2017-November/119130.html
similar with #244 