### PR TITLE
[sea-rt] use ptrdiff to hold ptr address

### DIFF
--- a/sea-rt/seahorn.cpp
+++ b/sea-rt/seahorn.cpp
@@ -8,6 +8,7 @@
 #include <cstring>
 #include <map>
 #include <functional>
+#include <stddef.h>
 
 extern "C" {
 
@@ -102,8 +103,8 @@ void* __emv(void* p) {
 
   bool is_legal_address (void *addr) {
     return (! is_dummy_address (addr) &&
-	    (intptr_t(addr) >= 0x100000 &&
-	     intptr_t(addr) <= 0xFFFFFFFFFFFF));
+	    (ptrdiff_t(addr) >= 0x100000 &&
+	     ptrdiff_t(addr) <= 0xFFFFFFFFFFFF));
   }
 
 /** Dummy implementation of memory wrapping functions */


### PR DESCRIPTION
Getting some false alarms that causes `__seahorn_mem_store` and `__seahorn_mem_alloc` to skipping loading/storing addresses that are high but still legal (i.e. `0xffffd414`). `intptr` is signed so it could convert such addresses into a negative integer and cause `is_legal_address` to return false incorrectly.