### PR TITLE
[sea exe] support for 32 bit executable cex

### DIFF
--- a/py/sea/__init__.py
+++ b/py/sea/__init__.py
@@ -119,6 +119,16 @@ def add_tmp_dir_args (ap):
                      help="Temporary directory", default=None)
     return ap
 
+def str2bool(v):
+    if isinstance(v, bool):
+        return v
+    if v.lower() in ('yes', 'true', 't', 'y', '1'):
+        return True
+    elif v.lower() in ('no', 'false', 'f', 'n', '0'):
+        return False
+    else:
+        raise argparse.ArgumentTypeError('Boolean value expected.')
+
 class CliCmd (object):
     def __init__ (self, name='', help='', allow_extra=False):
         self.name = name
@@ -137,6 +147,14 @@ class CliCmd (object):
         if work_dir is not None:
             out_file = os.path.join (work_dir, out_file)
         return out_file
+
+    def add_llvm_bool_arg(self, parser, name, default=False, help=None, dest=None):
+        dest_name = dest if dest else name
+        mutex_group = parser.add_mutually_exclusive_group(required=False)
+        mutex_group.add_argument('--' + name, dest=dest_name, type=str2bool, nargs='?', const=True, help=help)
+        mutex_group.add_argument('--no-' + name, dest=dest_name, type=lambda v:not(str2bool(v)),
+                                     nargs='?', const=False, help=help)
+        parser.set_defaults(**{dest_name:default})
 
     def main (self, argv):
         import argparse

--- a/py/sea/commands.py
+++ b/py/sea/commands.py
@@ -789,6 +789,7 @@ class WrapMem(sea.LimitedCmd):
         ap = super (WrapMem, self).mk_arg_parser (ap)
         ap.add_argument ('--no-wmem', dest='wmem_skip', help='Skipped wrap-mem pass',
                          default=False, action='store_true')
+        # self.add_llvm_bool_arg(ap, 'skip-wmem', dest='wmem_skip', help='Skipped wrap-mem pass')
         add_in_out_args (ap)
         _add_S_arg (ap)
         return ap

--- a/py/sea/commands.py
+++ b/py/sea/commands.py
@@ -228,7 +228,11 @@ class LinkRt(sea.LimitedCmd):
         if args.alloc_mem:
             libseart = os.path.join (lib_dir, 'libsea-mem-rt.a')
         else:
-            libseart = os.path.join (lib_dir, 'libsea-rt.a')
+            libseart32 = os.path.join(lib_dir, 'libsea-rt-32.a')
+            if args.machine == 32 and os.path.exists(libseart32):
+                libseart = libseart32
+            else:
+                libseart = os.path.join (lib_dir, 'libsea-rt.a')
         argv.append (libseart)
 
         return self.clangCmd.run (args, argv)


### PR DESCRIPTION
- In `LinkRt `,  if 32 bit binary of `sea-rt` exists and current machine mode is 32, link and compile with `libsea-rt-32.a` instead of 64 bit version.

- Added helper function for adding LLVM-style boolean command line arguemnt, usage example that is equivalent to current `no-wmem` option:
```
In WrapMem:
self.add_llvm_bool_arg(ap, 'skip-wmem', dest='wmem_skip', help='Skipped wrap-mem pass')
``` 
then to set `wmem_skip` to true:
`--skip-wmem=true` or `--skip-wmem`
to set `wmem_skip` to false:
`--no-skip-wmem=true` or `--no-skip-wmem` or do not set the cmd line option at all

note that `--<opt>` and `--no-<opt>` are mutually exclusive, meaning at most one of them may show up in the same command.