### PR TITLE
[sea-rt] use unsigned size_t to properly cast and compare high addresses

### DIFF
--- a/sea-rt/seahorn.cpp
+++ b/sea-rt/seahorn.cpp
@@ -103,8 +103,8 @@ void* __emv(void* p) {
 
   bool is_legal_address (void *addr) {
     return (! is_dummy_address (addr) &&
-	    (ptrdiff_t(addr) >= 0x100000 &&
-	     ptrdiff_t(addr) <= 0xFFFFFFFFFFFF));
+	    (size_t(addr) >= 0x100000 &&
+	     size_t(addr) <= 0xFFFFFFFFFFFF));
   }
 
 /** Dummy implementation of memory wrapping functions */


### PR DESCRIPTION
properly fixed the issue in #260 , `ptrdiff` is signed so is still prone to cast high address to negative value;
solution: use unsigned `size_t` instead.