### PR TITLE
[seapy] added python pass to remove target-features from LLVM IR

### DIFF
--- a/py/seapy
+++ b/py/seapy
@@ -46,6 +46,7 @@ def main (argv):
             sea.commands.SimpleMemoryChecks(),
             sea.commands.Smc,
             sea.commands.SeaExeCex(),
+            sea.commands.RemoveTargetFeatures(),
     ]
 
     cmd = sea.AgregateCmd('sea', 'SeaHorn Verification Framework', cmds)


### PR DESCRIPTION
Target dependent `target-features` may block generation of executable counter-examples
- added `RemoveTargetFeatures` command (`sea rmtf ...`) to `seapy`; it searches and removes `target-features` from llvm bitcode attributes; 
- added `RemoveTargetFeatures` to `sea exe` pipeline; by default it does not modify the bitcode file, but can be enabled by apply `--rmtf` or `--rmtf=true`