### PR TITLE
[CI] Run clang-format on pull requests

### DIFF
--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -1,0 +1,40 @@
+name: Check formatting
+
+on:
+  pull_request:
+
+jobs:
+  clang-format-check:
+    name: clang-format
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Setup environment
+        run: |
+          sudo apt-get install -yqq clang-format-9
+      - name: Checkout
+        run: |
+          git clone https://github.com/${{ github.repository }}.git .
+          git checkout ${{ github.base_ref }}
+          git fetch origin +${{ github.sha }}:${{ github.ref }} --update-head-ok
+          git checkout ${{ github.sha }}
+      - name: Run clang-format
+        run: |
+          git diff ${{ github.base_ref }} -U0 --no-color -- '**/*.cpp' '**/*.cc' '**/*.h' '**/*.hh' \
+            | clang-format-diff-9 -p1 >not-formatted.diff 2>&1
+      - name: Check formatting
+        run: |
+          if ! grep -q '[^[:space:]]' not-formatted.diff ; then
+            echo "Code formatted. Success."
+          else
+            echo "Code not formatted."
+            echo "Please run clang-format-diff on your changes and push again:"
+            echo "    git diff ${{ github.base_ref }} -U0 --no-color | clang-format-diff -p1 -i"
+            echo ""
+            echo "Tip: you can selectively disable clang-format checks. See https://clang.llvm.org/docs/ClangFormatStyleOptions.html#disabling-formatting-on-a-piece-of-code"
+            echo ""
+            echo "Diff:"
+            cat not-formatted.diff
+            echo ""
+            exit 2
+          fi
+


### PR DESCRIPTION
This adds a github action that checks if the code modified by a pull requests is formatted. If not, the CI bot will complain.

This github actions workflow is implemented in pure bash and does not reference any third-party actions. This usually takes <10s to execute.

Thought you may find it useful. Feel free to adapt & modify.