### PR TITLE
feat: add conventional commit check github action and client config

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -1,0 +1,31 @@
+# Enabling a subset of options
+# Full list at
+#  https://github.com/talos-systems/conform/blob/master/README.md
+
+policies:
+  - type: commit
+    spec:
+      header:
+        length: 80
+        imperative: false
+        case: lower
+        invalidLastCharacters: .
+      body:
+        required: false
+      # Allow maximum of one commit ahead of master
+      # TODO: figure out intent, false for now
+      maximumOfOneCommit: false
+      conventional:
+        types:
+          - fix
+          - feat
+          - build
+          - ci
+          - docs
+          - style
+          - refactor
+          - perf
+          - test
+        scopes:
+          - "scope"
+        descriptionLength: 72

--- a/.github/workflows/conform.yml
+++ b/.github/workflows/conform.yml
@@ -1,0 +1,10 @@
+name: Conform
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: Conform Action
+      uses: docker://autonomy/conform:v0.1.0-alpha.19

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+# .pre-commit-config.yaml
+
+# Hooks are divided into active and passive
+# active hooks report and 'fix' things on failure
+# passive hooks only report failure.
+# In both cases, failure of a check will fail an action e.g. commit
+repos:
+- repo: https://github.com/talos-systems/conform
+  rev: master
+  # This hook runs the conform enforcer (passive check)
+  # See .conform.yaml for which rules are enforced
+  hooks:
+  - id: conform
+    stages:
+    - commit-msg
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Commit guidelines
+
+TL;DR: We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit messages. We check that commits follow this convention. If you want to ensure compliance before sending a pull-request, please read on.
+
+###  How  to ensure commits follow guidelines before sending a pull-request
+
+Install [precommit](https://pre-commit.com/) 
+
+```shell
+>pip3 install pre-commit
+```
+
+Install `golang`if not already present (needed for conform)
+
+See if you have `golang`. E.g.
+
+```shell
+>go version
+go version go1.14.2 linux/amd64
+```
+
+Enable precommit inside root of local git repo
+
+```
+>pre-commit install
+```
+
+If you don't have it installed, you can install it using [these instructions.](https://github.com/golang/tools/tree/master/cmd/getgo).
+
+Install pre-commit into the `commit-msg` hook 
+
+<!-- TODO commit-msg hook may not be needed. This requires more testing so not blocking checkin on this -->
+
+```
+ pre-commit install -t commit-msg
+```
+
+Everything is now setup. `seahorn` contains the following configuration files (you should not need to change them).
+
+* `.pre-commit-config.yaml` - This is the configuration for pre-commit i.e. which checks to run e.g. `conform`, `clang-format`
+* `.conform.yaml`- This is the configuration used by [conform](https://github.com/talos-systems/conform) to figure out which checks to enable e.g. conventional commits.
+
+#### Run checks
+
+You can manually run a check from within a repo using
+
+```
+>pre-commit run
+```
+
+Checks will automatically be run during `git commit`.


### PR DESCRIPTION
1. Add github action and conform configuration
2. Add pre-commit config file (for local validation, if desired)
3. Add documentation for enabling local validation if needed

Comments from closed pr#281


...
https://magit.vc/manual/magit/My-Git-hooks-work-on-the-command_002dline-but-not-inside-Magit.html

Is this going to be a problem?

Instead of installing a lot of things and running on my local configurations, I would rather have the check ran as action on PRs. Often, when working any check like that would be in the way. However, when cleaning the work up for merging to master, it would be very welcome.
...
>The local check is only done for people who want it and install conform using pre-commit hooks. The github action is only executed on push and pull_request and does not depend on client configuration. I don't have a solution for the custom workflow using magit but then you may choose not to use local check at all. I imagine some people may find the local check useful than figuring that a push failed because of a commit message at the last minute. For these users, instructions in the guide and distributing the `.pre-commit` config file is all that is needed.

...
this does not look right. The goal is to hook commit messages, this also runs clang-format, and ignoring our custom configuration in .clang-format._
...
>I have removed clang-format check for now to keep the change simple. I would like the option of automatic clang format from cmdline on commit for similar reason as previous comment.

Thanks