### PR TITLE
fix: allow any scope in commit messages

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -27,5 +27,5 @@ policies:
           - perf
           - test
         scopes:
-          - "scope"
+          - .*
         descriptionLength: 72

--- a/.github/workflows/conform.yml
+++ b/.github/workflows/conform.yml
@@ -7,4 +7,4 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v1
     - name: Conform Action
-      uses: docker://autonomy/conform:v0.1.0-alpha.19
+      uses: docker://autonomy/conform:v0.1.0-alpha.19-6-gcea1ee9


### PR DESCRIPTION
https://github.com/talos-systems/conform/pull/171 allows regex in scope. Added .* for now.
Updated docker image to use this feature

tested:
tested on github in https://github.com/priyasiddharth/seahorn/actions/runs/104067498