### PR TITLE
feat(opsem): add an extra-wide memory manager which tracks (base, off…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
           travis_wait 120 sleep infinity &
           docker run -v $(pwd):/host -it seahorn_container /bin/bash -c "cd seahorn/share/seahorn && lit -a --time-tests --max-time=1200 test/opsem " &&
           docker run -v $(pwd):/host -it seahorn_container /bin/bash -c "cd seahorn/share/seahorn && lit -a --time-tests --max-time=1200 -D opsem-opts=--horn-bv2-widemem test/opsem " &&
-          docker run -v $(pwd):/host -it seahorn_container /bin/bash -c "cd seahorn/share/seahorn && lit -a --time-tests --max-time=1200 test/opsem/widemem " &&
+          docker run -v $(pwd):/host -it seahorn_container /bin/bash -c "cd seahorn/share/seahorn && lit -a --time-tests --max-time=1200 -D opsem-opts=--horn-bv2-extra-widemem test/opsem " &&
           docker run -v $(pwd):/host -it seahorn_container /bin/bash -c "cd seahorn/share/seahorn && lit -a --time-tests --max-time=1200 test/mcfuzz" &&
           docker login -u "$DOCKER_USER" -p "$DOCKER_PWD" &&
           docker tag seahorn_container seahorn/seahorn-llvm10:nightly &&
@@ -36,7 +36,7 @@ matrix:
           travis_wait 120 sleep infinity &
           docker run -v $(pwd):/host -it seahorn_container /bin/bash -c "cd seahorn/share/seahorn && lit -a --time-tests --max-time=1200 test/opsem " &&
           docker run -v $(pwd):/host -it seahorn_container /bin/bash -c "cd seahorn/share/seahorn && lit -a --time-tests --max-time=1200 -D opsem-opts=--horn-bv2-widemem test/opsem " &&
-          docker run -v $(pwd):/host -it seahorn_container /bin/bash -c "cd seahorn/share/seahorn && lit -a --time-tests --max-time=1200 test/opsem/widemem " &&
+          docker run -v $(pwd):/host -it seahorn_container /bin/bash -c "cd seahorn/share/seahorn && lit -a --time-tests --max-time=1200 -D opsem-opts=--horn-bv2-extra-widemem test/opsem " &&
           docker run -v $(pwd):/host -it seahorn_container /bin/bash -c "cd seahorn/share/seahorn && lit -a --time-tests --max-time=1200 test/mcfuzz" && 
           docker run -v $(pwd):/host -it seahorn_container /bin/bash -c "cd seahorn/share/seahorn && lit -a --time-tests --max-time=1200 test/smc" 
         fi

--- a/lib/seahorn/BvOpSem2.cc
+++ b/lib/seahorn/BvOpSem2.cc
@@ -44,7 +44,13 @@ static llvm::cl::opt<bool> UseFatMemory(
 
 static llvm::cl::opt<bool> UseWideMemory(
     "horn-bv2-widemem",
-    llvm::cl::desc("Use wide-memory model with pointers and object sizes"),
+    llvm::cl::desc("Use wide-memory model with pointer and object size"),
+    cl::init(false));
+
+static llvm::cl::opt<bool> UseExtraWideMemory(
+    "horn-bv2-extra-widemem",
+    llvm::cl::desc(
+        "Use extra wide memory model with base, offset and object size"),
     cl::init(false));
 
 static llvm::cl::opt<unsigned>
@@ -1765,6 +1771,8 @@ Bv2OpSemContext::Bv2OpSemContext(Bv2OpSem &sem, SymStore &values,
     mem = mkFatMemManager(m_sem, *this, PtrSize, WordSize, UseLambdas);
   else if (UseWideMemory) {
     mem = mkWideMemManager(m_sem, *this, PtrSize, WordSize, UseLambdas);
+  } else if (UseExtraWideMemory) {
+    mem = mkExtraWideMemManager(m_sem, *this, PtrSize, WordSize, UseLambdas);
   } else {
     mem = mkRawMemManager(m_sem, *this, PtrSize, WordSize, UseLambdas);
   }

--- a/lib/seahorn/BvOpSem2Context.hh
+++ b/lib/seahorn/BvOpSem2Context.hh
@@ -710,6 +710,10 @@ OpSemMemManager *mkWideMemManager(Bv2OpSem &sem, Bv2OpSemContext &ctx,
                                   unsigned ptrSz, unsigned wordSz,
                                   bool useLambdas = false);
 
+OpSemMemManager *mkExtraWideMemManager(Bv2OpSem &sem, Bv2OpSemContext &ctx,
+                                       unsigned ptrSz, unsigned wordSz,
+                                       bool useLambdas = false);
+
 /// \Brief Base class for memory representation
 class OpSemMemRepr {
 protected:

--- a/lib/seahorn/BvOpSem2ExtraWideMemMgr.cc
+++ b/lib/seahorn/BvOpSem2ExtraWideMemMgr.cc
@@ -1,0 +1,586 @@
+#include "BvOpSem2Context.hh"
+#include "BvOpSem2RawMemMgr.hh"
+
+#include "BvOpSem2WideMemManagerMixin.hh"
+
+#include "seahorn/Expr/ExprOpStruct.hh"
+#include "seahorn/Support/SeaDebug.h"
+#include "seahorn/Support/SeaLog.hh"
+
+static const unsigned int g_slotBitWidth = 64;
+static const unsigned int g_slotByteWidth = g_slotBitWidth / 8;
+
+static const unsigned int g_uninit = 0xDEADBEEF;
+
+namespace seahorn {
+namespace details {
+class ExtraWideMemManager : public OpSemMemManagerBase {
+
+  /// \brief Knows the memory representation and how to access it
+  std::unique_ptr<OpSemMemRepr> m_memRepr;
+
+  /// \brief Base name for non-deterministic pointer
+  Expr m_freshPtrName;
+
+  /// \brief Register that contains the value of the stack pointer on
+  /// function entry
+  Expr m_sp0;
+
+  /// \brief Source of unique identifiers
+  mutable unsigned m_id;
+
+  const Expr m_uninit_size;
+
+  /// \brief Memory manager for raw pointers
+  RawMemManager m_main;
+  /// \brief Memory manager for pointer offset
+
+  // NOTE: offset bitwidth is same as ptr bitwidth since we need to
+  // do arithmetic operations between them often.
+  RawMemManager m_offset;
+  /// \brief Memory manager for size
+  RawMemManager m_size;
+
+public:
+  using RawPtrTy = OpSemMemManager::PtrTy;
+  using RawMemValTy = OpSemMemManager::MemValTy;
+  using RawPtrSortTy = OpSemMemManager::PtrSortTy;
+  using RawMemSortTy = OpSemMemManager::MemSortTy;
+  using MemRegTy = OpSemMemManager::MemRegTy;
+
+  // size = size in bits
+  struct PtrTyImpl {
+    Expr m_v;
+
+    PtrTyImpl(RawPtrTy &&base, Expr &&offset, Expr &&size) {
+      m_v = strct::mk(std::move(base), std::move(offset), std::move(size));
+    }
+
+    PtrTyImpl(const RawPtrTy &base, const Expr offset, const Expr &size) {
+      m_v = strct::mk(base, offset, size);
+    }
+
+    explicit PtrTyImpl(const Expr &e) {
+      // Our base is a struct of three exprs
+      assert(strct::isStructVal(e));
+      assert(e->arity() == 3);
+      m_v = e;
+    }
+
+    Expr v() const { return m_v; }
+    Expr toExpr() const { return v(); }
+    explicit operator Expr() const { return toExpr(); }
+
+    RawPtrTy getBase() { return strct::extractVal(m_v, 0); }
+
+    Expr getOffset() { return strct::extractVal(m_v, 1); }
+
+    Expr getSize() { return strct::extractVal(m_v, 2); }
+  };
+
+  struct MemValTyImpl {
+    Expr m_v;
+
+    MemValTyImpl(RawMemValTy &&raw_val, Expr &&offset_val, Expr &&size_val) {
+      m_v = strct::mk(std::move(raw_val), std::move(offset_val),
+                      std::move(size_val));
+    }
+
+    MemValTyImpl(const RawPtrTy &raw_val, const Expr &offset_val,
+                 const Expr &size_val) {
+      m_v = strct::mk(raw_val, offset_val, size_val);
+    }
+
+    explicit MemValTyImpl(const Expr &e) {
+      // Our base is a struct of three exprs
+      assert(strct::isStructVal(e));
+      assert(e->arity() == 3);
+      m_v = e;
+    }
+
+    Expr v() const { return m_v; }
+    Expr toExpr() const { return v(); }
+    explicit operator Expr() const { return toExpr(); }
+
+    RawMemValTy getRaw() { return strct::extractVal(m_v, 0); }
+
+    Expr getOffset() { return strct::extractVal(m_v, 1); }
+
+    Expr getSize() { return strct::extractVal(m_v, 2); }
+  };
+
+  struct PtrSortTyImpl {
+    Expr m_ptr_sort;
+
+    PtrSortTyImpl(RawPtrSortTy &&ptr_sort, Expr &&offset_sort,
+                  Expr &&size_sort) {
+      m_ptr_sort = sort::structTy(std::move(ptr_sort), std::move(offset_sort),
+                                  std::move(size_sort));
+    }
+
+    PtrSortTyImpl(const RawPtrSortTy &ptr_sort, const Expr &offset_sort,
+                  const Expr &size_sort) {
+      m_ptr_sort = sort::structTy(ptr_sort, offset_sort, size_sort);
+    }
+
+    Expr v() const { return m_ptr_sort; }
+    Expr toExpr() const { return v(); }
+    explicit operator Expr() const { return toExpr(); }
+
+    RawPtrSortTy getBaseSort() { return m_ptr_sort->arg(0); }
+  };
+
+  struct MemSortTyImpl {
+    Expr m_mem_sort;
+
+    MemSortTyImpl(RawMemSortTy &&mem_sort, Expr &&offset_sort,
+                  Expr &&size_sort) {
+      m_mem_sort = sort::structTy(std::move(mem_sort), std::move(offset_sort),
+                                  std::move(size_sort));
+    }
+
+    MemSortTyImpl(const RawMemSortTy &mem_sort, Expr &offset_sort,
+                  const Expr &size_sort) {
+      m_mem_sort = sort::structTy(mem_sort, offset_sort, size_sort);
+    }
+
+    Expr v() const { return m_mem_sort; }
+    Expr toExpr() const { return v(); }
+    explicit operator Expr() const { return toExpr(); }
+  };
+
+  using PtrTy = PtrTyImpl;
+  using PtrSortTy = PtrSortTyImpl;
+  using MemValTy = MemValTyImpl;
+  using MemSortTy = MemSortTyImpl;
+
+  /// \brief A null pointer expression (cache)
+  PtrTy m_nullPtr;
+
+  ExtraWideMemManager(Bv2OpSem &sem, Bv2OpSemContext &ctx, unsigned ptrSz,
+                      unsigned wordSz, bool useLambdas = false);
+
+  ~ExtraWideMemManager() = default;
+
+  Expr bytesToSlotExpr(unsigned bytes) {
+    return m_ctx.alu().si(bytes, g_slotBitWidth);
+  }
+
+  PtrSortTy ptrSort() const {
+    return PtrSortTy(m_main.ptrSort(), m_offset.ptrSort(),
+                     m_ctx.alu().intTy(g_slotBitWidth));
+  }
+
+  PtrTy salloc(unsigned int bytes, uint32_t align) {
+    assert(isa<AllocaInst>(m_ctx.getCurrentInst()));
+    align = std::max(align, m_alignment);
+    auto region = m_main.getMAllocator().salloc(bytes, align);
+    assert(region.second > region.first);
+    // The size is min(alloc_size, requested_size)
+    return PtrTy(
+        mkStackPtr(region.second).getBase(), m_ctx.alu().si(0UL, ptrSzInBits()),
+        bytesToSlotExpr(std::min(region.second - region.first, bytes)));
+  }
+
+  PtrTy salloc(Expr elmts, unsigned int typeSz, uint32_t align) {
+    align = std::max(align, m_alignment);
+
+    // -- compute number of bytes needed
+    Expr bytes = elmts;
+    if (typeSz > 1) {
+      // TODO: factor out multiplication and number creation
+      bytes = m_ctx.alu().doMul(bytes, m_ctx.alu().si(typeSz, ptrSzInBits()),
+                                ptrSzInBits());
+    }
+
+    // allocate
+    auto region = m_main.getMAllocator().salloc(bytes, align);
+
+    // -- if allocation failed, return some pointer
+    if (m_main.getMAllocator().isBadAddrInterval(region)) {
+      LOG("opsem", WARN << "imprecise handling of dynamically "
+                        << "sized stack allocation of " << *elmts
+                        << " elements of size" << typeSz << " bytes\n";);
+      return freshPtr();
+    }
+
+    // -- have a good region, return pointer to it
+    return PtrTy(mkStackPtr(region.second).getBase(),
+                 m_ctx.alu().si(0UL, ptrSzInBits()),
+                 m_ctx.alu().si(region.first - region.second, g_slotBitWidth));
+  }
+
+  PtrTy mkStackPtr(unsigned int offset) {
+    return PtrTy(m_main.mkStackPtr(offset), m_ctx.alu().si(0UL, ptrSzInBits()),
+                 m_uninit_size);
+  }
+
+  PtrTy brk0Ptr() {
+    return PtrTy(m_main.brk0Ptr(), m_ctx.alu().si(0UL, ptrSzInBits()),
+                 m_uninit_size);
+  }
+
+  PtrTy halloc(unsigned int _bytes, uint32_t align) {
+    PtrTy res = freshPtr();
+    LOG("opsem", WARN << "halloc() not implemented!\n");
+    return res;
+  }
+
+  PtrTy halloc(Expr bytes, uint32_t align) {
+    PtrTy res = freshPtr();
+    LOG("opsem", WARN << "halloc() not implemented!\n");
+    return res;
+  }
+
+  PtrTy galloc(const GlobalVariable &gv, uint32_t align) {
+    uint64_t gvSz = m_sem.getTD().getTypeAllocSize(gv.getValueType());
+    auto range =
+        m_main.getMAllocator().galloc(gv, gvSz, std::max(align, m_alignment));
+    return PtrTy(m_ctx.alu().si(range.first, ptrSzInBits()),
+                 m_ctx.alu().si(0UL, ptrSzInBits()),
+                 bytesToSlotExpr(range.second - range.first));
+  }
+
+  PtrTy falloc(const Function &fn) {
+    auto range = m_main.getMAllocator().falloc(fn, m_alignment);
+    return PtrTy(m_ctx.alu().si(range.first, ptrSzInBits()),
+                 m_ctx.alu().si(0UL, ptrSzInBits()),
+                 bytesToSlotExpr(range.second - range.first));
+  }
+
+  // TODO: What is the right size to return here?
+  PtrTy getPtrToFunction(const Function &F) {
+    auto rawPtr = m_ctx.alu().si(
+        m_main.getMAllocator().getFunctionAddrAndSize(F, m_alignment).first,
+        ptrSzInBits());
+    auto size = m_ctx.alu().si(
+        m_main.getMAllocator().getFunctionAddrAndSize(F, m_alignment).second,
+        g_slotBitWidth);
+    return PtrTy(rawPtr, m_ctx.alu().si(0UL, ptrSzInBits()), size);
+  }
+
+  PtrTy getPtrToGlobalVariable(const GlobalVariable &gv) {
+    // TODO: Add a map of base to AllocInfo in allocator so that given any base,
+    // we can get size of allocation.
+    uint64_t gvSz = m_sem.getTD().getTypeAllocSize(gv.getValueType());
+    return PtrTy(m_ctx.alu().si(m_main.getMAllocator().getGlobalVariableAddr(
+                                    gv, gvSz, m_alignment),
+                                ptrSzInBits()),
+                 m_ctx.alu().si(0UL, ptrSzInBits()), bytesToSlotExpr(gvSz));
+  }
+
+  void initGlobalVariable(const GlobalVariable &gv) const {
+    m_main.initGlobalVariable(gv);
+  }
+
+  PtrTy mkAlignedPtr(Expr name, uint32_t align) const {
+    m_size.mkAlignedPtr(name, align);
+    return PtrTy(m_main.mkAlignedPtr(name, align),
+                 m_ctx.alu().si(0UL, ptrSzInBits()), m_uninit_size);
+  }
+
+  PtrSortTy mkPtrRegisterSort(const Instruction &inst) const {
+    return PtrSortTy(m_main.mkPtrRegisterSort(inst),
+                     m_offset.mkPtrRegisterSort(inst),
+                     m_ctx.alu().intTy(g_slotBitWidth));
+  }
+
+  PtrSortTy mkPtrRegisterSort(const Function &fn) const { return ptrSort(); }
+
+  /// \brief Returns sort of a pointer register for a global pointer
+  PtrSortTy mkPtrRegisterSort(const GlobalVariable &gv) const {
+    return ptrSort();
+  }
+
+  MemSortTy mkMemRegisterSort(const Instruction &inst) const {
+    RawMemSortTy mainSort = m_main.mkMemRegisterSort(inst);
+    RawMemSortTy offsetSort = m_offset.mkMemRegisterSort(inst);
+    RawMemSortTy sizeSort = m_size.mkMemRegisterSort(inst);
+    return MemSortTy(mainSort, offsetSort, sizeSort);
+  }
+
+  PtrTy freshPtr() {
+    Expr name = op::variant::variant(m_id++, m_freshPtrName);
+    return mkAlignedPtr(name, m_alignment);
+  }
+
+  PtrTy nullPtr() const { return m_nullPtr; }
+
+  Expr coerce(Expr sort, Expr val) {
+    if (strct::isStructVal(val)) {
+      // recursively coerce struct-ty
+      llvm::SmallVector<Expr, 8> kids;
+      assert(isOp<STRUCT_TY>(sort));
+      assert(sort->arity() == val->arity());
+      for (unsigned i = 0, sz = val->arity(); i < sz; ++i)
+        kids.push_back(coerce(sort->arg(i), val->arg(i)));
+      return strct::mk(kids);
+    }
+
+    return m_main.coerce(sort, val);
+  }
+
+  PtrTy ptrAdd(PtrTy base, int32_t _offset) const {
+    // add offset to existing offset
+    // base, size remain unchanged
+    if (_offset == 0)
+      return base;
+    Expr new_offset;
+    // do concrete computation if possible
+    if (m_ctx.alu().isNum(base.getOffset())) {
+      signed conc_offset = m_ctx.alu().toNum(base.getSize()).get_si() + _offset;
+      new_offset = m_ctx.alu().si(conc_offset, ptrSzInBits());
+    } else {
+      expr::mpz_class offset((signed long)_offset);
+      auto new_offset = m_ctx.alu().doAdd(base.getOffset(),
+                                          m_ctx.alu().si(offset, ptrSzInBits()),
+                                          ptrSzInBits());
+    }
+    return PtrTy(base.getBase(), new_offset, base.getSize());
+  }
+
+  PtrTy ptrAdd(PtrTy base, Expr offset) const {
+    if (m_ctx.alu().isNum(offset)) {
+      expr::mpz_class _offset = m_ctx.alu().toNum(offset);
+      return ptrAdd(base, _offset.get_si());
+    }
+    // TODO: What is the bitwidth of offset here?
+    auto new_offset =
+        m_ctx.alu().doAdd(base.getOffset(), offset, ptrSzInBits());
+
+    return PtrTy(base.getBase(), new_offset, base.getSize());
+  }
+
+  Expr loadIntFromMem(PtrTy base, MemValTy mem, unsigned int byteSz,
+                      uint64_t align) {
+    return m_main.loadIntFromMem(getAddressable(base), mem.getRaw(), byteSz,
+                                 align);
+  }
+
+  PtrTy loadPtrFromMem(PtrTy base, MemValTy mem, unsigned int byteSz,
+                       uint64_t align) {
+    RawMemValTy rawVal = m_main.loadPtrFromMem(getAddressable(base),
+                                               mem.getRaw(), byteSz, align);
+    Expr offsetVal = m_size.loadIntFromMem(getAddressable(base),
+                                           mem.getOffset(), byteSz, align);
+    Expr sizeVal = m_size.loadIntFromMem(getAddressable(base), mem.getSize(),
+                                         g_slotByteWidth, align);
+    return PtrTy(rawVal, offsetVal, sizeVal);
+  }
+
+  MemValTy storeIntToMem(Expr _val, PtrTy base, MemValTy mem,
+                         unsigned int byteSz, uint64_t align) {
+    return MemValTy(m_main.storeIntToMem(_val, getAddressable(base),
+                                         mem.getRaw(), byteSz, align),
+                    mem.getOffset(), mem.getSize());
+  }
+
+  MemValTy storePtrToMem(PtrTy val, PtrTy base, MemValTy mem,
+                         unsigned int byteSz, uint64_t align) {
+    RawMemValTy main = m_main.storePtrToMem(val.getBase(), getAddressable(base),
+                                            mem.getRaw(), byteSz, align);
+    Expr offset = m_size.storeIntToMem(val.getOffset(), getAddressable(base),
+                                       mem.getSize(), byteSz, align);
+    Expr size = m_size.storeIntToMem(val.getSize(), getAddressable(base),
+                                     mem.getSize(), g_slotByteWidth, align);
+    return MemValTy(main, offset, size);
+  }
+
+  Expr loadValueFromMem(PtrTy base, MemValTy mem, const Type &ty,
+                        uint64_t align) {
+    const unsigned byteSz =
+        m_sem.getTD().getTypeStoreSize(const_cast<llvm::Type *>(&ty));
+    ExprFactory &efac = base.getBase()->efac();
+
+    Expr res;
+    switch (ty.getTypeID()) {
+    case Type::IntegerTyID:
+      res = loadIntFromMem(base, mem, byteSz, align);
+      if (res && ty.getScalarSizeInBits() < byteSz * 8)
+        res = m_ctx.alu().doTrunc(res, ty.getScalarSizeInBits());
+      break;
+    case Type::FloatTyID:
+    case Type::DoubleTyID:
+    case Type::X86_FP80TyID:
+      errs() << "Error: load of float/double is not supported\n";
+      llvm_unreachable(nullptr);
+      break;
+    case Type::VectorTyID:
+      errs() << "Error: load of vectors is not supported\n";
+    case Type::PointerTyID:
+      res = loadPtrFromMem(base, mem, byteSz, align).v();
+      break;
+    case Type::StructTyID:
+      errs() << "loading form struct type " << ty << " is not supported";
+      return res;
+    default:
+      SmallString<256> msg;
+      raw_svector_ostream out(msg);
+      out << "Loading from type: " << ty << " is not supported\n";
+      assert(false);
+    }
+    return res;
+  }
+
+  MemValTy storeValueToMem(Expr _val, PtrTy base, MemValTy memIn,
+                           const Type &ty, uint32_t align) {
+    assert(base.v());
+    Expr val = _val;
+    const unsigned byteSz =
+        m_sem.getTD().getTypeStoreSize(const_cast<llvm::Type *>(&ty));
+    ExprFactory &efac = base.v()->efac();
+    // init memval to a default value
+    MemValTy res(m_ctx.alu().si(0UL, wordSzInBits()),
+                 m_ctx.alu().si(0UL, wordSzInBits()), m_uninit_size);
+    switch (ty.getTypeID()) {
+    case Type::IntegerTyID:
+      if (ty.getScalarSizeInBits() < byteSz * 8) {
+        val = m_ctx.alu().doZext(val, byteSz * 8, ty.getScalarSizeInBits());
+      }
+      res = storeIntToMem(val, base, memIn, byteSz, align);
+      break;
+    case Type::FloatTyID:
+    case Type::DoubleTyID:
+    case Type::X86_FP80TyID:
+      errs() << "Error: store of float/double is not supported\n";
+      llvm_unreachable(nullptr);
+      break;
+    case Type::VectorTyID:
+      errs() << "Error: store of vectors is not supported\n";
+    case Type::PointerTyID:
+      res = storePtrToMem(PtrTy(val), base, memIn, byteSz, align);
+      break;
+    case Type::StructTyID:
+      WARN << "Storing struct type " << ty << " is not supported\n";
+      return res;
+    default:
+      SmallString<256> msg;
+      raw_svector_ostream out(msg);
+      out << "Loading from type: " << ty << " is not supported\n";
+      assert(false);
+    }
+    return res;
+  }
+
+  MemValTy MemSet(PtrTy base, Expr _val, unsigned int len, MemValTy mem,
+                  uint32_t align) {
+    return MemValTy(
+        m_main.MemSet(getAddressable(base), _val, len, mem.getRaw(), align),
+        mem.getOffset(), mem.getSize());
+  }
+
+  MemValTy MemCpy(PtrTy dPtr, PtrTy sPtr, unsigned int len,
+                  MemValTy memTrsfrRead, uint32_t align) {
+    return MemValTy(m_main.MemCpy(getAddressable(dPtr), getAddressable(sPtr),
+                                  len, memTrsfrRead.getRaw(), align),
+                    m_offset.MemCpy(getAddressable(dPtr), getAddressable(sPtr),
+                                    len, memTrsfrRead.getRaw(), align),
+                    m_size.MemCpy(getAddressable(dPtr), getAddressable(sPtr),
+                                  len, memTrsfrRead.getSize(), align));
+  }
+
+  MemValTy MemFill(PtrTy dPtr, char *sPtr, unsigned int len, MemValTy mem,
+                   uint32_t align) {
+    return MemValTy(
+        m_main.MemFill(getAddressable(dPtr), sPtr, len, mem.getRaw(), align),
+        mem.getOffset(), mem.getSize());
+  }
+
+  PtrTy inttoptr(Expr intVal, const Type &intTy, const Type &ptrTy) const {
+    return PtrTy(m_main.inttoptr(intVal, intTy, ptrTy),
+                 m_ctx.alu().si(0UL, ptrSzInBits()), m_uninit_size);
+  }
+
+  Expr ptrtoint(PtrTy base, const Type &ptrTy, const Type &intTy) const {
+    return m_main.ptrtoint(getAddressable(base), ptrTy, intTy);
+  }
+
+  PtrTy gep(PtrTy base, gep_type_iterator it, gep_type_iterator end) const {
+    // offset bitwidth is ptrSz
+    Expr new_offset = m_sem.symbolicIndexedOffset(it, end, m_ctx);
+    return PtrTy(base.getBase(), new_offset, base.getSize());
+  }
+
+  void onFunctionEntry(const Function &fn) { m_main.onFunctionEntry(fn); }
+
+  void onModuleEntry(const Module &M) { m_main.onModuleEntry(M); }
+
+  void dumpGlobalsMap() { m_main.dumpGlobalsMap(); }
+
+  std::pair<char *, unsigned int>
+  getGlobalVariableInitValue(const GlobalVariable &gv) {
+    return m_main.getGlobalVariableInitValue(gv);
+  }
+
+  MemValTy zeroedMemory() const {
+    return MemValTy(m_main.zeroedMemory(), m_offset.zeroedMemory(),
+                    m_size.zeroedMemory());
+  }
+
+  Expr isDereferenceable(PtrTy p, Expr byteSz) {
+    // size should be >= byteSz + offset
+    if (m_ctx.alu().isNum(byteSz) && m_ctx.alu().isNum(p.getSize()) &&
+        m_ctx.alu().isNum(p.getOffset())) {
+      signed numBytes = m_ctx.alu().toNum(byteSz).get_si();
+      signed conc_size = m_ctx.alu().toNum(p.getSize()).get_si();
+      signed conc_offset = m_ctx.alu().toNum(p.getOffset()).get_si();
+      return conc_size >= numBytes + conc_offset ? m_ctx.alu().getTrue()
+                                                 : m_ctx.alu().getFalse();
+    } else {
+      // TODO: this addition can be concrete
+      auto lastBytePos =
+          m_ctx.alu().doAdd(byteSz, p.getOffset(), ptrSzInBits());
+      return m_ctx.alu().doSge(p.getSize(), castPtrSzToSlotSz(lastBytePos),
+                               g_slotBitWidth);
+    }
+  }
+
+  RawPtrTy getAddressable(PtrTy p) const {
+    // do concrete computation if possible
+    // NOTE: This is needed in ConstantEvaluator
+    if (m_ctx.alu().isNum(p.getBase()) && m_ctx.alu().isNum(p.getOffset())) {
+      signed ptrBase = m_ctx.alu().toNum(p.getBase()).get_si();
+      signed offset = m_ctx.alu().toNum(p.getOffset()).get_si();
+      return m_ctx.alu().si(ptrBase + offset, ptrSzInBits());
+    }
+    return m_ctx.alu().doAdd(p.getBase(), p.getOffset(), ptrSzInBits());
+  }
+
+  Expr getSize(PtrTy p) const { return p.getSize(); }
+
+  const OpSemMemManager &getMainMemMgr() const { return m_main; }
+
+  Expr castPtrSzToSlotSz(const Expr val) const {
+    if (ptrSzInBits() == g_slotBitWidth) {
+      return val;
+    } else if (g_slotBitWidth > ptrSzInBits()) {
+      return m_ctx.alu().doSext(val, g_slotBitWidth, ptrSzInBits());
+    } else {
+      LOG("opsem", WARN << "widemem: Casting ptrSz to slotSz - information may "
+                           "be lost!\n");
+      return m_ctx.alu().doTrunc(val, g_slotBitWidth);
+    }
+  }
+};
+
+ExtraWideMemManager::ExtraWideMemManager(Bv2OpSem &sem, Bv2OpSemContext &ctx,
+                                         unsigned ptrSz, unsigned wordSz,
+                                         bool useLambdas)
+    : OpSemMemManagerBase(
+          sem, ctx, ptrSz, wordSz,
+          false /* this is a nop since we delegate to RawMemMgr */),
+      m_main(sem, ctx, ptrSz, wordSz, useLambdas),
+      m_offset(sem, ctx, ptrSz, wordSz, useLambdas, true),
+      m_size(sem, ctx, ptrSz, g_slotByteWidth, useLambdas, true),
+      m_uninit_size(m_ctx.alu().si(g_uninit, g_slotBitWidth)),
+      m_nullPtr(PtrTy(m_main.nullPtr(), m_ctx.alu().si(0UL, ptrSzInBits()),
+                      m_uninit_size)) {}
+
+OpSemMemManager *mkExtraWideMemManager(Bv2OpSem &sem, Bv2OpSemContext &ctx,
+                                       unsigned ptrSz, unsigned wordSz,
+                                       bool useLambdas) {
+  return new OpSemWideMemManagerMixin<ExtraWideMemManager>(sem, ctx, ptrSz,
+                                                           wordSz, useLambdas);
+}
+} // namespace details
+} // namespace seahorn

--- a/lib/seahorn/BvOpSem2WideMemManagerMixin.hh
+++ b/lib/seahorn/BvOpSem2WideMemManagerMixin.hh
@@ -1,0 +1,338 @@
+#pragma once
+#include "BvOpSem2Context.hh"
+
+namespace seahorn {
+
+using namespace seahorn::details;
+
+template <typename BaseT>
+class OpSemWideMemManagerMixin : public BaseT, public OpSemMemManager {
+
+public:
+  using Base = BaseT;
+  using PtrTy = Expr;
+  using MemRegTy = Expr;
+  using MemValTy = Expr;
+  using PtrSortTy = Expr;
+  using MemSortTy = Expr;
+
+  using BasePtrSortTy = typename Base::PtrSortTy;
+  using BaseMemSortTy = typename Base::MemSortTy;
+
+  using BasePtrTy = typename Base::PtrTy;
+  using BaseMemRegTy = typename Base::MemRegTy;
+  using BaseMemValTy = typename Base::MemValTy;
+
+protected:
+  Base &base() { return static_cast<Base &>(*this); }
+  Base const &base() const { return static_cast<Base const &>(*this); }
+  auto toPtrTy(BasePtrTy &&p) const { return static_cast<PtrTy>(p); }
+  auto toMemValTy(BaseMemValTy &&m) const { return static_cast<MemValTy>(m); }
+  auto toPtrSortTy(BasePtrSortTy &&s) const {
+    return static_cast<PtrSortTy>(s);
+  }
+  auto toMemSortTy(BaseMemSortTy &&s) const {
+    return static_cast<MemSortTy>(s);
+  }
+
+public:
+  template <typename... Ts>
+  OpSemWideMemManagerMixin(Ts &&... Args)
+      : BaseT(std::forward<Ts>(Args)...),
+        OpSemMemManager(base().sem(), base().ctx(), base().ptrSzInBytes(),
+                        base().wordSzInBytes(), base().isIgnoreAlignment()) {}
+  virtual ~OpSemWideMemManagerMixin() = default;
+
+  PtrSortTy ptrSort() const override {
+    auto res = base().ptrSort();
+    return toPtrSortTy(std::move(res));
+  }
+
+  PtrTy salloc(unsigned bytes, uint32_t align = 0) override {
+    auto res = base().salloc(bytes, align);
+    return toPtrTy(std::move(res));
+  }
+
+  PtrTy salloc(Expr elmts, unsigned typeSz, uint32_t align = 0) override {
+    auto res = base().salloc(elmts, typeSz, align);
+    return toPtrTy(std::move(res));
+  }
+
+  PtrTy mkStackPtr(unsigned offset) override {
+    auto res = base().mkStackPtr(offset);
+    return toPtrTy(std::move(res));
+  }
+
+  PtrTy brk0Ptr() override {
+    auto res = base().brk0Ptr();
+    return toPtrTy(std::move(res));
+  }
+
+  PtrTy halloc(unsigned _bytes, uint32_t align = 0) override {
+    auto res = base().halloc(_bytes, align);
+    return toPtrTy(std::move(res));
+  }
+
+  PtrTy halloc(Expr bytes, uint32_t align = 0) override {
+    auto res = base().halloc(bytes, align);
+    return toPtrTy(std::move(res));
+  }
+
+  PtrTy galloc(const GlobalVariable &gv, uint32_t align = 0) override {
+    auto res = base().galloc(gv, align);
+    return toPtrTy(std::move(res));
+  }
+
+  PtrTy falloc(const Function &fn) override {
+    auto res = base().falloc(fn);
+    return toPtrTy(std::move(res));
+  }
+
+  PtrTy getPtrToFunction(const Function &F) override {
+    auto res = base().getPtrToFunction(F);
+    return toPtrTy(std::move(res));
+  }
+
+  PtrTy getPtrToGlobalVariable(const GlobalVariable &gv) override {
+    auto res = base().getPtrToGlobalVariable(gv);
+    return toPtrTy(std::move(res));
+  }
+
+  void initGlobalVariable(const GlobalVariable &gv) const {
+    base().initGlobalVariable(gv);
+  }
+
+  PtrTy mkAlignedPtr(Expr name, uint32_t align) const override {
+    auto res = base().mkAlignedPtr(name, align);
+    return toPtrTy(std::move(res));
+  }
+
+  PtrSortTy mkPtrRegisterSort(const Instruction &inst) const override {
+    auto res = base().mkPtrRegisterSort(inst);
+    return toPtrSortTy(std::move(res));
+  }
+
+  PtrSortTy mkPtrRegisterSort(const Function &fn) const override {
+    auto res = base().mkPtrRegisterSort(fn);
+    return toPtrSortTy(std::move(res));
+  }
+
+  PtrSortTy mkPtrRegisterSort(const GlobalVariable &gv) const override {
+    auto res = base().mkPtrRegisterSort(gv);
+    return toPtrSortTy(std::move(res));
+  }
+
+  MemSortTy mkMemRegisterSort(const Instruction &inst) const override {
+    auto res = base().mkMemRegisterSort(inst);
+    return toMemSortTy(std::move(res));
+  }
+
+  PtrTy freshPtr() override {
+    auto res = base().freshPtr();
+    return toPtrTy(std::move(res));
+  }
+
+  PtrTy nullPtr() const override {
+    auto res = base().nullPtr();
+    return toPtrTy(std::move(res));
+  }
+
+  // XXX figure out proper typing
+  Expr coerce(Expr sort, Expr val) override { return base().coerce(sort, val); }
+
+  /// \brief Pointer addition with symbolic offset
+  PtrTy ptrAdd(PtrTy ptr, Expr offset) const override {
+    auto res = base().ptrAdd(BasePtrTy(std::move(ptr)), offset);
+    return toPtrTy(std::move(res));
+  }
+
+  PtrTy ptrAdd(PtrTy ptr, int32_t _offset) const override {
+    auto res = base().ptrAdd(BasePtrTy(std::move(ptr)), _offset);
+    return toPtrTy(std::move(res));
+  }
+
+  Expr loadIntFromMem(PtrTy ptr, MemValTy mem, unsigned byteSz,
+                      uint64_t align) override {
+    auto res = base().loadIntFromMem(
+        BasePtrTy(std::move(ptr)), BaseMemValTy(std::move(mem)), byteSz, align);
+    return res;
+  }
+
+  PtrTy loadPtrFromMem(PtrTy ptr, MemValTy mem, unsigned byteSz,
+                       uint64_t align) override {
+    auto res = base().loadPtrFromMem(
+        BasePtrTy(std::move(ptr)), BaseMemValTy(std::move(mem)), byteSz, align);
+    return toPtrTy(std::move(res));
+  }
+
+  MemValTy storeIntToMem(Expr _val, PtrTy ptr, MemValTy mem, unsigned byteSz,
+                         uint64_t align) override {
+    auto res =
+        base().storeIntToMem(_val, BasePtrTy(std::move(ptr)),
+                             BaseMemValTy(std::move(mem)), byteSz, align);
+    return toMemValTy(std::move(res));
+  }
+
+  MemValTy storePtrToMem(PtrTy val, PtrTy ptr, MemValTy mem, unsigned byteSz,
+                         uint64_t align) override {
+    auto res =
+        base().storePtrToMem(BasePtrTy(val), BasePtrTy(std::move(ptr)),
+                             BaseMemValTy(std::move(mem)), byteSz, align);
+    return toMemValTy(std::move(res));
+  }
+
+  Expr loadValueFromMem(PtrTy ptr, MemValTy mem, const llvm::Type &ty,
+                        uint64_t align) override {
+    auto res = base().loadValueFromMem(BasePtrTy(std::move(ptr)),
+                                       BaseMemValTy(std::move(mem)), ty, align);
+    return res;
+  }
+
+  MemValTy storeValueToMem(Expr _val, PtrTy ptr, MemValTy memIn,
+                           const llvm::Type &ty, uint32_t align) override {
+    auto res =
+        base().storeValueToMem(_val, BasePtrTy(std::move(ptr)),
+                               BaseMemValTy(std::move(memIn)), ty, align);
+    return toMemValTy(std::move(res));
+  }
+
+  MemValTy MemSet(PtrTy ptr, Expr _val, unsigned len, MemValTy mem,
+                  uint32_t align) override {
+    auto res = base().MemSet(BasePtrTy(std::move(ptr)), _val, len,
+                             BaseMemValTy(std::move(mem)), align);
+    return toMemValTy(std::move(res));
+  }
+
+  MemValTy MemCpy(PtrTy dPtr, PtrTy sPtr, unsigned len, MemValTy memTrsfrRead,
+                  uint32_t align) override {
+    auto res =
+        base().MemCpy(BasePtrTy(std::move(dPtr)), BasePtrTy(std::move(sPtr)),
+                      len, BaseMemValTy(std::move(memTrsfrRead)), align);
+    return toMemValTy(std::move(res));
+  }
+
+  MemValTy MemFill(PtrTy dPtr, char *sPtr, unsigned len, MemValTy mem,
+                   uint32_t align = 0) override {
+    auto res = base().MemFill(BasePtrTy(std::move(dPtr)), sPtr, len,
+                              BaseMemValTy(std::move(mem)), align);
+    return toMemValTy(std::move(res));
+  }
+
+  PtrTy inttoptr(Expr intVal, const Type &intTy,
+                 const Type &ptrTy) const override {
+    auto res = base().inttoptr(intVal, intTy, ptrTy);
+    return toPtrTy(std::move(res));
+  }
+
+  Expr ptrtoint(PtrTy ptr, const Type &ptrTy,
+                const Type &intTy) const override {
+    auto res = base().ptrtoint(BasePtrTy(std::move(ptr)), ptrTy, intTy);
+    return res;
+  }
+
+  Expr ptrUlt(PtrTy p1, PtrTy p2) const override {
+    return base().getMainMemMgr().ptrUlt(
+        base().getAddressable(BasePtrTy(std::move(p1))),
+        base().getAddressable(BasePtrTy(std::move(p2))));
+  }
+
+  Expr ptrSlt(PtrTy p1, PtrTy p2) const override {
+    return base().getMainMemMgr().ptrSlt(
+        base().getAddressable(BasePtrTy(std::move(p1))),
+        base().getAddressable(BasePtrTy(std::move(p2))));
+  }
+
+  Expr ptrUle(PtrTy p1, PtrTy p2) const override {
+    return base().getMainMemMgr().ptrUle(
+        base().getAddressable(BasePtrTy(std::move(p1))),
+        base().getAddressable(BasePtrTy(std::move(p2))));
+  }
+
+  Expr ptrSle(PtrTy p1, PtrTy p2) const override {
+    return base().getMainMemMgr().ptrSle(
+        base().getAddressable(BasePtrTy(std::move(p1))),
+        base().getAddressable(BasePtrTy(std::move(p2))));
+  }
+
+  Expr ptrUgt(PtrTy p1, PtrTy p2) const override {
+    return base().getMainMemMgr().ptrUgt(
+        base().getAddressable(BasePtrTy(std::move(p1))),
+        base().getAddressable(BasePtrTy(std::move(p2))));
+  }
+
+  Expr ptrSgt(PtrTy p1, PtrTy p2) const override {
+    return base().getMainMemMgr().ptrSgt(
+        base().getAddressable(BasePtrTy(std::move(p1))),
+        base().getAddressable(BasePtrTy(std::move(p2))));
+  }
+
+  Expr ptrUge(PtrTy p1, PtrTy p2) const override {
+    return base().getMainMemMgr().ptrUge(
+        base().getAddressable(BasePtrTy(std::move(p1))),
+        base().getAddressable(BasePtrTy(std::move(p2))));
+  }
+
+  Expr ptrSge(PtrTy p1, PtrTy p2) const override {
+    return base().getMainMemMgr().ptrSge(
+        base().getAddressable(BasePtrTy(std::move(p1))),
+        base().getAddressable(BasePtrTy(std::move(p2))));
+  }
+
+  Expr ptrEq(PtrTy p1, PtrTy p2) const override {
+    return base().getMainMemMgr().ptrEq(
+        base().getAddressable(BasePtrTy(std::move(p1))),
+        base().getAddressable(BasePtrTy(std::move(p2))));
+  }
+
+  Expr ptrNe(PtrTy p1, PtrTy p2) const override {
+    return base().getMainMemMgr().ptrNe(
+        base().getAddressable(BasePtrTy(std::move(p1))),
+        base().getAddressable(BasePtrTy(std::move(p2))));
+  }
+
+  Expr ptrSub(PtrTy p1, PtrTy p2) const override {
+    return base().getMainMemMgr().ptrSub(
+        base().getAddressable(BasePtrTy(std::move(p1))),
+        base().getAddressable(BasePtrTy(std::move(p2))));
+  }
+
+  PtrTy gep(PtrTy ptr, gep_type_iterator it,
+            gep_type_iterator end) const override {
+    auto res = base().gep(BasePtrTy(std::move(ptr)), it, end);
+    return toPtrTy(std::move(res));
+  }
+
+  void onFunctionEntry(const Function &fn) override {
+    base().onFunctionEntry(fn);
+  }
+
+  void onModuleEntry(const Module &M) override { base().onModuleEntry(M); }
+
+  void dumpGlobalsMap() override { base().dumpGlobalsMap(); }
+
+  std::pair<char *, unsigned>
+  getGlobalVariableInitValue(const llvm::GlobalVariable &gv) override {
+    return base().getGlobalVariableInitValue(gv);
+  }
+
+  MemValTy zeroedMemory() const override {
+    auto res = base().zeroedMemory();
+    return toMemValTy(std::move(res));
+  }
+
+  Expr getFatData(PtrTy p, unsigned SlotIdx) override {
+    LOG("opsem", WARN << "getFatData() not implemented!\n");
+    return Expr();
+  }
+
+  /// \brief returns Expr after setting data.
+  PtrTy setFatData(PtrTy p, unsigned SlotIdx, Expr data) override {
+    LOG("opsem", WARN << "setFatData() not implemented!\n");
+    return toPtrTy(std::move(base().nullPtr()));
+  }
+
+  Expr isDereferenceable(PtrTy p, Expr byteSz) {
+    return base().isDereferenceable(BasePtrTy(std::move(p)), byteSz);
+  }
+};
+} // namespace seahorn

--- a/lib/seahorn/CMakeLists.txt
+++ b/lib/seahorn/CMakeLists.txt
@@ -43,7 +43,8 @@ add_llvm_library (seahorn.LIB DISABLE_LLVM_LINK_LLVM_DYLIB
   BvOpSem2ConstEval.cc
   BvOpSem2RawMemMgr.cc
   BvOpSem2FatMemMgr.cc
-  BvOpsem2WideMemMgr.cc
+  BvOpSem2WideMemMgr.cc
+  BvOpSem2ExtraWideMemMgr.cc
   VCGen.cc
   DfCoiAnalysis.cc
   )

--- a/scripts/coverage/docker-run-lcov.sh
+++ b/scripts/coverage/docker-run-lcov.sh
@@ -11,7 +11,7 @@
 # lit /seahorn/test
 lit /seahorn/test/opsem
 lit -D opsem-opts=--horn-bv2-widemem /seahorn/test/opsem 
-lit /seahorn/test/opsem/widemem
+lit -D opsem-opts=--horn-bv2-extra-widemem /seahorn/test/opsem
 lit /seahorn/test/mcfuzz
 lit /seahorn/test/simple
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -28,9 +28,10 @@ add_lit_testsuite(test-fat-ptr-sym "Run fat ptr symbolic tests"
   DEPENDS seahorn
   )
 
-add_lit_testsuite(test-widemem "Run wide memory symbolic tests"
+add_lit_testsuite(test-opsem-extra-widemem "Run opsem tests using extra wide memory manager"
+   -D opsem_opts="--horn-bv2-extra-widemem"
   -v
-  ${CMAKE_CURRENT_SOURCE_DIR}/opsem/widemem
+  ${CMAKE_CURRENT_SOURCE_DIR}/opsem
   ARGS
   --path=${CMAKE_INSTALL_PREFIX}/bin
   DEPENDS seahorn
@@ -215,14 +216,13 @@ if (CMAKE_GENERATOR STREQUAL "Ninja")
   add_dependencies(test-cex install)
   add_dependencies(test-inter-mem install)
   add_dependencies(test-fat-ptr-sym install)
-  add_dependencies(test-widemem install)
+  add_dependencies(test-opsem-extra-widemem install)
 
 endif()
 install (DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/simple DESTINATION share/seahorn/test)
 install (DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/solve DESTINATION share/seahorn/test)
 install (DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/smc DESTINATION share/seahorn/test)
 install (DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/opsem DESTINATION share/seahorn/test)
-install (DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/opsem/widemem DESTINATION share/seahorn/test)
 install (DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/abc DESTINATION share/seahorn/test)
 install (DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/bmc DESTINATION share/seahorn/test)
 install (DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/gsa DESTINATION share/seahorn/test)

--- a/test/opsem/widemem/buffer_outofbounds_sat.ll
+++ b/test/opsem/widemem/buffer_outofbounds_sat.ll
@@ -1,4 +1,4 @@
-; RUN: %seabmc --horn-bv2-widemem --horn-bv2-ptr-size=8 --horn-bv2-word-size=8 "%s" 2>&1 | %oc %s
+; RUN: %seabmc --horn-bv2-ptr-size=8 --horn-bv2-word-size=8 "%s" 2>&1 | %oc %s
 
 ; CHECK: ^sat$
 ; ModuleID = '/tmp/fat/bitcode.fat.pp.ms.o.ul.cut.o.bc'

--- a/test/opsem/widemem/buffer_outofbounds_unsat.ll
+++ b/test/opsem/widemem/buffer_outofbounds_unsat.ll
@@ -1,4 +1,4 @@
-; RUN: %seabmc --horn-bv2-widemem --horn-bv2-ptr-size=8 --horn-bv2-word-size=8 "%s" 2>&1 | %oc %s
+; RUN: %seabmc --horn-bv2-ptr-size=8 --horn-bv2-word-size=8 "%s" 2>&1 | %oc %s
 ; CHECK: ^unsat$
 
 ; ModuleID = '/tmp/fat/bitcode.fat.pp.ms.o.ul.cut.bc'


### PR DESCRIPTION
…set, size)

details:
1. Moved some common functions between {,extra} wide memory manager to a wide mem mgr mixin class by introducing primitives like getAddressable(). The refactor is not complete since I wanted to get something out soon. This is a prototype of where I want to go eventually.
2. Fixed a flag in opsem/widemem tests and an actual bug in wide memory manager. The fact that no-one has noticed may mean that tests are not running in CI. That problem is out of scope for this commit.
3. Replaced test-widemem flag with test-opsem-extra-widemem since tests in subdirectory opsem/widemem are automatically run as part of test-opsem. Now we have three targets 1) test-opsem 2) test-opsem-widemem and 3) test-opsem-extra-widemem.
4. Fix widememmgr name