### PR TITLE
Speedup gate SSA transformation.

### DIFF
--- a/lib/Analysis/ControlDependenceAnalysis.cc
+++ b/lib/Analysis/ControlDependenceAnalysis.cc
@@ -19,6 +19,7 @@
 #include "llvm/Support/raw_ostream.h"
 
 #include "seahorn/Support/SeaDebug.h"
+#include "seahorn/Support/Stats.hh"
 
 #define CDA_LOG(...) LOG("cda", __VA_ARGS__)
 
@@ -187,10 +188,12 @@ void ControlDependenceAnalysisPass::getAnalysisUsage(AnalysisUsage &AU) const {
 }
 
 bool ControlDependenceAnalysisPass::runOnModule(llvm::Module &M) {
+  Stats::resume("Control dependence analysis");
   bool changed = false;
   for (auto &F : M)
     if (!F.isDeclaration())
       changed |= runOnFunction(F);
+  Stats::stop("Control dependence analysis");
   return changed;
 }
 


### PR DESCRIPTION
The commit speeds up the gate ssa transformation. Instead of iterating over the `flowValues` and checking the dominance relation we can iterate over the nodes dominators and check if `flowValues` has a corresponding value.

As an example, for the SVCOMP-19 benchmark instance `c/*/linux-3.14__complex_emg__linux-alloc-spinlock__drivers-media-usb-usbvision-usbvision_true-unreach-call.cil.i`, the change reduces the transformation time from ~250 seconds to ~12 seconds.

Question: What I do not understand is why the `flowValues` has an entry for a post-dominator that isn't immediate but not for the immediate post-dominator. We are walking over `cdInfo` is reverse topological order!