### PR TITLE
perf(gate-analysis): improve GSSA transformation (#310)

### DIFF
--- a/lib/Analysis/ControlDependenceAnalysis.cc
+++ b/lib/Analysis/ControlDependenceAnalysis.cc
@@ -19,6 +19,7 @@
 #include "llvm/Support/raw_ostream.h"
 
 #include "seahorn/Support/SeaDebug.h"
+#include "seahorn/Support/Stats.hh"
 
 #define CDA_LOG(...) LOG("cda", __VA_ARGS__)
 
@@ -187,10 +188,12 @@ void ControlDependenceAnalysisPass::getAnalysisUsage(AnalysisUsage &AU) const {
 }
 
 bool ControlDependenceAnalysisPass::runOnModule(llvm::Module &M) {
+  Stats::resume("Control dependence analysis");
   bool changed = false;
   for (auto &F : M)
     if (!F.isDeclaration())
       changed |= runOnFunction(F);
+  Stats::stop("Control dependence analysis");
   return changed;
 }
 

--- a/lib/Analysis/GateAnalysis.cc
+++ b/lib/Analysis/GateAnalysis.cc
@@ -20,6 +20,7 @@
 #include "seahorn/Analysis/ControlDependenceAnalysis.hh"
 
 #include "seahorn/Support/SeaDebug.h"
+#include "seahorn/Support/Stats.hh"
 
 #define GSA_LOG(...) LOG("gsa", __VA_ARGS__)
 
@@ -149,9 +150,7 @@ GateAnalysisImpl::processIncomingValues(PHINode *PN, Instruction *insertionPt) {
     BasicBlock *falseDest = BI->getSuccessor(1);
     assert(trueDest == currentBB || falseDest == currentBB);
 
-    if (ThinnedGsa) {
-      incomingBlockToValue[incomingBlock] = incomingValue;
-    } else {
+    if (!ThinnedGsa) {
       Value *SI = m_IRB.CreateSelect(
           cond, trueDest == currentBB ? incomingValue : Undef,
           falseDest == currentBB ? incomingValue : Undef,
@@ -171,23 +170,21 @@ void GateAnalysisImpl::processPhi(PHINode *PN, Instruction *insertionPt) {
   DenseMap<BasicBlock *, Value *> incomingBlockToValue =
       processIncomingValues(PN, insertionPt);
 
+  // Make sure CD blocks are sorted in reverse-topological order. We need this
+  // because we want to process them in order opposite to execution order.
+  auto GreaterThanTopo = [this](BasicBlock *first, BasicBlock *second) {
+    return m_CDA.getBBTopoIdx(first) > m_CDA.getBBTopoIdx(second);
+  };
+  // TODO: Look into the performance effects of using a set wrt a vector.
+  // For now we use a set since, the number of redundant blocks are huge. Using
+  // a set results in a smaller time complexity.
+  std::set<BasicBlock *, decltype(GreaterThanTopo)> cdInfo(GreaterThanTopo);
   // Collect all blocks the incoming blocks are control dependent on.
-  std::vector<BasicBlock *> cdInfo;
   for (unsigned i = 0, e = PN->getNumIncomingValues(); i != e; ++i) {
     auto *BB = PN->getIncomingBlock(i);
     for (BasicBlock *CDBlock : m_CDA.getCDBlocks(BB))
-      cdInfo.push_back(CDBlock);
+      cdInfo.insert(CDBlock);
   }
-
-  // Make sure CD blocks are sorted in reverse-topological order. We need this
-  // because we want to process them in order opposite to execution order.
-  std::sort(cdInfo.begin(), cdInfo.end(),
-            [this](BasicBlock *first, BasicBlock *second) {
-              return m_CDA.getBBTopoIdx(first) > m_CDA.getBBTopoIdx(second);
-            });
-  // We can have repeated blocks if multiple incoming blocks have non-empty
-  // intersections of blocks they are control dependent on.
-  cdInfo.erase(std::unique(cdInfo.begin(), cdInfo.end()), cdInfo.end());
 
   // Mapping from blocks in cdInfo to values potentially guarded by gammas.
   DenseMap<BasicBlock *, Value *> flowingValues(incomingBlockToValue.begin(),
@@ -199,7 +196,6 @@ void GateAnalysisImpl::processPhi(PHINode *PN, Instruction *insertionPt) {
 
   // For all blocks in cdInfo and inspect their successors to construct gamma
   // nodes where needed.
-  unsigned cdNum = 0;
   GSA_LOG(errs() << "CDInfo size: " << cdInfo.size() << "\n");
   for (BasicBlock *BB : cdInfo) {
     GSA_LOG(errs() << "CDBlock: " << BB->getName() << "\n");
@@ -232,16 +228,23 @@ void GateAnalysisImpl::processPhi(PHINode *PN, Instruction *insertionPt) {
 
       // Or the successors unconditionally flows to an already processed block.
       // Note that there can be at most one such block.
-      for (auto &BlockValuePair : flowingValues) {
-        if (m_PDT.dominates(BlockValuePair.first, S)) {
-          SuccToVal[S] = BlockValuePair.second;
-          GSA_LOG({
-            errs() << "2) SuccToVal[" << S->getName() << "] = postdom for cd "
-                   << BlockValuePair.first->getName() << ": "
-                   << SuccToVal[S]->getName() << "\n";
-          });
+
+      // Used to iterate over all the post-dominators of `S`.
+      BasicBlock *postDomBlock = S;
+      while (postDomBlock) {
+        auto it = flowingValues.find(postDomBlock);
+        if (it != flowingValues.end()) {
+          SuccToVal[S] = it->second;
+          GSA_LOG(errs() << "2) SuccToVal[" << S->getName()
+                         << "] = postdom for cd " << postDomBlock->getName()
+                         << ": " << it->second->getName() << "\n");
           break;
         }
+        auto *treeNode = m_PDT.getNode(postDomBlock)->getIDom();
+        if (treeNode == nullptr) {
+          break;
+        }
+        postDomBlock = treeNode->getBlock();
       }
     }
 
@@ -270,8 +273,6 @@ void GateAnalysisImpl::processPhi(PHINode *PN, Instruction *insertionPt) {
         flowingValues[BB] = Ite;
       }
     }
-
-    ++cdNum;
   }
 
   BasicBlock *IDomBlock = m_DT.getNode(currentBB)->getIDom()->getBlock();
@@ -281,7 +282,7 @@ void GateAnalysisImpl::processPhi(PHINode *PN, Instruction *insertionPt) {
   Value *gamma = flowingValues[IDomBlock];
   Twine newName = gamma->getName() + ".y." + PN->getName();
   gamma->setName(newName);
-  m_gammas[PN] = flowingValues[IDomBlock];
+  m_gammas[PN] = gamma;
 
   GSA_LOG(errs() << "Gamma for phi: " << PN->getName() << "\n\t");
   GSA_LOG(m_gammas[PN]->print(errs()));
@@ -304,6 +305,7 @@ void GateAnalysisPass::getAnalysisUsage(AnalysisUsage &AU) const {
 }
 
 bool GateAnalysisPass::runOnModule(llvm::Module &M) {
+  Stats::resume("Thinned Gate SSA transformation");
   auto &CDP = getAnalysis<ControlDependenceAnalysisPass>();
 
   bool changed = false;
@@ -311,14 +313,14 @@ bool GateAnalysisPass::runOnModule(llvm::Module &M) {
     if (!F.isDeclaration())
       changed |= runOnFunction(F, CDP.getControlDependenceAnalysis(F));
 
-  GSA_LOG({
-    if (GsaReplacePhis)
-      for (auto &F : M)
-        if (!F.isDeclaration())
-          for (auto &BB : F)
-            for (auto &I : BB)
-              assert(!isa<PHINode>(I));
-  });
+  Stats::stop("Thinned Gate SSA transformation");
+
+  LOG("gsa", if (GsaReplacePhis) for (
+                 auto &F
+                 : M) if (!F.isDeclaration()) for (auto &BB
+                                                   : F) for (auto &I
+                                                             : BB)
+                 assert(!isa<PHINode>(I)));
 
   return changed;
 }


### PR DESCRIPTION
The commit speeds up the gate ssa transformation. Instead of iterating over
the flowValues and checking the dominance relation we can iterate over the
nodes dominators and check if flowValues has a corresponding value.

Signed-off-by: Parv Mor <parvmor.pm@gmail.com>

This PR was already merged in master. This is a new PR for the development branch dev10.