### PR TITLE
Type checker bug fix

### DIFF
--- a/include/seahorn/Expr/ExprOpCore.hh
+++ b/include/seahorn/Expr/ExprOpCore.hh
@@ -12,11 +12,9 @@ namespace typeCheck {
 struct Any;
 } // namespace typeCheck
 namespace sort {
-Expr terminalTy(ExprFactory &efac);
 Expr stringTerminalTy(ExprFactory &efac);
-Expr uintTerminalTy(ExprFactory &efac);
-Expr mpzTerminalTy(ExprFactory &efac);
-Expr mpqTerminalTy(ExprFactory &efac);
+Expr intTy(ExprFactory &efac);
+Expr realTy(ExprFactory &efac);
 } // namespace sort
 } // namespace op
 
@@ -177,7 +175,7 @@ template <> struct TerminalTrait<unsigned int> {
   static TerminalKind getKind() { return TerminalKind::UINT; }
   static std::string name() { return "unsigned int"; }
   static inline Expr inferType(Expr exp, TypeChecker &tc) {
-    return sort::uintTerminalTy(exp->efac());
+    return sort::intTy(exp->efac());
   }
 };
 
@@ -210,7 +208,7 @@ template <> struct TerminalTrait<expr::mpz_class> {
   static TerminalKind getKind() { return TerminalKind::MPZ; }
   static std::string name() { return "expr::mpz_class"; }
   static inline Expr inferType(Expr exp, TypeChecker &tc) {
-    return sort::mpzTerminalTy(exp->efac());
+    return sort::intTy(exp->efac());
   }
 };
 
@@ -239,7 +237,7 @@ template <> struct TerminalTrait<expr::mpq_class> {
   static TerminalKind getKind() { return TerminalKind::MPQ; }
   static std::string name() { return "expr::mpq_class"; }
   static inline Expr inferType(Expr exp, TypeChecker &tc) {
-    return sort::mpqTerminalTy(exp->efac());
+    return sort::realTy(exp->efac());
   }
 };
 

--- a/include/seahorn/Expr/ExprOpTerminalSort.hh
+++ b/include/seahorn/Expr/ExprOpTerminalSort.hh
@@ -13,9 +13,6 @@ namespace op {
 
 enum class TerminalTypeOpKind {
   STRING_TERMINAL_TY,
-  UINT_TERMINAL_TY,
-  MPQ_TERMINAL_TY,
-  MPZ_TERMINAL_TY,
   BVAR_TERMINAL_TY,
   LLVM_VALUE_TERMINAL_TY,
   LLVM_BASICBLOCK_TERMINAL_TY,
@@ -26,12 +23,6 @@ NOP_BASE(TerminalTypeOp)
 
 /// \brief String terminal type,
 NOP(STRING_TERMINAL_TY, "STRING TERMINAL", PREFIX, TerminalTypeOp, typeCheck::simpleType::Simple)
-/// \brief Uint terminal type,
-NOP(UINT_TERMINAL_TY, "UINT TERMINAL", PREFIX, TerminalTypeOp, typeCheck::simpleType::Simple)
-/// \brief GMP rational terminal type,
-NOP(MPQ_TERMINAL_TY, "MPQ TERMINAL", PREFIX, TerminalTypeOp, typeCheck::simpleType::Simple)
-/// \brief GMP integer terminal type,
-NOP(MPZ_TERMINAL_TY, "MPZ TERMINAL", PREFIX, TerminalTypeOp, typeCheck::simpleType::Simple)
 /// \brief Bounded variable terminal type,
 NOP(BVAR_TERMINAL_TY, "BVAR TERMINAL", PREFIX, TerminalTypeOp, typeCheck::simpleType::Simple)
 /// \brief llvm::Value terminal type,
@@ -45,9 +36,6 @@ NOP(LLVM_FUNCTION_TERMINAL_TY, "LLVM::FUNCTION TERMINAL", PREFIX, TerminalTypeOp
 namespace op {
 namespace sort {
 inline Expr stringTerminalTy(ExprFactory &efac) { return mk<STRING_TERMINAL_TY>(efac); }
-inline Expr uintTerminalTy(ExprFactory &efac) { return mk<UINT_TERMINAL_TY>(efac); }
-inline Expr mpqTerminalTy(ExprFactory &efac) { return mk<MPQ_TERMINAL_TY>(efac); }
-inline Expr mpzTerminalTy(ExprFactory &efac) { return mk<MPZ_TERMINAL_TY>(efac); }
 inline Expr bvarTerminalTy(ExprFactory &efac) { return mk<BVAR_TERMINAL_TY>(efac); }
 inline Expr llvmValueTerminalTy(ExprFactory &efac) { return mk<LLVM_VALUE_TERMINAL_TY>(efac); }
 inline Expr llvmBasicBlockTerminalTy(ExprFactory &efac) { return mk<LLVM_BASICBLOCK_TERMINAL_TY>(efac); }

--- a/include/seahorn/Expr/ExprOpVariant.hh
+++ b/include/seahorn/Expr/ExprOpVariant.hh
@@ -51,7 +51,7 @@ static inline Expr checkVariant(Expr exp, TypeChecker &tc) {
 
 struct Variant {
   static inline Expr inferType(Expr exp, TypeChecker &tc) {
-    return checkVariant <UINT_TERMINAL_TY> (exp, tc);
+    return checkVariant <INT_TY> (exp, tc);
   }
 };
 

--- a/include/seahorn/Expr/TypeCheckerUtils.hh
+++ b/include/seahorn/Expr/TypeCheckerUtils.hh
@@ -180,4 +180,4 @@ struct Any {
 } // namespace op
 } // namespace expr
 
-#define NUM_TYPES INT_TY, REAL_TY, UNINT_TY, UINT_TERMINAL_TY, MPQ_TERMINAL_TY, MPZ_TERMINAL_TY
+#define NUM_TYPES INT_TY, REAL_TY, UNINT_TY

--- a/lib/seahorn/Smt/TypeChecker.cc
+++ b/lib/seahorn/Smt/TypeChecker.cc
@@ -148,10 +148,4 @@ TypeChecker::~TypeChecker() { delete m_impl; }
 Expr TypeChecker::typeOf(Expr e) { return m_impl->typeOf(e); }
 Expr TypeChecker::getErrorExp() { return m_impl->getErrorExp(); }
 
-// TypeChecker::TypeChecker() {}
-// Expr TypeChecker::typeOf(Expr e) { return m_tc.typeOf(e); }
-
-// // to be called after typeOf() or sortOf()
-// Expr TypeChecker::getErrorExp() { return m_tc.getErrorExp(); }
-
 } // namespace expr

--- a/units/TypeCheckerTests.cpp
+++ b/units/TypeCheckerTests.cpp
@@ -279,9 +279,8 @@ TEST_CASE("numWellFormed.test") {
   // -- manages expressions
   ExprFactory efac;
 
-  Expr uintSort = sort::uintTerminalTy(efac);
-  Expr mpqSort = sort::mpqTerminalTy(efac);
-  Expr mpzSort = sort::mpzTerminalTy(efac);
+  Expr intSort = sort::intTy(efac);
+  Expr realSort = sort::realTy(efac);
 
   Expr aUint = mkTerm<unsigned>(5, efac);
   Expr bUint = mkTerm<unsigned>(20, efac);
@@ -292,6 +291,10 @@ TEST_CASE("numWellFormed.test") {
   Expr aMPZ = mkTerm<mpz_class>(20, efac);
   Expr bMPZ = mkTerm<mpz_class>(99, efac);
 
+  Expr aInt = intConst("aInt", efac);
+
+  Expr aReal = realConst("aReal", efac);
+
   std::vector<Expr> e;
   Expr temp;
 
@@ -301,22 +304,26 @@ TEST_CASE("numWellFormed.test") {
   temp = mk<UN_MINUS>(bUint, bUint, e.back());
   e.push_back(temp);
 
-  checkWellFormed(e, uintSort);
-  e.clear();
-
-  temp = mk<ITV>(aMPQ, bMPQ);
-  e.push_back(temp);
-
-  checkWellFormed(e, mpqSort);
-  e.clear();
-
   temp = mk<REM>(aMPZ, bMPZ);
   e.push_back(temp);
 
   temp = mk<MULT>(e.back(), mk<ABS>(e.back()), mk<ABS>(e.back()));
   e.push_back(temp);
 
-  checkWellFormed(e, mpzSort);
+  temp = mk<PLUS>(aUint, aMPZ, aInt);
+  e.push_back(temp);
+
+  checkWellFormed(e, intSort);
+  e.clear();
+
+  temp = mk<ITV>(aMPQ, bMPQ);
+  e.push_back(temp);
+
+  temp = mk<MINUS>(aMPQ, aReal);
+  e.push_back(temp);
+
+  checkWellFormed(e, realSort);
+  e.clear();
 }
 
 TEST_CASE("numNotWellFormed.test") {
@@ -361,6 +368,10 @@ TEST_CASE("numNotWellFormed.test") {
   error.push_back(tempError);
 
   tempError = mk<MINUS>(aMPZ);
+  error.push_back(tempError);
+  e.push_back(tempError);
+
+  tempError = mk<GT>(aMPQ, aMPZ); // REAL > INT, types do not match
   error.push_back(tempError);
   e.push_back(tempError);
 


### PR DESCRIPTION
Made unsigned, mpz, and ints have the same type. Also made mpq and reals have the same type.
Before the fix it thought that, for example, an int + mpz was an error when it shouldn't be