### PR TITLE
Typechecker bug fix: make equals work with finite maps

### DIFF
--- a/include/seahorn/Expr/ExprOpCompare.hh
+++ b/include/seahorn/Expr/ExprOpCompare.hh
@@ -18,12 +18,39 @@ struct Equality {
   /// \return BOOL_TY
   /// Possible types of children: any type except for ERROR_TY
   static inline Expr inferType(Expr exp, TypeChecker &tc) {
+
+    // finite maps are a special case: the keys are stored directly, not as
+    // their type
+    if (isOp<FINITE_MAP_TY>(tc.typeOf(exp->first()))) {
+      if (!(exp->arity() == 2 && isOp<FINITE_MAP_TY>(tc.typeOf(exp->right()))))
+        return sort::errorTy(exp->efac());
+
+      Expr leftType = tc.typeOf(exp->left());
+      Expr rightType = tc.typeOf(exp->right());
+
+      bool sameValTy =
+          sort::finiteMapValTy(leftType) == sort::finiteMapValTy(rightType);
+      bool sameNumKeys = sort::finiteMapKeyTy(leftType)->arity() ==
+                         sort::finiteMapKeyTy(rightType)->arity();
+      bool sameKeyTy =
+          tc.typeOf(sort::finiteMapKeyTy(leftType)->first()) ==
+          tc.typeOf(sort::finiteMapKeyTy(leftType)
+                        ->first()); // just check that the keys have the same
+                                    // type, not necessarily the same name
+
+      if (sameValTy && sameNumKeys && sameKeyTy) {
+        return sort::boolTy(exp->efac());
+      }
+
+      return sort::errorTy(exp->efac());
+    }
+
     return typeCheck::binary<BOOL_TY, ANY_TY>(exp, tc);
   }
 };
 struct Inequality {
   /// \return BOOL_TY
-  /// Possible types of children: any number type 
+  /// Possible types of children: any number type
   static inline Expr inferType(Expr exp, TypeChecker &tc) {
     return typeCheck::binary<BOOL_TY, NUM_TYPES>(exp, tc);
   }

--- a/units/TypeCheckerTests.cpp
+++ b/units/TypeCheckerTests.cpp
@@ -1440,6 +1440,8 @@ TEST_CASE("finiteMapWellFormed.test") {
 
   Expr aIntKey = intConst("k_aInt", efac);
   Expr bIntKey = intConst("k_bInt", efac);
+  Expr cIntKey = intConst("k_cInt", efac);
+  Expr dIntKey = intConst("k_dInt", efac);
 
   Expr boolSort = sort::boolTy(efac);
   Expr intSort = sort::intTy(efac);
@@ -1483,6 +1485,16 @@ TEST_CASE("finiteMapWellFormed.test") {
   e.push_back(temp);
 
   checkWellFormed(e, finiteMapSort2);
+  e.clear();
+
+  temp = finite_map::constFiniteMap(keys, vals);
+  keys.clear();
+  keys.push_back(cIntKey);
+  keys.push_back(dIntKey);
+  Expr temp2 = finite_map::constFiniteMap(keys, vals);
+  e.push_back(mk<EQ>(temp, temp2)); // keys have same type but different names
+
+  checkWellFormed(e, boolSort);
 }
 TEST_CASE("finiteMapNotWellFormed.test") {
   seahorn::SeaEnableLog("tc");


### PR DESCRIPTION
The finite map type stores the keys directly (not as their type) so if the keys have different names then it will think there's an error. This fix checks that each finite map has: 1. the same value type, 2. the same number of keys, 3. the same type of keys (ignoring what the actual keys are)