### PR TITLE
fix(typechecker): add ability to infer type before visiting children

### DIFF
--- a/include/seahorn/Expr/ExprCore.hh
+++ b/include/seahorn/Expr/ExprCore.hh
@@ -88,7 +88,10 @@ public:
   /// \brief Returns heap-allocted copy of the operator
   virtual Operator *clone(ExprFactoryAllocator &allocator) const = 0;
   virtual std::string name() const = 0;
-  /// \brief Returns the type of the expression 
+  /// \return true for the typechecker to infer the type of the current
+  /// expression before visiting its children
+  virtual bool typeCheckTopDown() const = 0;
+  /// \brief Returns the type of the expression
   virtual Expr inferType(Expr exp, TypeChecker &tc) const = 0;
 };
 
@@ -183,7 +186,6 @@ public:
     Print(std::cerr, 0, false);
     std::cerr << std::endl;
   }
-
 
   friend class ExprFactory;
   friend struct std::less<expr::ENode *>;

--- a/include/seahorn/Expr/ExprOpArray.hh
+++ b/include/seahorn/Expr/ExprOpArray.hh
@@ -35,8 +35,8 @@ static inline void getArrayTypes(Expr exp, TypeChecker &tc, Expr &mapTy, Expr &i
   ///ensures that the expression's key type matches the arrays's key type
   /// checks for the following children (in order): map, index
   /// \return the array's value type
-struct Select {
-  static inline Expr inferType(Expr exp, TypeChecker &tc) {
+struct Select  : public TypeCheckBase{
+  inline Expr inferType(Expr exp, TypeChecker &tc) {
     return typeCheck::mapType::select<ARRAY_TY>(exp, tc, getArrayTypes);
   }
 };
@@ -44,16 +44,16 @@ struct Select {
   /// ensures that the index type and value type match the array's index and value types
   /// checks for the following children (in order): array, index, value
   /// \return ARRAY_TY
-struct Store {
-  static inline Expr inferType(Expr exp, TypeChecker &tc) {
+struct Store  : public TypeCheckBase{
+  inline Expr inferType(Expr exp, TypeChecker &tc) {
     return typeCheck::mapType::store<ARRAY_TY>(exp, tc, getArrayTypes);
   }
 };
 
   /// Expected Children types(in order): TYPE_TY, anything
   /// \return: ARRAY_TY
-struct Const {
-  static inline Expr inferType(Expr exp, TypeChecker &tc) {
+struct Const  : public TypeCheckBase{
+  inline Expr inferType(Expr exp, TypeChecker &tc) {
     if (exp->arity() != 2)
       return sort::errorTy(exp->efac());
 
@@ -69,8 +69,8 @@ struct Const {
 
   /// Expected Children type: ARRAY_TY
   /// \return: ARRAY_TY
-struct Default {
-  static inline Expr inferType(Expr exp, TypeChecker &tc) {
+struct Default  : public TypeCheckBase{
+  inline Expr inferType(Expr exp, TypeChecker &tc) {
 
     if (!checkArray(exp, tc, 1))
       return sort::errorTy(exp->efac());

--- a/include/seahorn/Expr/ExprOpBinder.hh
+++ b/include/seahorn/Expr/ExprOpBinder.hh
@@ -6,6 +6,8 @@
 #include "seahorn/Expr/ExprOpBool.hh"
 #include "seahorn/Expr/ExprOpCore.hh"
 #include "seahorn/Expr/ExprVisitor.hh"
+#include "seahorn/Expr/TypeCheckerUtils.hh"
+
 namespace expr {
 namespace op {
 namespace bind {
@@ -149,13 +151,13 @@ static inline bool binderCheck(Expr exp, TypeChecker &tc,
   return true;
 }
 
-struct Lambda {
+struct Lambda : public TypeCheckBase{
   /// ensures that all children except for the last (the body) are constants
   /// \note does not check bound variables
   /// \return FUNCTIONAL_TY
   /// for example, for the expression lambda a, b, c ... :: body, the return
   /// type is FUNCTIONAL_TY(typeOf(a), typeOf(b), ... , typeOf(body))
-  static inline Expr inferType(Expr exp, TypeChecker &tc) {
+  inline Expr inferType(Expr exp, TypeChecker &tc) {
     ExprVector boundTypes;
     if (!binderCheck(exp, tc, boundTypes))
       return sort::errorTy(exp->efac());
@@ -167,12 +169,12 @@ struct Lambda {
   }
 };
 
-struct Quantifier {
+struct Quantifier : public TypeCheckBase{
   /// ensures that: 1. all children except for the last (the body) are constants
   ///  2. the body type is BOOL_TY
   /// \note does not check bound variables
   /// \return BOOL_TY
-  static inline Expr inferType(Expr exp, TypeChecker &tc) {
+  inline Expr inferType(Expr exp, TypeChecker &tc) {
     ExprVector boundTypes;
     Expr body = exp->last();
     if (!(binderCheck(exp, tc, boundTypes) &&

--- a/include/seahorn/Expr/ExprOpBool.hh
+++ b/include/seahorn/Expr/ExprOpBool.hh
@@ -14,40 +14,40 @@ enum class BoolOpKind { TRUE, FALSE, AND, OR, XOR, NEG, IMPL, ITE, IFF };
 namespace typeCheck {
 namespace boolType {
 
-struct OneOrMore {
+struct OneOrMore  : public TypeCheckBase{
   /// \return BOOL_TY
   /// Possible types of children: BOOL_TY
-  static inline Expr inferType(Expr exp, TypeChecker &tc) {
+  inline Expr inferType(Expr exp, TypeChecker &tc) {
     return typeCheck::oneOrMore<BOOL_TY, BOOL_TY>(exp, tc);
   }
 };
 
-struct Unary {
+struct Unary  : public TypeCheckBase{
   /// \return BOOL_TY
   /// Possible types of children: BOOL_TY
-  static inline Expr inferType(Expr exp, TypeChecker &tc) {
+  inline Expr inferType(Expr exp, TypeChecker &tc) {
     return typeCheck::unary<BOOL_TY, BOOL_TY>(exp, tc);
   }
 };
 
-struct Binary {
+struct Binary  : public TypeCheckBase{
   /// \return BOOL_TY
   /// Possible types of children: BOOL_TY
-  static inline Expr inferType(Expr exp, TypeChecker &tc) {
+  inline Expr inferType(Expr exp, TypeChecker &tc) {
     return typeCheck::binary<BOOL_TY, BOOL_TY>(exp, tc);
   }
 };
 
-struct Nary {
+struct Nary  : public TypeCheckBase{
   /// \return BOOL_TY
   /// Possible types of children: BOOL_TY
-  static inline Expr inferType(Expr exp, TypeChecker &tc) {
+  inline Expr inferType(Expr exp, TypeChecker &tc) {
     return typeCheck::nary<BOOL_TY, BOOL_TY>(exp, tc);
   }
 };
 
-struct ITE {
-  static inline Expr inferType(Expr exp, TypeChecker &tc) {
+struct ITE  : public TypeCheckBase{
+  inline Expr inferType(Expr exp, TypeChecker &tc) {
 
     // ite(a,b,c) : a is bool type, b and c are the same type
     if (exp->arity() == 3 && isOp<BOOL_TY>(tc.typeOf(exp->arg(0))) &&
@@ -58,8 +58,8 @@ struct ITE {
   }
 };
 
-struct TrueFalse {
-  static inline Expr inferType(Expr exp, TypeChecker &tc) {
+struct TrueFalse  : public TypeCheckBase{
+  inline Expr inferType(Expr exp, TypeChecker &tc) {
     return sort::boolTy(exp->efac());
   }
 };

--- a/include/seahorn/Expr/ExprOpBv.hh
+++ b/include/seahorn/Expr/ExprOpBv.hh
@@ -194,32 +194,32 @@ static inline Expr returnType(Expr exp, TypeChecker &tc) {
 
 /// \return: type of children
 /// Possible types of children: BVSORT
-struct Unary {
-  static inline Expr inferType(Expr exp, TypeChecker &tc) {
+struct Unary  : public TypeCheckBase{
+  inline Expr inferType(Expr exp, TypeChecker &tc) {
     return typeCheck::unary<BVSORT>(exp, tc, returnType);
   }
 };
 
 /// \return: type of children
 /// Possible types of children: BVSORT
-struct Binary {
-  static inline Expr inferType(Expr exp, TypeChecker &tc) {
+struct Binary  : public TypeCheckBase{
+  inline Expr inferType(Expr exp, TypeChecker &tc) {
     return typeCheck::binary<BVSORT>(exp, tc, returnType);
   }
 };
 
 /// \return: type of children
 /// Possible types of children: BVSORT
-struct Nary {
-  static inline Expr inferType(Expr exp, TypeChecker &tc) {
+struct Nary  : public TypeCheckBase{
+  inline Expr inferType(Expr exp, TypeChecker &tc) {
     return typeCheck::nary<BVSORT>(exp, tc, returnType);
   }
 };
 
 /// \return: BOOL_TY
 /// Possible types of children: BVSORT
-struct BinaryBool {
-  static inline Expr inferType(Expr exp, TypeChecker &tc) {
+struct BinaryBool  : public TypeCheckBase{
+  inline Expr inferType(Expr exp, TypeChecker &tc) {
     return typeCheck::binary<BOOL_TY, BVSORT>(exp, tc);
   }
 };
@@ -235,11 +235,11 @@ static inline Expr getExtendReturnType(Expr exp, TypeChecker &tc) {
   return bv::bvsort(width, exp->efac());
 }
 
-struct Concat {
+struct Concat  : public TypeCheckBase{
 
   /// \return: BVSORT with sum of children's width
   /// Possible types of children: BVSORT (children don't need matching widths)
-  static inline Expr inferType(Expr exp, TypeChecker &tc) {
+  inline Expr inferType(Expr exp, TypeChecker &tc) {
     auto returnTypeFn = [](Expr exp, TypeChecker &tc) {
       return getExtendReturnType(exp, tc);
     };
@@ -248,11 +248,11 @@ struct Concat {
   }
 };
 
-struct Extend {
+struct Extend  : public TypeCheckBase{
   /// \return: BVSORT with sum of children's width
   /// Expected Children (in order): BVSORT type, and bvsort(the operator, not an
   /// expresion of this type)
-  static inline Expr inferType(Expr exp, TypeChecker &tc) {
+  inline Expr inferType(Expr exp, TypeChecker &tc) {
     if (exp->arity() != 2)
       return sort::errorTy(exp->efac());
 
@@ -284,11 +284,11 @@ checkUnsignedChildren(Expr exp, TypeChecker &tc, unsigned numChildren,
   return sort::errorTy(exp->efac());
 }
 
-struct Extract {
+struct Extract  : public TypeCheckBase{
   /// \return: BVSORT with a width corresponding that specified in the
   /// expression Expected Children types(in order): UINT_TERMINAL_TY,
   /// UINT, BVSORT
-  static inline Expr inferType(Expr exp, TypeChecker &tc) {
+  inline Expr inferType(Expr exp, TypeChecker &tc) {
     auto returnTypeFn = [](Expr exp, TypeChecker &tc) {
       Expr high = exp->arg(0);
       Expr low = exp->arg(1);
@@ -310,16 +310,16 @@ struct Extract {
 
 /// \return: INT_TY
 /// Possible types of children: BVSORT
-struct Bv2Int {
-  static inline Expr inferType(Expr exp, TypeChecker &tc) {
+struct Bv2Int : public TypeCheckBase {
+  inline Expr inferType(Expr exp, TypeChecker &tc) {
     return typeCheck::unary<INT_TY, BVSORT>(exp, tc);
   }
 };
 
 /// \return: BVSORT with a width corresponding that specified in the expression
 /// Expected Children types(in order): UINT, INT_TY
-struct Int2Bv {
-  static inline Expr inferType(Expr exp, TypeChecker &tc) {
+struct Int2Bv : public TypeCheckBase {
+  inline Expr inferType(Expr exp, TypeChecker &tc) {
     auto returnTypeFn = [](Expr exp, TypeChecker &tc) {
       unsigned width = getTerm<unsigned>(exp->left());
       return bv::bvsort(width, exp->efac());
@@ -331,8 +331,8 @@ struct Int2Bv {
 
 /// \return: BVSORT with a width matching the passed bv expression
 /// Expected Children types(in order): UINT, BVSORT
-struct Rotate {
-  static inline Expr inferType(Expr exp, TypeChecker &tc) {
+struct Rotate  : public TypeCheckBase{
+  inline Expr inferType(Expr exp, TypeChecker &tc) {
     auto returnTypeFn = [](Expr exp, TypeChecker &tc) {
       return tc.typeOf(exp->right());
     };
@@ -343,8 +343,8 @@ struct Rotate {
 
 /// \return: BVSORT with a width multiplied by the number of times its repeated
 /// Expected Children types(in order): UINT_TERMINAL_TY, BVSORT
-struct Repeat {
-  static inline Expr inferType(Expr exp, TypeChecker &tc) {
+struct Repeat  : public TypeCheckBase{
+  inline Expr inferType(Expr exp, TypeChecker &tc) {
     auto returnTypeFn = [](Expr exp, TypeChecker &tc) {
       unsigned timesRepeated = getTerm<unsigned>(exp->left());
       unsigned width = bv::width(tc.typeOf(exp->right()));

--- a/include/seahorn/Expr/ExprOpCompare.hh
+++ b/include/seahorn/Expr/ExprOpCompare.hh
@@ -14,10 +14,10 @@ enum class CompareOpKind { EQ, NEQ, LEQ, GEQ, LT, GT };
 namespace typeCheck {
 namespace compareType {
 
-struct Equality {
+struct Equality  : public TypeCheckBase{
   /// \return BOOL_TY
   /// Possible types of children: any type except for ERROR_TY
-  static inline Expr inferType(Expr exp, TypeChecker &tc) {
+  inline Expr inferType(Expr exp, TypeChecker &tc) {
 
     // finite maps are a special case: the keys are stored directly, not as
     // their type
@@ -48,10 +48,10 @@ struct Equality {
     return typeCheck::binary<BOOL_TY, ANY_TY>(exp, tc);
   }
 };
-struct Inequality {
+struct Inequality  : public TypeCheckBase{
   /// \return BOOL_TY
   /// Possible types of children: any number type
-  static inline Expr inferType(Expr exp, TypeChecker &tc) {
+  inline Expr inferType(Expr exp, TypeChecker &tc) {
     return typeCheck::binary<BOOL_TY, NUM_TYPES>(exp, tc);
   }
 };

--- a/include/seahorn/Expr/ExprOpCore.hh
+++ b/include/seahorn/Expr/ExprOpCore.hh
@@ -128,6 +128,10 @@ public:
            llvm::cast<TerminalBase>(op)->m_kind == terminal_type::getKind();
   }
 
+  bool typeCheckTopDown() const override {
+    return false;
+  }
+
   Expr inferType(Expr exp, TypeChecker &tc) const override {
     return terminal_type::inferType(exp, tc);
   }
@@ -424,8 +428,12 @@ struct DefOp : public B {
            llvm::cast<base_type>(op)->m_kind == kind;
   }
 
+ bool typeCheckTopDown() const override {
+    return checker_type().topDown();
+  }
+
   Expr inferType(Expr exp, TypeChecker &tc) const override {
-    return checker_type::inferType(exp, tc);
+    return checker_type().inferType(exp, tc);
   }
 };
 

--- a/include/seahorn/Expr/ExprOpFiniteMap.hh
+++ b/include/seahorn/Expr/ExprOpFiniteMap.hh
@@ -47,10 +47,10 @@ NOP(SET, "set", FUNCTIONAL, FiniteMapOp, typeCheck::finiteMapType::Set)
 namespace typeCheck {
 namespace finiteMapType {
 
-struct ValuesKeys {
+struct ValuesKeys  : public TypeCheckBase{
   /// ensures that all children are the same type
   /// \return the type of its children
-  static inline Expr inferType(Expr exp, TypeChecker &tc) {
+  inline Expr inferType(Expr exp, TypeChecker &tc) {
     auto returnFn = [](Expr exp, TypeChecker &tc) {
       return tc.typeOf(exp->first());
     };
@@ -59,10 +59,10 @@ struct ValuesKeys {
         exp, tc, returnFn); // children can by of any type
   }
 };
-struct ValuesDefault {
+struct ValuesDefault  : public TypeCheckBase{
   /// ensures that there is 1 child
   /// \return the type of its child
-  static inline Expr inferType(Expr exp, TypeChecker &tc) {
+  inline Expr inferType(Expr exp, TypeChecker &tc) {
     auto returnFn = [](Expr exp, TypeChecker &tc) {
       return tc.typeOf(exp->first());
     };
@@ -72,10 +72,10 @@ struct ValuesDefault {
   }
 };
 
-struct FiniteMap {
+struct FiniteMap  : public TypeCheckBase{
   /// ensures that the left child is a valid key type, and right is a valid value
   /// \return: FINITE_MAP_TY
-  static inline Expr inferType(Expr exp, TypeChecker &tc) {
+  inline Expr inferType(Expr exp, TypeChecker &tc) {
     if (exp->arity() != 2)
       return sort::errorTy(exp->efac());
 
@@ -114,23 +114,23 @@ static inline void getFiniteMapTypes(Expr exp, TypeChecker &tc,
   valTy = sort::finiteMapValTy(mapTy);
 }
 
-struct Get {
+struct Get  : public TypeCheckBase{
   /// ensures that the expression's index type matches the map's index type
   /// checks for the following children (in order): map, index
   /// \return the map's value type
   /// \note this is the same as array select
-  static inline Expr inferType(Expr exp, TypeChecker &tc) {
+  inline Expr inferType(Expr exp, TypeChecker &tc) {
     return typeCheck::mapType::select<FINITE_MAP_TY>(exp, tc,
                                                      getFiniteMapTypes);
   }
 };
 
-struct Set {
+struct Set  : public TypeCheckBase{
   /// ensures that the index type and value type match the map's index and value types
   /// checks for the following children (in order): map, index, value
   /// \return FINITE_MAP_TY
   /// \note this is the same as array store
-  static inline Expr inferType(Expr exp, TypeChecker &tc) {
+  inline Expr inferType(Expr exp, TypeChecker &tc) {
     return typeCheck::mapType::store<FINITE_MAP_TY>(exp, tc,
                                                     getFiniteMapTypes);
   }

--- a/include/seahorn/Expr/ExprOpNum.hh
+++ b/include/seahorn/Expr/ExprOpNum.hh
@@ -31,26 +31,26 @@ namespace numType {
 static inline Expr returnType(Expr exp, TypeChecker &tc) {
   return tc.typeOf(exp->first());
 }
-struct Unary {
+struct Unary  : public TypeCheckBase{
   /// Possible types of children: any num type
   /// \return: type of children
-  static inline Expr inferType(Expr exp, TypeChecker &tc) {
+  inline Expr inferType(Expr exp, TypeChecker &tc) {
     return typeCheck::unary<NUM_TYPES>(exp, tc, returnType);
   }
 };
 
-struct Binary {
+struct Binary  : public TypeCheckBase{
   /// Possible types of children: any num type
   /// \return: type of children
-  static inline Expr inferType(Expr exp, TypeChecker &tc) {
+  inline Expr inferType(Expr exp, TypeChecker &tc) {
     return typeCheck::binary<NUM_TYPES>(exp, tc, returnType);
   }
 };
 
-struct Nary {
+struct Nary  : public TypeCheckBase{
   // Return type: type of children
   // Possible types of children: any number type
-  static inline Expr inferType(Expr exp, TypeChecker &tc) {
+  inline Expr inferType(Expr exp, TypeChecker &tc) {
     return typeCheck::nary<NUM_TYPES>(exp, tc, returnType);
   }
 };

--- a/include/seahorn/Expr/ExprOpSort.hh
+++ b/include/seahorn/Expr/ExprOpSort.hh
@@ -4,6 +4,7 @@
 #include "seahorn/Expr/ExprApi.hh"
 #include "seahorn/Expr/ExprCore.hh"
 #include "seahorn/Expr/ExprOpCore.hh"
+#include "seahorn/Expr/TypeCheckerBase.hh"
 #include <string>
 
 namespace expr {
@@ -33,8 +34,8 @@ inline Expr typeTy(ExprFactory &efac);
 
 namespace typeCheck {
 namespace simpleType {
-struct Simple {
-  static inline Expr inferType(Expr exp, TypeChecker &tc) {
+struct Simple : public TypeCheckBase{
+  inline Expr inferType(Expr exp, TypeChecker &tc) {
     return sort::typeTy(exp->efac());
   }
 };

--- a/include/seahorn/Expr/ExprOpStruct.hh
+++ b/include/seahorn/Expr/ExprOpStruct.hh
@@ -16,8 +16,8 @@ enum class StructOpKind { MK_STRUCT, EXTRACT_VALUE, INSERT_VALUE };
 
 namespace typeCheck {
 namespace structType {
-struct Struct {
-  static inline Expr inferType(Expr exp, TypeChecker &tc) {
+struct Struct  : public TypeCheckBase{
+  inline Expr inferType(Expr exp, TypeChecker &tc) {
     ExprVector childrenTypes;
     bool wellFormed = true;
 
@@ -47,8 +47,8 @@ static inline bool structCheck(Expr exp, unsigned numChildren) {
          getIndex(exp) < getStruct(exp)->arity();
 }
 
-struct Insert {
-  static inline Expr inferType(Expr exp, TypeChecker &tc) {
+struct Insert  : public TypeCheckBase{
+  inline Expr inferType(Expr exp, TypeChecker &tc) {
     if (!structCheck(exp, 3))
       return sort::errorTy(exp->efac());
 
@@ -67,8 +67,8 @@ struct Insert {
   }
 };
 
-struct Extract {
-  static inline Expr inferType(Expr exp, TypeChecker &tc) {
+struct Extract  : public TypeCheckBase{
+  inline Expr inferType(Expr exp, TypeChecker &tc) {
     if (!structCheck(exp, 2))
       return sort::errorTy(exp->efac());
 

--- a/include/seahorn/Expr/ExprOpVariant.hh
+++ b/include/seahorn/Expr/ExprOpVariant.hh
@@ -49,14 +49,14 @@ static inline Expr checkVariant(Expr exp, TypeChecker &tc) {
 
 }
 
-struct Variant {
-  static inline Expr inferType(Expr exp, TypeChecker &tc) {
+struct Variant : public TypeCheckBase {
+  inline Expr inferType(Expr exp, TypeChecker &tc) {
     return checkVariant <INT_TY> (exp, tc);
   }
 };
 
-struct Tag {
-  static inline Expr inferType(Expr exp, TypeChecker &tc) {
+struct Tag : public TypeCheckBase{
+  inline Expr inferType(Expr exp, TypeChecker &tc) {
     return checkVariant <ANY_TY>(exp, tc);
   }
 };

--- a/include/seahorn/Expr/TypeChecker.hh
+++ b/include/seahorn/Expr/TypeChecker.hh
@@ -12,8 +12,9 @@ namespace expr {
  * method. It should return the type of the specific operator
  *
  * Adding new Normal operators (NOP, DefOp): The type checking is defined
- * externally. Create a struct with an inferType(Expr, TypeChecker&) function
- * and pass this struct to NOP/DefOp
+ * externally. Create a struct that inherits TypeCheckBase (in TypeCheckBase.hh)
+ * with an inferType(Expr, TypeChecker&) function and pass this struct to
+ * NOP/DefOp
  *
  * Adding new Terminal operators: The type checking is defined internally. Every
  * terminal trait defines its own inferType(Expr, TypeChecker&) function

--- a/include/seahorn/Expr/TypeCheckerBase.hh
+++ b/include/seahorn/Expr/TypeCheckerBase.hh
@@ -1,0 +1,21 @@
+
+#pragma once
+
+#include "seahorn/Expr/TypeChecker.hh"
+
+namespace expr {
+namespace op {
+namespace typeCheck {
+
+struct TypeCheckBase {
+
+  /// \return true to infer the type of the current expression before visiting
+  /// its children
+  virtual inline bool topDown() { return false; };
+
+  /// \return the type of the expression
+  virtual inline Expr inferType(Expr exp, TypeChecker &tc) = 0;
+};
+} // namespace typeCheck
+} // namespace op
+} // namespace expr

--- a/include/seahorn/Expr/TypeCheckerUtils.hh
+++ b/include/seahorn/Expr/TypeCheckerUtils.hh
@@ -2,6 +2,7 @@
 
 #include "seahorn/Expr/ExprOpSort.hh"
 #include "seahorn/Expr/TypeChecker.hh"
+#include "seahorn/Expr/TypeCheckerBase.hh"
 
 namespace expr {
 namespace op {
@@ -171,8 +172,8 @@ static inline Expr nary(Expr exp, TypeChecker &tc) {
                                                   returnTypeFn<returnType>);
 }
 
-struct Any {
-  static inline Expr inferType(Expr exp, TypeChecker &tc) {
+struct Any : TypeCheckBase {
+  inline Expr inferType(Expr exp, TypeChecker &tc) {
     return sort::anyTy(exp->efac());
   }
 };

--- a/units/TypeCheckerTests.cpp
+++ b/units/TypeCheckerTests.cpp
@@ -1319,6 +1319,21 @@ TEST_CASE("fappWellFormed.test") {
   e.push_back(temp);
 
   checkWellFormed(e, intSort);
+  e.clear();
+
+  Expr errorName = mk<AND>(intBound0);
+
+  args.clear();
+  args.push_back(errorName);
+  args.push_back(boolSort);
+  args.push_back(intSort);
+  args.push_back(intSort);
+
+  temp = mknary<FDECL>(args.begin(),
+                       args.end()); // fdecl should skip over the name
+  e.push_back(temp);
+
+  checkWellFormed(e, functionalSort);
 }
 TEST_CASE("fappNotWellFormed.test") {
   seahorn::SeaEnableLog("tc");


### PR DESCRIPTION
used to skip typechecking the name expression of fdecls