### PR TITLE
fix(hex-dump): updated widths,and fixed ite

### DIFF
--- a/include/seahorn/Expr/HexDump.hh
+++ b/include/seahorn/Expr/HexDump.hh
@@ -10,7 +10,7 @@ namespace hexDump {
  * This is an individual cell in the hex dump. It stores a key and its
  * corresponding value
  *
- * \note bvnums are stored as MPZ expressions
+ * \note bvnums and UINT are stored as MPZ expressions
  */
 class KeyValue {
   std::pair<Expr, Expr> m_pair; // <key, value>
@@ -74,12 +74,15 @@ class HexDump {
   Impl *m_impl;
 
 public:
-  HexDump(Expr exp, unsigned addressesPerWord = 1);
+  HexDump(Expr exp, unsigned bytesPerWord = 1);
   ~HexDump();
 
   const_hd_iterator cbegin() const;
   const_hd_iterator cend() const;
 
+  /// \note the width of the index is based on the max number of bytes out of
+  /// all the indices
+  /// \note the width of the value is based on the bytesPerWord
   template <typename T> void print(T &OS, bool includeAscii = true) const;
 
   friend llvm::raw_ostream &operator<<(llvm::raw_ostream &OS,
@@ -98,7 +101,7 @@ class StructHexDump {
   StructImpl *m_impl;
 
 public:
-  StructHexDump(Expr exp, unsigned addressesPerWord = 1);
+  StructHexDump(Expr exp, unsigned bytesPerWord = 1);
   ~StructHexDump();
 
   std::vector<const_hd_range> getRanges() const;

--- a/units/HexDumpTests.cpp
+++ b/units/HexDumpTests.cpp
@@ -66,8 +66,8 @@ TEST_CASE("hexDumpBvNum.test") {
                             true)); // filler KeyValue
   populateBvNumArr(e, efac, kvList, 30, 116);
 
-  HexDump hd(e, 2);
-  llvm::errs() << hd;
+  HexDump hd(e, 2); // value has a width of 2 bytes
+  llvm::errs() << hd << "\n";
   // // std::cout<<hd;
   // hd.dump(std::cout, false);
   std::string outcome = boost::lexical_cast<std::string>(hd);
@@ -86,6 +86,29 @@ TEST_CASE("hexDumpBvNum.test") {
 
   CHECK(outcome == expected);
   checkPairs(kvList.cbegin(), kvList.cend(), hd.cbegin(), hd.cend());
+
+  //------
+  defaultValue = bv::bvnum(0x14, 16, efac);
+
+  e = array::constArray(bvSort, defaultValue);
+
+  kvList.clear();
+  populateBvNumArr(e, efac, kvList, 4, 12);
+  kvList.push_back(KeyValue(mkTerm<mpz_class>(8, efac), defaultValue,
+                            false)); // filler KeyValue
+  populateBvNumArr(e, efac, kvList, 12, 84);
+
+  HexDump hd2(e, 4); // value has a width of 4 bytes
+  llvm::errs() << hd2 << "\n";
+  outcome = boost::lexical_cast<std::string>(hd2);
+  outcome = std::regex_replace(outcome, std::regex(" *\n *"), "");
+
+  expected = "0004: 00 00 00 0c  |....|\
+0008: 00 00 00 14  |....|\
+000c: 00 00 00 54  |...T|";
+
+  CHECK(outcome == expected);
+  checkPairs(kvList.cbegin(), kvList.cend(), hd2.cbegin(), hd2.cend());
 }
 
 TEST_CASE("num.test") {
@@ -107,10 +130,10 @@ TEST_CASE("num.test") {
   std::string outcome = boost::lexical_cast<std::string>(hd);
   outcome = std::regex_replace(outcome, std::regex(" *\n *"), "");
 
-  std::string expected = "0: 10  |.|\
-4: 01  |.|\
-8: 05  |.|\
-c: 02  |.|";
+  std::string expected = "00: 00 00 00 10  |....|\
+04: 00 00 00 01  |....|\
+08: 00 00 00 05  |....|\
+0c: 00 00 00 02  |....|";
 
   CHECK(outcome == expected);
 
@@ -126,17 +149,16 @@ c: 02  |.|";
 
   llvm::errs() << "Expression: " << *e;
 
-  HexDump hd2(e, 2);
+  HexDump hd2(e, 4);
   llvm::errs() << hd2 << "\n";
 
   outcome = boost::lexical_cast<std::string>(hd2);
   outcome = std::regex_replace(outcome, std::regex(" *\n *"), "");
 
   expected = "100000: 00 11 11 11  |....|\
-100002: 12 34 56 78  |.4Vx|\
+100004: 12 34 56 78  |.4Vx|\
 *\
 10000c: 00 00 00 00  |....|\
-10000e: 12 34 56 78  |.4Vx|\
 100010: 00 33 44 55  |.3DU|";
 
   CHECK(outcome == expected);
@@ -152,9 +174,9 @@ TEST_CASE("finiteMap.test") {
   keys.push_back(mkTerm<mpz_class>(0x500002, efac));
 
   ExprVector values;
-  values.push_back(mkTerm<mpz_class>(0xffffaa, efac));
-  values.push_back(mkTerm<mpz_class>(0x12345, efac));
-  values.push_back(mkTerm<mpz_class>(0xaaaa1, efac));
+  values.push_back(mkTerm<mpz_class>(0xffaa, efac));
+  values.push_back(mkTerm<mpz_class>(0x2345, efac));
+  values.push_back(mkTerm<mpz_class>(0xaaa1, efac));
 
   Expr e = finite_map::constFiniteMap(keys, values);
   e = finite_map::set(e, mkTerm<mpz_class>(0x500010, efac),
@@ -172,19 +194,19 @@ TEST_CASE("finiteMap.test") {
   std::string outcome = boost::lexical_cast<std::string>(hd);
   outcome = std::regex_replace(outcome, std::regex(" *\n *"), "");
 
-  std::string expected = "500000: 01 23 45  |.#E|\
-500002: 0a aa a1  |...|\
-50000a: ff ff aa  |...|\
-500010: 00 00 0a  |...|";
+  std::string expected = "500000: 23 45  |#E|\
+500002: aa a1  |..|\
+50000a: ff aa  |..|\
+500010: 00 0a  |..|";
 
   CHECK(outcome == expected);
 
   kvList.push_back(KeyValue(mkTerm<mpz_class>(0x500000, efac),
-                            mkTerm<mpz_class>(0x12345, efac)));
+                            mkTerm<mpz_class>(0x2345, efac)));
   kvList.push_back(KeyValue(mkTerm<mpz_class>(0x500002, efac),
-                            mkTerm<mpz_class>(0xaaaa1, efac)));
+                            mkTerm<mpz_class>(0xaaa1, efac)));
   kvList.push_back(KeyValue(mkTerm<mpz_class>(0x50000a, efac),
-                            mkTerm<mpz_class>(0xffffaa, efac)));
+                            mkTerm<mpz_class>(0xffaa, efac)));
   kvList.push_back(KeyValue(mkTerm<mpz_class>(0x500010, efac),
                             mkTerm<mpz_class>(0xa, efac)));
 
@@ -210,58 +232,68 @@ TEST_CASE("ite.test") {
 
   std::vector<KeyValue> kvList;
   kvList.push_back(
-      KeyValue(mkTerm<mpz_class>(2, efac), mkTerm<mpz_class>(90, efac)));
+      KeyValue(mkTerm<mpz_class>(2, efac), mkTerm<mpz_class>(0x5a, efac)));
+  kvList.push_back(KeyValue(mkTerm<mpz_class>(3, efac),
+                            mkTerm<mpz_class>(0x01, efac), true));
   kvList.push_back(
-      KeyValue(mkTerm<mpz_class>(10, efac), mkTerm<mpz_class>(3, efac)));
+      KeyValue(mkTerm<mpz_class>(0xa, efac), mkTerm<mpz_class>(3, efac)));
 
   checkPairs(kvList.begin(), kvList.end(), hd.cbegin(), hd.cend());
 
   std::string outcome = boost::lexical_cast<std::string>(hd);
   outcome = std::regex_replace(outcome, std::regex(" *\n *"), "");
 
-  std::string expected = "2: 5a  |Z|\
-a: 03  |.|";
+  std::string expected = "02: 5a  |Z|\
+03: 01  |.|\
+*\
+0a: 03  |.|";
 
   CHECK(outcome == expected);
 
   //----------
 
   eq1 = mk<NEQ>(mkTerm<unsigned>(20, efac), a);
-  eq2 = mk<NEQ>(mkTerm<unsigned>(5, efac), a);
+  eq2 = mk<NEQ>(mkTerm<unsigned>(4, efac), a);
   Expr eq3 = mk<NEQ>(mkTerm<unsigned>(40, efac), a);
 
-  ite = mk<ITE>(eq1, a, mkTerm<mpz_class>(0x12345, efac));
+  ite = mk<ITE>(eq1, mkTerm<mpz_class>(0x0, efac),
+                mkTerm<mpz_class>(0x12345, efac));
   ite = mk<ITE>(eq2, ite, mkTerm<mpz_class>(0x114232, efac));
   ite = mk<ITE>(eq3, ite, mkTerm<mpz_class>(0xaa3fde, efac));
 
   llvm::errs() << "Expression: " << *ite;
   printIteTree(ite);
 
-  HexDump hd2(ite);
+  HexDump hd2(ite, 4);
   llvm::errs() << hd2;
 
   kvList.clear();
   kvList.push_back(
-      KeyValue(mkTerm<unsigned>(5, efac), mkTerm<mpz_class>(0x114232, efac)));
+      KeyValue(mkTerm<unsigned>(4, efac), mkTerm<mpz_class>(0x114232, efac)));
+  kvList.push_back(
+      KeyValue(mkTerm<unsigned>(8, efac), mkTerm<mpz_class>(0x0, efac), true));
   kvList.push_back(
       KeyValue(mkTerm<unsigned>(20, efac), mkTerm<mpz_class>(0x12345, efac)));
+  kvList.push_back(
+      KeyValue(mkTerm<unsigned>(24, efac), mkTerm<mpz_class>(0x0, efac), true));
   kvList.push_back(
       KeyValue(mkTerm<unsigned>(40, efac), mkTerm<mpz_class>(0xaa3fde, efac)));
 
   checkPairs(kvList.begin(), kvList.end(), hd2.cbegin(), hd2.cend());
 
-  // -------------------
+  // // -------------------
 
   eq1 = mk<NEQ>(mkTerm<mpz_class>(0x200000, efac), a);
   eq2 = mk<EQ>(mkTerm<mpz_class>(0x200004, efac), a);
 
-  ite = mk<ITE>(eq1, a, mkTerm<mpz_class>(0xaaaa1234, efac));
+  ite = mk<ITE>(eq1, mkTerm<mpz_class>(0x9, efac),
+                mkTerm<mpz_class>(0xaaaa1234, efac));
   ite = mk<ITE>(eq2, mkTerm<mpz_class>(0xbbbb1111, efac), ite);
 
   llvm::errs() << "Expression: " << *ite;
   printIteTree(ite);
 
-  HexDump hd3(ite);
+  HexDump hd3(ite, 4);
   llvm::errs() << hd3;
 
   kvList.clear();
@@ -271,6 +303,30 @@ a: 03  |.|";
                             mkTerm<mpz_class>(0xbbbb1111, efac)));
 
   checkPairs(kvList.begin(), kvList.end(), hd3.cbegin(), hd3.cend());
+
+  // //---------------
+
+  eq1 = mk<EQ>(bv::bvnum(0x45, 32, efac), a);
+  eq2 = mk<EQ>(mkTerm<mpz_class>(0x77, efac), a);
+
+  ite = mk<ITE>(eq1, bv::bvnum(0x6672, 32, efac), bv::bvnum(0x4444, 32, efac));
+  ite = mk<ITE>(eq2, mkTerm<mpz_class>(0xbbbb, efac), ite);
+
+  llvm::errs() << "Expression: " << *ite;
+  printIteTree(ite);
+
+  HexDump hd4(ite, 2);
+  llvm::errs() << hd4;
+
+  kvList.clear();
+  kvList.push_back(
+      KeyValue(mkTerm<mpz_class>(0x45, efac), mkTerm<mpz_class>(0x6672, efac)));
+  kvList.push_back(KeyValue(mkTerm<mpz_class>(0x47, efac),
+                            mkTerm<mpz_class>(0x4444, efac), true));
+  kvList.push_back(
+      KeyValue(mkTerm<mpz_class>(0x77, efac), mkTerm<mpz_class>(0xbbbb, efac)));
+
+  checkPairs(kvList.begin(), kvList.end(), hd4.cbegin(), hd4.cend());
 }
 
 TEST_CASE("lambda.test") {
@@ -287,7 +343,7 @@ TEST_CASE("lambda.test") {
   Expr eq1 = mk<EQ>(intBound0, mkTerm<mpz_class>(0, efac));
   Expr eq2 = mk<EQ>(mkTerm<mpz_class>(2, efac), intBound1);
 
-  Expr ite = mk<ITE>(eq1, bv::bvnum(0x345672, 32, efac), intBound1);
+  Expr ite = mk<ITE>(eq1, bv::bvnum(0x2, 32, efac), bv::bvnum(0xff, 32, efac));
   ite = mk<ITE>(eq2, bv::bvnum(0x4, 32, efac),
                 ite); // only b and d are actually reachable
 
@@ -296,12 +352,14 @@ TEST_CASE("lambda.test") {
   llvm::errs() << "Expression: " << *lambda << "\n";
   printIteTree(ite);
 
-  HexDump hd(ite);
+  HexDump hd(ite, 1);
   llvm::errs() << hd;
 
   std::vector<KeyValue> kvList;
   kvList.push_back(
-      KeyValue(mkTerm<mpz_class>(0, efac), mkTerm<mpz_class>(0x345672, efac)));
+      KeyValue(mkTerm<mpz_class>(0, efac), mkTerm<mpz_class>(0x2, efac)));
+  kvList.push_back(
+      KeyValue(mkTerm<mpz_class>(1, efac), mkTerm<mpz_class>(0xff, efac)));
   kvList.push_back(
       KeyValue(mkTerm<mpz_class>(2, efac), mkTerm<mpz_class>(4, efac)));
 
@@ -316,15 +374,15 @@ TEST_CASE("struct.test") {
   Expr bvSort = bv::bvsort(16, efac);
 
   std::vector<KeyValue> kvList;
-  Expr defaultValue = bv::bvnum(0x61626364, 32, efac);
+  Expr defaultValue = bv::bvnum(0x61, 32, efac);
   Expr e1 = array::constArray(bvSort, defaultValue);
   defaultValue = defaultValue->first(); // MPZ term
 
-  populateBvNumArr(e1, efac, kvList, 0xa00000, 0x99999, 32);
+  populateBvNumArr(e1, efac, kvList, 0xa00000, 0x99, 32);
   populateBvNumArr(e1, efac, kvList, 0xa00001, 116, 32);
   kvList.push_back(KeyValue(mkTerm<mpz_class>(0xa00002, efac), defaultValue,
                             false)); // filler KeyValue
-  populateBvNumArr(e1, efac, kvList, 0xa00003, 0x30313233, 32);
+  populateBvNumArr(e1, efac, kvList, 0xa00003, 0x30, 32);
 
   //-----------------
 
@@ -339,17 +397,17 @@ TEST_CASE("struct.test") {
   Expr eq2 = mk<EQ>(mkTerm<mpz_class>(2, efac), intBound0);
   Expr eq3 = mk<EQ>(intBound1, mkTerm<mpz_class>(1, efac));
 
-  Expr ite = mk<ITE>(eq1, mkTerm<mpz_class>(0x4365ffab, efac),
-                     mkTerm<mpz_class>(4, efac));
-  ite = mk<ITE>(eq2, mkTerm<mpz_class>(0x67a56b, efac), ite);
-  ite = mk<ITE>(eq3, mkTerm<mpz_class>(0x9088dd, efac), ite);
+  Expr ite =
+      mk<ITE>(eq1, mkTerm<mpz_class>(0x43, efac), mkTerm<mpz_class>(4, efac));
+  ite = mk<ITE>(eq2, mkTerm<mpz_class>(0x67, efac), ite);
+  ite = mk<ITE>(eq3, mkTerm<mpz_class>(0x90, efac), ite);
 
-  pairList2.push_back(KeyValue(mkTerm<mpz_class>(0, efac),
-                               mkTerm<mpz_class>(0x4365ffab, efac)));
   pairList2.push_back(
-      KeyValue(mkTerm<mpz_class>(1, efac), mkTerm<mpz_class>(0x9088dd, efac)));
+      KeyValue(mkTerm<mpz_class>(0, efac), mkTerm<mpz_class>(0x43, efac)));
   pairList2.push_back(
-      KeyValue(mkTerm<mpz_class>(2, efac), mkTerm<mpz_class>(0x67a56b, efac)));
+      KeyValue(mkTerm<mpz_class>(1, efac), mkTerm<mpz_class>(0x90, efac)));
+  pairList2.push_back(
+      KeyValue(mkTerm<mpz_class>(2, efac), mkTerm<mpz_class>(0x67, efac)));
 
   Expr e2 = mk<LAMBDA>(intConst, intConst, ite);
 
@@ -378,6 +436,7 @@ TEST_CASE("struct.test") {
 TEST_CASE("specialCases.test") {
   ExprFactory efac;
   Expr intConst = bind::intConst(mkTerm<std::string>("intConst", efac));
+  Expr intSort = sort::intTy(efac);
 
   Expr e = mk<AND>(intConst,
                    intConst); // doesn't have anything that is supported by the
@@ -407,7 +466,7 @@ TEST_CASE("specialCases.test") {
   kvList.push_back(KeyValue(mkTerm<std::string>("*", efac),
                             mkTerm<mpz_class>(0xa345ff22, efac)));
 
-  llvm::errs() << "Expression: " << *e;
+  llvm::errs() << "Expression: " << *e << "\n";
 
   HexDump hd2(e, 4);
 
@@ -432,7 +491,7 @@ TEST_CASE("specialCases.test") {
   e = finite_map::constFiniteMap(
       keys, values); // only has a const finite map (not wrapped in SET)
 
-  llvm::errs() << "Expression: " << *e;
+  llvm::errs() << "Expression: " << *e << "\n";
   HexDump hd3(e, 2);
 
   llvm::errs() << hd3;
@@ -440,11 +499,29 @@ TEST_CASE("specialCases.test") {
   outcome = boost::lexical_cast<std::string>(hd3);
   outcome = std::regex_replace(outcome, std::regex(" *\n *"), "");
 
-  expected = "0: 12  |.|";
+  expected = "00: 00 12  |..|";
+
+  CHECK(outcome == expected);
 
   kvList.clear();
   kvList.push_back(
       KeyValue(mkTerm<mpz_class>(0, efac), mkTerm<mpz_class>(0x12, efac)));
 
   checkPairs(kvList.cbegin(), kvList.cend(), hd3.cbegin(), hd3.cend());
+
+  //----------
+
+  e = array::constArray(intSort, bv::bvnum(0xa345ff22, 32, efac));
+
+  llvm::errs() << "Expression: " << *e << "\n";
+  HexDump hd4(e, 1); // actual width is larger than desired width
+
+  llvm::errs() << hd4;
+
+  outcome = boost::lexical_cast<std::string>(hd4);
+  outcome = std::regex_replace(outcome, std::regex(" *\n *"), "");
+
+  expected = "*: a3 45 ff 22  |.E.\"|";
+
+  CHECK(outcome == expected);
 }


### PR DESCRIPTION
Made width based on passed number of bytes, added default value to ite,
and recognize bvnums as numerical (to prevent the assertion failure that was happening)