### PR TITLE
fix(sea): harness validation in exe-cex

### DIFF
--- a/py/sea/commands.py
+++ b/py/sea/commands.py
@@ -761,7 +761,7 @@ class ExecHarness(sea.LimitedCmd):
         self.harnessCmd = sea.ExtCmd (eharness)
         if args.cpu is None: args.cpu = 10
 
-        retval = self.harnessCmd.run (args, [eharness], stdout=subprocess.PIPE)
+        retval = self.harnessCmd.run (args, [eharness], encoding='utf-8', errors='replace', stdout=subprocess.PIPE)
 
         if "[sea] __VERIFIER_error was executed" in self.harnessCmd.stdout:
             print ("__VERIFIER_error was executed")


### PR DESCRIPTION
The code for exe-cex is for Python 2, and assumes that pipes from stdout yield strings. In Python3, we get byte arrays instead. This commit adds two arguments to the subprocess which (1) decodes each byte array as a utf-8 string and (2) replaces invalid characters in said byte array.