### PR TITLE
refactor(opsem): encapsulate solver in bv2 ctx

### DIFF
--- a/lib/seahorn/BvOpSem2.cc
+++ b/lib/seahorn/BvOpSem2.cc
@@ -2,6 +2,8 @@
 #include "BvOpSem2RawMemMgr.hh"
 
 #include "llvm/CodeGen/IntrinsicLowering.h"
+#include "llvm/IR/DebugInfo.h"
+#include "llvm/IR/DebugLoc.h"
 #include "llvm/IR/GetElementPtrTypeIterator.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Format.h"
@@ -579,59 +581,91 @@ public:
     setValue(*CS.getInstruction(), res);
   }
 
-  void visitAssertIf(CallSite CS) {
-    ScopedStats __stats__("opsem.assert.if");
-    // NOTE: assert.if.not is not supported
+  void visitAssert(Expr ante, Expr conseq, const DebugLoc &dloc) {
+    ScopedStats __stats__("opsem.assert");
     if (VacuityCheckOpt == VacCheckOptions::NONE) {
       return;
     }
-    auto I = CS.getInstruction();
-    Expr ante = lookup(*CS.getArgument(0));
     Stats::resume("opsem.vacuity");
+    // The solving is done incrementally. We only
+    // reset the solver once per assert instruction.
+    // We then add expressions incrementally.
+    // This works because this check never needs to
+    // remove an expression from the solver.
     tribool anteRes = solveWithConstraints(ante);
     Stats::stop("opsem.vacuity");
     // if ante is unsat then report false and bail out
     if (!anteRes) {
-      LOG("opsem", ERR << "Antecedent is unsat/unknown: " << *I << "\n");
+      LOG(
+          "opsem",
+          if (dloc) {
+            ERR << "Antecedent is unsat/unknown: "
+                << "[" << (*dloc).getFilename() << ":" << dloc.getLine() << "]";
+          } else { ERR << "Antecedent is unsat/unknown"; });
       return; // return early since conseq is unreachable
+    } else {
+      LOG(
+          "opsem",
+          if (dloc) {
+            INFO << "Vacuity passed: "
+                 << "[" << (*dloc).getFilename() << ":" << dloc.getLine()
+                 << "]";
+          } else { INFO << "Vacuity passed"; });
     }
-    LOG("opsem", INFO << "Vacuity passed: " << *I << "\n";);
     if (VacuityCheckOpt == VacCheckOptions::ANTE) {
       return; // don't need to process conseq
     }
-    Expr conseq = lookup(*CS.getArgument(1));
-    Expr e = boolop::land(ante, boolop::lneg(conseq));
+    Expr e = boolop::lneg(conseq);
     Stats::resume("opsem.incbmc");
-    tribool conseqRes = solveWithConstraints(e);
+    tribool conseqRes = solveWithConstraints(e, true /* incremental */);
     Stats::stop("opsem.incbmc");
     if (conseqRes) {
-      LOG("opsem", ERR << "Consequent is sat/unknown: " << *I << "\n");
+      LOG(
+          "opsem",
+          if (dloc) {
+            ERR << "Consequent is sat: "
+                << "[" << (*dloc).getFilename() << ":" << dloc.getLine() << "]";
+          } else { ERR << "Consequent is sat"; });
     } else {
-      LOG("opsem", INFO << "Assertion passed: " << *I << "\n";);
+      LOG(
+          "opsem",
+          if (dloc) {
+            INFO << "Assertion passed: "
+                 << "[" << (*dloc).getFilename() << ":" << dloc.getLine()
+                 << "]";
+          } else { INFO << "Assertion passed"; });
     }
   }
 
-  tribool solveWithConstraints(const Expr &solveFor) const {
-    // OPTIMIZE: Solver need not be reset
-    m_ctx.solver().reset();
-    ExprVector conds(m_ctx.side());
-    conds.push_back(m_ctx.getPathCond());
-    for (auto e : conds) {
-      m_ctx.solver().assertExpr(e);
-    }
-    m_ctx.solver().assertExpr(solveFor);
+  void visitAssertIf(CallSite CS) {
+    // NOTE: sea.assert.if.not is not supported
+    auto I = CS.getInstruction();
+    Expr ante = lookup(*CS.getArgument(0));
+    Expr conseq = lookup(*CS.getArgument(1));
+    const llvm::DebugLoc &dloc = I->getDebugLoc();
+    visitAssert(ante, conseq, dloc);
+  }
 
-    boost::tribool res = m_ctx.solver().solve();
-    return res;
+  boost::tribool solveWithConstraints(const Expr &solveFor,
+                                      bool incremental = false) const {
+    // if incremental is true then use existing constraints in solver
+    // else reset solver
+    if (!incremental) {
+      m_ctx.resetSolver();
+    }
+    for (auto e : m_ctx.side()) {
+      m_ctx.addToSolver(e);
+    }
+    m_ctx.addToSolver(m_ctx.getPathCond());
+    m_ctx.addToSolver(solveFor);
+
+    return m_ctx.solve();
   }
 
   void visitAssertStmt(CallSite CS) {
-    // This is called when UnifyAssumes does not replace
-    // verifier.assert with sea.assert.if e.g.
-    // when no assumes is found, as a workaround do the following
-    // TODO: add logic to delegate to sea.assert.if(true, conseq)
-    LOG("opsem", INFO << "verifier.assert{.not} stmts ignored: "
-                      << *CS.getInstruction());
+    Expr conseq = lookup(*CS.getArgument(0));
+    const DebugLoc &dloc = CS.getInstruction()->getDebugLoc();
+    visitAssert(m_ctx.alu().getTrue(), conseq, dloc);
   }
 
   void visitFatPointerInstr(CallSite CS) {
@@ -2254,6 +2288,22 @@ std::pair<char *, unsigned>
 Bv2OpSemContext::getGlobalVariableInitValue(const llvm::GlobalVariable &gv) {
   return m_memManager->getGlobalVariableInitValue(gv);
 }
+
+void Bv2OpSemContext::resetSolver() {
+  m_z3_solver->reset();
+  m_addedToSolver.clear();
+}
+
+void Bv2OpSemContext::addToSolver(const Expr e) {
+  if (!m_addedToSolver.count(e)) {
+    // if not found, add to solver and keep track
+    m_z3_solver->assertExpr(e);
+    m_addedToSolver.insert(e);
+  }
+}
+
+boost::tribool Bv2OpSemContext::solve() { return m_z3_solver->solve(); }
+
 } // namespace details
 
 Bv2OpSem::Bv2OpSem(ExprFactory &efac, Pass &pass, const DataLayout &dl,

--- a/lib/seahorn/BvOpSem2Context.hh
+++ b/lib/seahorn/BvOpSem2Context.hh
@@ -7,6 +7,7 @@
 
 #include "seahorn/Expr/ExprLlvm.hh"
 #include "seahorn/Expr/Smt/EZ3.hh"
+#include <unordered_set>
 
 namespace seahorn {
 namespace details {
@@ -102,6 +103,7 @@ private:
   std::shared_ptr<ZSolver<EZ3>> m_z3_solver;
 
   bool m_shouldSimplify = false;
+  std::unordered_set<Expr> m_addedToSolver;
 
 public:
   /// \brief Create a new context with given semantics, values, and side
@@ -144,8 +146,6 @@ public:
       return m_parent->alu();
     llvm_unreachable(nullptr);
   }
-
-  ZSolver<EZ3> &solver() const { return *m_z3_solver; }
 
   /// \brief Push parameter on a stack for a function call
   void pushParameter(Expr v) { m_fparams.push_back(v); }
@@ -284,6 +284,10 @@ public:
   OpSemContextPtr fork(SymStore &values, ExprVector &side) {
     return OpSemContextPtr(new Bv2OpSemContext(values, side, *this));
   }
+
+  void resetSolver();
+  void addToSolver(const Expr e);
+  boost::tribool solve();
 
 private:
   static Bv2OpSemContext &ctx(OpSemContext &ctx) {

--- a/test/opsem2/lit.cfg
+++ b/test/opsem2/lit.cfg
@@ -70,6 +70,7 @@ seasmt = [seahorn_cmd, '--horn-bmc-engine=mono',
           '--keep-shadows=true' ]
 sea = [sea_cmd, 'bpf', '--horn-bmc-engine=mono',
        '--horn-bmc', '--horn-bv2=true', '--log=opsem',
+       '--horn-bv2-vacuity-check=all'
       ]
 config.substitutions.append(('%seabmc', ' '.join(seabmc)))
 config.substitutions.append(('%seasmt', ' '.join(seasmt)))

--- a/test/opsem2/verifier_assert_sat.02.c
+++ b/test/opsem2/verifier_assert_sat.02.c
@@ -9,7 +9,10 @@ extern int nd_int(void);
 
 int main(int argc, char **argv) {
   int a = nd_int();
-  __VERIFIER_assert(a == 99);
-  sassert(a == 99);
+  __VERIFIER_assume(a == 10);
+  if (a > 0) {
+    __VERIFIER_assert(a == 99);
+    sassert(a == 99);
+  }
   return 0;
 }


### PR DESCRIPTION
1. keep track of assertions during single vacuity and incremental check
2. add printing of debug location if available