### PR TITLE
fix(seaopt): lower umul instrinsics from later passes

### DIFF
--- a/tools/seahorn/seahorn.cpp
+++ b/tools/seahorn/seahorn.cpp
@@ -350,6 +350,11 @@ int main(int argc, char **argv) {
     pass_manager.add(seahorn::createNondetInitPass());
   pass_manager.add(seahorn::createSeaDsaShadowMemPass());
 
+  // Preceding passes may introduce overflow intrinsics. This is undesirable if
+  // we are not in BMC mode.
+  if (!Bmc)
+    pass_manager.add(seahorn::createLowerArithWithOverflowIntrinsicsPass());
+
   pass_manager.add(new seahorn::RemoveUnreachableBlocksPass());
   pass_manager.add(seahorn::createStripLifetimePass());
   pass_manager.add(seahorn::createDeadNondetElimPass());


### PR DESCRIPTION
LLVM will replace overflow checks with the overflow flag from @llvm.umul. This comes after the current `LowerArithWithOverflowIntrinsics` pass. These intrinsics are undesirable outside of BMC mode. This commit resolves the issue by apply the pass a second time, when run outside of BMC mode.