### PR TITLE
Add __seahorn_get_value_*() implementation for missing ctype i1

### DIFF
--- a/lib/Transforms/Instrumentation/KleeInternalize.cc
+++ b/lib/Transforms/Instrumentation/KleeInternalize.cc
@@ -192,6 +192,7 @@ public:
     m_externalNames.insert("__VERIFIER_assume");
     m_externalNames.insert("__VERIFIER_error");
 
+    m_externalNames.insert("__seahorn_get_value_i1");
     m_externalNames.insert("__seahorn_get_value_i8");
     m_externalNames.insert("__seahorn_get_value_i16");
     m_externalNames.insert("__seahorn_get_value_i32");

--- a/sea-rt/seahorn.cpp
+++ b/sea-rt/seahorn.cpp
@@ -29,6 +29,16 @@ void __VERIFIER_assume(bool x) {
   assert(x);
 }
 
+bool __seahorn_get_value_i1(int ctr, bool *g_arr, int g_arr_sz) {
+  sealog("[sea] __seahorn_get_value_i1(%d, %d)\n", ctr, g_arr_sz);
+  if (ctr >= g_arr_sz) {
+    sealog("\tout-of-bounds index\n");
+    return 0;
+  } else {
+    return g_arr[ctr];
+  }
+}
+
 #define get_value_helper(ctype, llvmtype)                               \
   ctype __seahorn_get_value_ ## llvmtype (int ctr, ctype *g_arr, int g_arr_sz) { \
     sealog("[sea] __seahorn_get_value_(" #llvmtype ", %d, %d)\n", ctr, g_arr_sz); \


### PR DESCRIPTION
`uint1_t` is not defined in C, so `get_value_int(1)` will not be properly expanded like with other integer types; need to force define `__seahorn_get_value_i1` so that nondet boolean functions will behave as expected in executable counter examples.