### PR TITLE
chore(bmc): remove commented code to reduce confusion

### DIFF
--- a/lib/seahorn/Bmc.cc
+++ b/lib/seahorn/Bmc.cc
@@ -30,10 +30,6 @@ BmcEngine::BmcEngine(OperationalSemantics &sem, EZ3 &zctx)
   z3n_set_param(":model.compact", false);
   if (BmcSmtTactic != "default")
     z3n_set_param(":tactic.default_tactic", BmcSmtTactic.c_str());
-
-  // ZParams<EZ3> params(zctx);
-  // params.set("tactic.default_tactic", "smtfd");
-  // m_smt_solver.set(params);
 }
 
 void BmcEngine::addCutPoint(const CutPoint &cp) {

--- a/lib/seahorn/BvOpSem2.cc
+++ b/lib/seahorn/BvOpSem2.cc
@@ -581,9 +581,7 @@ public:
     setValue(*CS.getInstruction(), res);
   }
 
-  void visitBranchSentinel(CallSite CS) {
-    // do nothing
-  }
+  void visitBranchSentinel(CallSite CS) {}
 
   void visitIsDereferenceable(CallSite CS) {
     Expr ptr = lookup(*CS.getArgument(0));


### PR DESCRIPTION
The right way to specify a tactic is using the cmd line flag --horn-bmc-tactic