### PR TITLE
feat(bmc): enable hex dump in solver interface

### DIFF
--- a/lib/seahorn/Bmc.cc
+++ b/lib/seahorn/Bmc.cc
@@ -14,11 +14,13 @@
 namespace seahorn {
 std::string BmcSmtLogic;
 std::string BmcSmtTactic;
+bool DumpHex;
 } // namespace seahorn
 
-static llvm::cl::opt<bool>
-    DumpHex("horn-bmc-hexdump",
-            llvm::cl::desc("Dump memory state using hexdump"), cl::init(false));
+static llvm::cl::opt<bool, true>
+    XDumpHex("horn-bmc-hexdump",
+             llvm::cl::desc("Dump memory state using hexdump"),
+             llvm::cl::location(seahorn::DumpHex), cl::init(false));
 static llvm::cl::opt<std::string, true>
     XBmcSmtTactic("horn-bmc-tactic", llvm::cl::desc("Z3 tactic to use for BMC"),
                   llvm::cl::location(seahorn::BmcSmtTactic),

--- a/lib/seahorn/SolverBmc.cc
+++ b/lib/seahorn/SolverBmc.cc
@@ -13,6 +13,7 @@
 
 namespace seahorn {
 /* use options from Bmc.cc*/
+extern bool DumpHex;
 extern std::string BmcSmtLogic;
 extern std::string BmcSmtTactic;
 } // namespace seahorn
@@ -291,7 +292,19 @@ template <> raw_ostream &SolverBmcTrace::print(raw_ostream &out) {
 
       if (out.has_colors())
         out.changeColor(raw_ostream::RED);
-      out << "  %" << I.getName() << " " << *v;
+      if (DumpHex && shadow_mem) {
+        using HD = expr::hexDump::HexDump;
+        using SHD = expr::hexDump::StructHexDump;
+        out << "  %" << I.getName() << "\n";
+
+        if (isOp<MK_STRUCT>(v)) {
+          out << SHD(v);
+        } else {
+          out << HD(v);
+        }
+
+      } else
+        out << "  %" << I.getName() << " " << *v;
       const DebugLoc &dloc = I.getDebugLoc();
       if (dloc) {
         if (out.has_colors())


### PR DESCRIPTION
Re-enable `horn-bmc-hexdump` for solver interface based bmc engine.