### PR TITLE
refactor(opsem): use compile time compute to reduce duplicate code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,8 +247,9 @@ if(NOT LLVM_FOUND)
   return()
 endif()
 
-set (Boost_USE_STATIC_LIBS ${SEAHORN_STATIC_EXE})
-find_package (Boost 1.65 REQUIRED)
+# boost version >= 1.71 because of https://github.com/boostorg/hana/issues/446
+set(Boost_USE_STATIC_LIBS ${SEAHORN_STATIC_EXE})
+find_package(Boost 1.71 REQUIRED)
 if (Boost_FOUND)
   include_directories (${Boost_INCLUDE_DIRS})
   if(NOT LLVM_ENABLE_EH)

--- a/lib/seahorn/BvOpSem2.cc
+++ b/lib/seahorn/BvOpSem2.cc
@@ -641,21 +641,14 @@ public:
 
   void visitIsModified(CallSite CS) {
     if (!m_ctx.getMemReadRegister()) {
-      LOG("opsem", ERR << "No read register found - check if corresponding "
+      LOG("opsem", ERR << "No read register found - check if corresponding"
                           "shadow instruction is present.");
       return;
     }
-    // TODO: move logic to MemManager
     Expr ptr = lookup(*CS.getArgument(0));
     auto memIn = m_ctx.read(m_ctx.getMemReadRegister());
     OpSemMemManager &memManager = m_ctx.mem();
-    // TODO: remove alignment formal arg since it is set by Metadatamemory
-    // internally
-    auto val =
-        memManager.getMetaData(ptr, memIn, 1, 0 /* alignment don't care */);
-    auto sentinel = m_ctx.alu().si(1, memManager.getMetaDataMemWordSzInBits());
-    auto res = m_ctx.alu().doEq(val, sentinel,
-                                memManager.getMetaDataMemWordSzInBits());
+    auto res = memManager.isModified(ptr, memIn);
     setValue(*CS.getInstruction(), res);
     m_ctx.setMemReadRegister(Expr());
   }

--- a/lib/seahorn/BvOpSem2ExtraWideMemMgr.hh
+++ b/lib/seahorn/BvOpSem2ExtraWideMemMgr.hh
@@ -14,6 +14,7 @@
 
 namespace seahorn {
 namespace details {
+
 template <class T> class ExtraWideMemManager : public OpSemMemManagerBase {
 
   /// \brief Knows the memory representation and how to access it
@@ -49,6 +50,7 @@ template <class T> class ExtraWideMemManager : public OpSemMemManagerBase {
   RawMemManager m_size;
 
 public:
+  using TrackingTag = typename T::TrackingTag;
   using RawPtrTy = typename T::PtrTy;
   using RawMemValTy = typename T::MemValTy;
   using RawPtrSortTy = typename T::PtrSortTy;
@@ -278,19 +280,22 @@ public:
 
   Expr isDereferenceable(PtrTy p, Expr byteSz);
 
-  RawMemValTy setModified(ExtraWideMemManager::PtrTy ptr,
-                          ExtraWideMemManager::MemValTy mem, uint64_t align);
+  typename ExtraWideMemManager<T>::RawMemValTy
+  setModified(ExtraWideMemManager::PtrTy ptr,
+              ExtraWideMemManager::MemValTy mem);
 
   Expr isModified(ExtraWideMemManager::PtrTy ptr,
-                  ExtraWideMemManager::MemValTy mem, uint64_t align);
+                  ExtraWideMemManager::MemValTy mem);
 
-  MemValTy memsetMetaData(PtrTy ptr, unsigned int len, MemValTy memIn,
-                          uint32_t align, unsigned int val);
+  typename ExtraWideMemManager<T>::MemValTy
+  memsetMetaData(ExtraWideMemManager::PtrTy ptr, unsigned int len,
+                 ExtraWideMemManager::MemValTy memIn, unsigned int val);
 
-  MemValTy memsetMetaData(PtrTy ptr, Expr len, MemValTy memIn, uint32_t align,
-                          unsigned int val);
-  Expr getMetaData(PtrTy ptr, MemValTy memIn, unsigned int byteSz,
-                   uint32_t align);
+  typename ExtraWideMemManager<T>::MemValTy
+  memsetMetaData(ExtraWideMemManager::PtrTy ptr, Expr len,
+                 ExtraWideMemManager::MemValTy memIn, unsigned int val);
+
+  Expr getMetaData(PtrTy ptr, MemValTy memIn, unsigned int byteSz);
 
   unsigned int getMetaDataMemWordSzInBits();
 

--- a/lib/seahorn/BvOpSem2FatMemMgr.cc
+++ b/lib/seahorn/BvOpSem2FatMemMgr.cc
@@ -571,23 +571,6 @@ public:
     LOG("opsem", WARN << "isDereferenceable() not implemented!\n");
     return m_ctx.alu().getFalse();
   }
-
-  Expr memsetMetaData(Expr ptr, unsigned int len, Expr memIn, uint32_t align,
-                      unsigned int val) {
-    LOG("opsem", ERR << "memsetMetaData() not implemented");
-    return Expr();
-  }
-
-  Expr memsetMetaData(Expr ptr, Expr len, Expr memIn, uint32_t align,
-                      unsigned int val) {
-    LOG("opsem", ERR << "memsetMetaData() not implemented");
-    return Expr();
-  }
-
-  unsigned int getMetaDataMemWordSzInBits() {
-    LOG("opsem", ERR << "getMetaDataMemWordSzInBits() not implemented");
-    return 0;
-  }
 };
 
 FatMemManager::FatMemManager(Bv2OpSem &sem, Bv2OpSemContext &ctx,

--- a/lib/seahorn/BvOpSem2MemManagerMixin.hh
+++ b/lib/seahorn/BvOpSem2MemManagerMixin.hh
@@ -319,28 +319,7 @@ public:
     return base().isDereferenceable(BasePtrTy(std::move(p)), byteSz);
   }
 
-  Expr memsetMetaData(PtrTy ptr, unsigned int len, MemValTy memIn,
-                      uint32_t align, unsigned int val) {
-    LOG("opsem", ERR << "memsetMetaData() not implemented");
-    return Expr();
-  }
-
-  Expr memsetMetaData(PtrTy ptr, Expr len, MemValTy memIn, uint32_t align,
-                      unsigned int val) {
-    LOG("opsem", ERR << "memsetMetaData() not implemented");
-    return Expr();
-  }
-
-  Expr getMetaData(PtrTy ptr, MemValTy memIn, unsigned int byteSz,
-                   uint32_t align) {
-    LOG("opsem", ERR << "getMetaData() not implemented");
-    return Expr();
-  }
-
-  unsigned int getMetaDataMemWordSzInBits() {
-    LOG("opsem", ERR << "getMetaDataMemWordSzInBits() not implemented");
-    return 0;
-  }
+  Expr isModified(PtrTy p, MemValTy Mem) { return Expr(); }
 };
 } // namespace details
 } // namespace seahorn

--- a/lib/seahorn/BvOpSem2RawMemMgr.cc
+++ b/lib/seahorn/BvOpSem2RawMemMgr.cc
@@ -678,21 +678,8 @@ Expr RawMemManager::isDereferenceable(PtrTy p, Expr byteSz) {
   return Expr();
 }
 
-Expr RawMemManager::memsetMetaData(Expr ptr, unsigned int len, Expr memIn,
-                                   uint32_t align, unsigned int val) {
-  LOG("opsem", ERR << "memsetMetaData() not implemented");
-  return Expr();
-}
-
-Expr RawMemManager::memsetMetaData(Expr ptr, Expr len, Expr memIn,
-                                   uint32_t align, unsigned int val) {
-  LOG("opsem", ERR << "memsetMetaData() not implemented");
-  return Expr();
-}
-
-Expr RawMemManager::getMetaData(PtrTy ptr, MemValTy memIn, unsigned int byteSz,
-                                uint32_t align) {
-  LOG("opsem", ERR << "getMetaData() not implemented");
+Expr RawMemManager::isModified(PtrTy p, MemValTy mem) {
+  LOG("opsem", ERR << "()isModified() not implemented");
   return Expr();
 }
 
@@ -753,9 +740,5 @@ Expr RawMemManager::zeroedMemory() const {
 }
 OpSemAllocator &RawMemManager::getMAllocator() const { return *m_allocator; }
 bool RawMemManager::ignoreAlignment() const { return m_ignoreAlignment; }
-unsigned int RawMemManager::getMetaDataMemWordSzInBits() {
-  LOG("opsem", ERR << "getMetaDataMemWordSzInBits() not implemented");
-  return 0;
-}
 } // namespace details
 } // namespace seahorn

--- a/lib/seahorn/BvOpSem2RawMemMgr.hh
+++ b/lib/seahorn/BvOpSem2RawMemMgr.hh
@@ -52,6 +52,8 @@ public:
   using PtrSortTy = OpSemMemManager::PtrSortTy;
   using MemSortTy = OpSemMemManager::MemSortTy;
   using MemRegTy = OpSemMemManager::MemRegTy;
+  // setting TrackingTag to int disqualifies this class as having tracking
+  using TrackingTag = int;
 
   PtrTy ptrSort() const override { return m_ctx.alu().intTy(ptrSzInBits()); }
 
@@ -277,15 +279,7 @@ public:
 
   Expr isDereferenceable(PtrTy p, Expr byteSz) override;
 
-  Expr memsetMetaData(PtrTy ptr, unsigned int len, MemValTy memIn,
-                      uint32_t align, unsigned int val) override;
-
-  Expr memsetMetaData(PtrTy ptr, Expr len, MemValTy memIn, uint32_t align,
-                      unsigned int val) override;
-
-  Expr getMetaData(PtrTy ptr, MemValTy memIn, unsigned int byteSz,
-                   uint32_t align) override;
-  unsigned int getMetaDataMemWordSzInBits() override;
+  Expr isModified(PtrTy p, MemValTy mem) override;
 };
 } // namespace details
 } // namespace seahorn

--- a/lib/seahorn/BvOpSem2TrackingRawMemMgr.cc
+++ b/lib/seahorn/BvOpSem2TrackingRawMemMgr.cc
@@ -206,28 +206,28 @@ Expr TrackingRawMemManager::loadIntFromMem(TrackingRawMemManager::PtrTy ptr,
 }
 TrackingRawMemManager::MemValTy
 TrackingRawMemManager::memsetMetaData(PtrTy ptr, Expr len, MemValTy memIn,
-                                      uint32_t align, unsigned int val) {
-  // make sure we can fit the supplied value in metadata memory slot
-  assert(llvm::Log2_64(val) + 1 <= g_MetadataBitWidth);
-  return MemValTy(memIn.getRaw(),
-                  m_metadata.MemSet(ptr,
-                                    m_ctx.alu().si(val, g_MetadataBitWidth),
-                                    len, memIn.getMetadata(), align));
-}
-TrackingRawMemManager::MemValTy
-TrackingRawMemManager::memsetMetaData(PtrTy ptr, unsigned int len,
-                                      MemValTy memIn, uint32_t align,
                                       unsigned int val) {
   // make sure we can fit the supplied value in metadata memory slot
   assert(llvm::Log2_64(val) + 1 <= g_MetadataBitWidth);
-  return MemValTy(memIn.getRaw(),
-                  m_metadata.MemSet(ptr,
-                                    m_ctx.alu().si(val, g_MetadataBitWidth),
-                                    len, memIn.getMetadata(), align));
+  return MemValTy(
+      memIn.getRaw(),
+      m_metadata.MemSet(ptr, m_ctx.alu().si(val, g_MetadataBitWidth), len,
+                        memIn.getMetadata(), m_metadata.wordSzInBytes()));
+}
+TrackingRawMemManager::MemValTy
+TrackingRawMemManager::memsetMetaData(PtrTy ptr, unsigned int len,
+                                      MemValTy memIn, unsigned int val) {
+  // make sure we can fit the supplied value in metadata memory slot
+  assert(llvm::Log2_64(val) + 1 <= g_MetadataBitWidth);
+  return MemValTy(
+      memIn.getRaw(),
+      m_metadata.MemSet(ptr, m_ctx.alu().si(val, g_MetadataBitWidth), len,
+                        memIn.getMetadata(), m_metadata.wordSzInBytes()));
 }
 Expr TrackingRawMemManager::getMetaData(PtrTy ptr, MemValTy memIn,
-                                        unsigned int byteSz, uint32_t align) {
-  return m_metadata.loadIntFromMem(ptr, memIn.getMetadata(), byteSz, align);
+                                        unsigned int byteSz) {
+  return m_metadata.loadIntFromMem(ptr, memIn.getMetadata(), byteSz,
+                                   0 /* TODO: fix */);
 }
 TrackingRawMemManager::PtrTy
 TrackingRawMemManager::ptrAdd(TrackingRawMemManager::PtrTy ptr,
@@ -318,6 +318,10 @@ TrackingRawMemManager::mkStackPtr(unsigned int offset) {
 }
 unsigned int TrackingRawMemManager::getMetaDataMemWordSzInBits() {
   return m_metadata.wordSzInBits();
+}
+Expr TrackingRawMemManager::isModified(PtrTy p, MemValTy Mem) {
+  LOG("opsem", WARN << "isModified() not implemented!\n");
+  return Expr();
 }
 
 } // namespace details

--- a/lib/seahorn/BvOpSem2TrackingRawMemMgr.hh
+++ b/lib/seahorn/BvOpSem2TrackingRawMemMgr.hh
@@ -30,6 +30,8 @@ private:
   static const unsigned int g_num_slots = 2;
 
 public:
+  // This memory manager supports tracking
+  using TrackingTag = MemoryFeatures::Tracking_tag;
   using PtrTy = OpSemMemManager::PtrTy;
   using PtrSortTy = OpSemMemManager::PtrSortTy;
   using MemRegTy = OpSemMemManager::MemRegTy;
@@ -146,15 +148,18 @@ public:
 
   PtrTy ptrAdd(PtrTy ptr, Expr offset) const;
 
-  MemValTy memsetMetaData(PtrTy ptr, unsigned int len, MemValTy memIn,
-                          uint32_t align, unsigned int val);
+  TrackingRawMemManager::MemValTy
+  memsetMetaData(PtrTy ptr, unsigned int len, MemValTy memIn, unsigned int val);
 
-  MemValTy memsetMetaData(PtrTy ptr, Expr len, MemValTy memIn, uint32_t align,
-                          unsigned int val);
+  TrackingRawMemManager::MemValTy
+  memsetMetaData(PtrTy ptr, Expr len, MemValTy memIn, unsigned int val);
 
-  Expr getMetaData(PtrTy ptr, MemValTy memIn, unsigned int byteSz,
-                   uint32_t align);
+  Expr getMetaData(PtrTy ptr, MemValTy memIn, unsigned int byteSz);
 
+  /// \brief get word size (in bits) of Metadata memory, associated with a
+  /// Tracking memory manager.
+  // TODO: This should be replaced by a general way to query memory properties
+  // from a memory manager.
   unsigned int getMetaDataMemWordSzInBits();
 
   Expr loadIntFromMem(PtrTy ptr, MemValTy mem, unsigned int byteSz,
@@ -175,9 +180,15 @@ public:
   MemValTy storeValueToMem(Expr _val, PtrTy ptr, MemValTy memIn, const Type &ty,
                            uint32_t align);
 
+  /// \brief memset metadata memory associated with a Tracking Memory
+  /// manager and return resulting memory. The 'raw' portion of memory is
+  /// untouched.
   MemValTy MemSet(PtrTy ptr, Expr _val, unsigned int len, MemValTy mem,
                   uint32_t align);
 
+  /// \brief memset metadata memory associated with a Tracking Memory
+  /// manager and return resulting memory. The 'raw' portion of memory is
+  /// untouched.
   MemValTy MemSet(PtrTy ptr, Expr _val, Expr len, MemValTy mem, uint32_t align);
 
   MemValTy MemCpy(PtrTy dPtr, PtrTy sPtr, unsigned int len,
@@ -209,6 +220,8 @@ public:
   Expr isDereferenceable(PtrTy p, Expr byteSz);
 
   PtrTy getAddressable(PtrTy p) const;
+
+  Expr isModified(PtrTy p, MemValTy Mem);
 };
 
 } // namespace details

--- a/lib/seahorn/BvOpSem2WideMemManagerMixin.hh
+++ b/lib/seahorn/BvOpSem2WideMemManagerMixin.hh
@@ -13,6 +13,7 @@ template <typename BaseT>
 class OpSemWideMemManagerMixin : public BaseT, public OpSemMemManager {
 
 public:
+  using TrackingTag = typename BaseT::TrackingTag;
   using Base = BaseT;
   using PtrTy = Expr;
   using MemRegTy = Expr;
@@ -174,29 +175,18 @@ public:
 
   Expr isDereferenceable(PtrTy p, Expr byteSz) override;
 
-  MemValTy memsetMetaData(PtrTy ptr, unsigned int len, MemValTy memIn,
-                          uint32_t align, unsigned int val) override;
+  Expr isModified(PtrTy p, MemValTy mem) override;
 
-  MemValTy memsetMetaData(PtrTy ptr, Expr len, MemValTy memIn, uint32_t align,
-                          unsigned int val) override;
+  typename OpSemWideMemManagerMixin<BaseT>::MemValTy
+  memsetMetaData(PtrTy ptr, unsigned int len, MemValTy memIn, unsigned int val);
 
-  Expr getMetaData(PtrTy ptr, PtrTy memIn, unsigned int byteSz,
-                   uint32_t align) override;
-  unsigned int getMetaDataMemWordSzInBits() override;
+  typename OpSemWideMemManagerMixin<BaseT>::MemValTy
+  memsetMetaData(PtrTy ptr, Expr len, MemValTy memIn, unsigned int val);
+
+  Expr getMetaData(PtrTy ptr, PtrTy memIn, unsigned int byteSz);
+
+  unsigned int getMetaDataMemWordSzInBits();
 };
-
-// 'HasTracking' is a solution for conditionally compiling in memory tracking
-// code only when needed. It utilizes C++ metaprogramming and LLVM optimization.
-// FIXME: It suffers from the shortcoming that unneeded calls cannot be
-// completely removed by C++ metaprogramming which leads functions declared in
-// OpSemMemManager being defined in *all* mem managers. Once we move to a SFINAE
-// solution we will only need to define functions when they are
-// used - faster to iterate through changes.
-template <typename T> struct HasTracking : std::false_type {};
-
-template <>
-struct HasTracking<OpSemWideMemManagerMixin<TrackingRawMemManager>>
-    : std::true_type {};
 
 } // namespace details
 } // namespace seahorn

--- a/lib/seahorn/BvOpSem2WideMemMgr.cc
+++ b/lib/seahorn/BvOpSem2WideMemMgr.cc
@@ -435,30 +435,6 @@ WideMemManager::PtrSortTy WideMemManager::ptrSort() const {
 Expr WideMemManager::bytesToSlotExpr(unsigned int bytes) {
   return m_ctx.alu().si(bytes, g_slotBitWidth);
 }
-WideMemManager::MemValTy
-WideMemManager::memsetMetaData(PtrTy ptr, unsigned int len,
-                               WideMemManager::MemValTy memIn, uint32_t align,
-                               unsigned int val) {
-  LOG("opsem", WARN << "memsetMetadata() not implemented!\n");
-  return memIn;
-}
-WideMemManager::MemValTy
-WideMemManager::memsetMetaData(PtrTy ptr, Expr len,
-                               WideMemManager::MemValTy memIn, uint32_t align,
-                               unsigned int val) {
-  LOG("opsem", WARN << "memsetMetadata() not implemented!\n");
-  return memIn;
-}
-Expr WideMemManager::getMetaData(PtrTy ptr, MemValTy memIn, unsigned int byteSz,
-                                 uint32_t align) {
-  LOG("opsem", WARN << "getMetadata() not implemented!\n");
-  return Expr();
-}
-unsigned int WideMemManager::getMetaDataMemWordSzInBits() {
-  LOG("opsem", WARN << "getMetaDataWordSzInBits() not implemented!\n");
-  return 0;
-}
-
 OpSemMemManager *mkWideMemManager(Bv2OpSem &sem, Bv2OpSemContext &ctx,
                                   unsigned ptrSz, unsigned wordSz,
                                   bool useLambdas) {

--- a/lib/seahorn/BvOpSem2WideMemMgr.hh
+++ b/lib/seahorn/BvOpSem2WideMemMgr.hh
@@ -34,6 +34,8 @@ class WideMemManager : public OpSemMemManagerBase {
   static const unsigned int g_num_slots = 2;
 
 public:
+  // setting TrackingTag to int disqualifies this class as having tracking
+  using TrackingTag = int;
   using RawPtrTy = OpSemMemManager::PtrTy;
   using RawMemValTy = OpSemMemManager::MemValTy;
   using RawPtrSortTy = OpSemMemManager::PtrSortTy;
@@ -243,16 +245,6 @@ public:
   MemValTy zeroedMemory() const;
 
   Expr isDereferenceable(PtrTy p, Expr byteSz);
-
-  MemValTy memsetMetaData(PtrTy ptr, unsigned int len, MemValTy memIn,
-                          uint32_t align, unsigned int val);
-
-  MemValTy memsetMetaData(PtrTy ptr, Expr len, MemValTy memIn, uint32_t align,
-                          unsigned int val);
-  Expr getMetaData(PtrTy ptr, MemValTy memIn, unsigned int byteSz,
-                   uint32_t align);
-
-  unsigned int getMetaDataMemWordSzInBits();
 
   RawPtrTy getAddressable(PtrTy p) const;
 


### PR DESCRIPTION
This uses 'tags' to enable custom functionality to be added to only a subset of memory managers without adding default(NOP) impl to the rest of memory managers.

It has been implemented using boost::hana which I chose in favour of std::enable_if since it is easier to construct a solution using hana

Pros of boost::hana vs raw SFINAE (C++ 14)
1. Not easy to check if component class of mixin has a feature in raw SFINAE. This is an advertised idiom in Hana.
2. Easier to construct - Raw SFINAE does not support partial specialization of class methods. Thus we cannot use a class template param in specializing a method. This leads to more verbosity at call site.
3. while the sprinkling of eval_if + lambdas takes getting used to - imo it is more readable/understandable than the equivalent function specialization which will require two method declarations + definitions for true/false for each method we want to specialized.