### PR TITLE
test(opsem): add opsem2 tests to azure ci

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,4 +17,4 @@ jobs:
       - script: docker build -t seahorn/seahorn-builder:bionic-llvm10 -f docker/seahorn-builder.Dockerfile .
       - script:  docker run -v $(pwd):/host -i seahorn/seahorn-builder:bionic-llvm10 /bin/sh -c "cp build/SeaHorn*.tar.gz /host/"
       - script: docker build -t seahorn_container -f docker/seahorn.Dockerfile .
-      - script: docker run -v $(pwd):/host -i seahorn_container /bin/bash -c "cd seahorn/share/seahorn && lit test/opsem"
+      - script: docker run -v $(pwd):/host -i seahorn_container /bin/bash -c "cd seahorn/share/seahorn && lit test/opsem test/opsem2 test/mcfuzz"


### PR DESCRIPTION
Travis CI times out with opsem2 tests, this will ensure better test coverage