### PR TITLE
refactor(opsem): make rawmemmgr available through mixin

### DIFF
--- a/lib/seahorn/BvOpSem2Allocators.hh
+++ b/lib/seahorn/BvOpSem2Allocators.hh
@@ -1,0 +1,119 @@
+#pragma once
+
+#include "BvOpSem2Context.hh"
+#include "BvOpSem2RawMemMgr.hh"
+
+namespace seahorn {
+namespace details {
+
+/// \brief  Lays out / allocates pointers in a virtual memory space
+///
+/// The class is responsible for laying out allocated object in memory.
+/// The exact semantics are yet to be determined. Currently, it is assumed
+/// that the layout respects stack / heap / text area separation.
+///
+/// Note that in addition to the parameters passed directly, the allocator has
+/// access to the \p OpSemContext so it can depend on the current instruction
+/// being executed.
+
+class OpSemAllocator {
+protected:
+  struct AllocInfo;
+  struct FuncAllocInfo;
+  struct GlobalAllocInfo;
+
+  RawMemManagerCore &m_mem;
+  Bv2OpSemContext &m_ctx;
+  Bv2OpSem &m_sem;
+  ExprFactory &m_efac;
+
+  /// \brief All known stack allocations
+  std::vector<AllocInfo> m_allocas;
+  /// \brief All known code allocations
+  std::vector<FuncAllocInfo> m_funcs;
+  /// \brief All known global allocations
+  std::vector<GlobalAllocInfo> m_globals;
+
+  /// \brief Maximal assumed size of symbolic allocation
+  unsigned m_maxSymbAllocSz;
+
+  // TODO: turn into user-controlled parameters
+  const unsigned MAX_STACK_ADDR = 0xC0000000;
+  const unsigned MIN_STACK_ADDR = (MAX_STACK_ADDR - 9437184);
+  const unsigned TEXT_SEGMENT_START = 0x08048000;
+
+public:
+  using AddrInterval = std::pair<unsigned, unsigned>;
+  explicit OpSemAllocator(RawMemManagerCore &mem,
+                          unsigned maxSymbAllocSz = 4096);
+
+  virtual ~OpSemAllocator();
+
+  /// \brief Allocates memory on the stack and returns a pointer to it
+  /// \param align is requested alignment. If 0, default alignment is used
+  virtual AddrInterval salloc(unsigned bytes, uint32_t align) = 0;
+
+  /// \brief Allocates memory on the stack
+  ///
+  /// \param bytes is a symbolic representation for number of bytes to allocate
+  virtual AddrInterval salloc(Expr bytes, uint32_t align) = 0;
+
+  /// \brief Address at which heap starts (initial value of \c brk)
+  unsigned brk0Addr();
+
+  bool isBadAddrInterval(AddrInterval range) {
+    return range == AddrInterval(0, 0);
+  }
+
+  /// \brief Return the maximal legal range of the stack pointer
+  AddrInterval getStackRange() { return {MIN_STACK_ADDR, MAX_STACK_ADDR}; }
+
+  /// \brief Called whenever a new module is to be executed
+  virtual void onModuleEntry(const Module &M) {}
+
+  /// \brief Called whenever a new function is to be executed
+  virtual void onFunctionEntry(const Function &fn) {}
+
+  /// \brief Allocates memory on the heap and returns a pointer to it
+  virtual AddrInterval halloc(unsigned _bytes, unsigned align) {
+    llvm_unreachable("not implemented");
+  }
+
+  /// \brief Allocates memory in global (data/bss) segment for given global
+  /// \param bytes is the expected size of allocation
+  virtual AddrInterval galloc(const GlobalVariable &gv, uint64_t bytes,
+                              unsigned align);
+
+  /// \brief Allocates memory in code segment for the code of a given function
+  virtual AddrInterval falloc(const Function &fn, unsigned align);
+
+  /// \brief Returns an address at which a given function resides
+  virtual unsigned getFunctionAddr(const Function &F, unsigned align);
+
+  virtual AddrInterval getFunctionAddrAndSize(const Function &F,
+                                              unsigned int align);
+
+  /// \brief Returns an address of a global variable
+  virtual unsigned getGlobalVariableAddr(const GlobalVariable &gv,
+                                         unsigned bytes, unsigned align);
+
+  /// \brief Returns an address of memory segment to store value of the variable
+  virtual char *getGlobalVariableMem(const GlobalVariable &gv) const;
+
+  /// \brief Returns initial value of a global variable
+  ///
+  /// Returns (nullptr, 0) if the global variable has no known initial value
+  virtual std::pair<char *, unsigned>
+  getGlobalVariableInitValue(const GlobalVariable &gv);
+
+  virtual void dumpGlobalsMap();
+};
+
+/// \brief Creates an instance of OpSemAllocator
+std::unique_ptr<OpSemAllocator>
+mkNormalOpSemAllocator(RawMemManagerCore &mem, unsigned maxSymbAllocSz = 4096);
+std::unique_ptr<OpSemAllocator>
+mkStaticOpSemAllocator(RawMemManagerCore &mem, unsigned maxSymbAllocSz = 4096);
+
+} // namespace details
+} // namespace seahorn

--- a/lib/seahorn/BvOpSem2Alu.cc
+++ b/lib/seahorn/BvOpSem2Alu.cc
@@ -131,6 +131,8 @@ public:
   }
 
   Expr doZext(Expr op, unsigned bitWidth, unsigned opBitWidth) override {
+    // TODO: change signature to ({op, opBitWith}, bitWidth) for consistent API
+    // TODO: optimize by considering that op can be a 1 bit number.
     Expr res = op;
     switch (opBitWidth) {
     case 1:

--- a/lib/seahorn/BvOpSem2ExtraWideMemMgr.hh
+++ b/lib/seahorn/BvOpSem2ExtraWideMemMgr.hh
@@ -1,9 +1,9 @@
 #pragma once
 
 #include "BvOpSem2Context.hh"
+#include "BvOpSem2MemManagerMixin.hh"
 #include "BvOpSem2RawMemMgr.hh"
 #include "BvOpSem2TrackingRawMemMgr.hh"
-#include "BvOpSem2WideMemManagerMixin.hh"
 
 #include "seahorn/Expr/ExprOpStruct.hh"
 #include "seahorn/Support/SeaDebug.h"
@@ -15,10 +15,7 @@
 namespace seahorn {
 namespace details {
 
-template <class T> class ExtraWideMemManager : public OpSemMemManagerBase {
-
-  /// \brief Knows the memory representation and how to access it
-  std::unique_ptr<OpSemMemRepr> m_memRepr;
+template <class T> class ExtraWideMemManager : public MemManagerCore {
 
   /// \brief Base name for non-deterministic pointer
   Expr m_freshPtrName;
@@ -31,13 +28,6 @@ template <class T> class ExtraWideMemManager : public OpSemMemManagerBase {
   mutable unsigned m_id;
 
   const Expr m_uninit_size;
-
-  static const unsigned int g_slotBitWidth = 64;
-  static const unsigned int g_slotByteWidth = g_slotBitWidth / 8;
-
-  static const unsigned int g_uninit = 0xDEADBEEF;
-  static const unsigned int g_uninit_small = 0xDEAD;
-  static const unsigned int g_num_slots = 3;
 
   /// \brief Memory manager for raw pointers
   T m_main;
@@ -73,7 +63,6 @@ public:
     explicit PtrTyImpl(const Expr &e) {
       // Our base is a struct of three exprs
       assert(strct::isStructVal(e));
-      assert(e->arity() == g_num_slots);
       m_v = e;
     }
 
@@ -108,8 +97,6 @@ public:
       assert(strct::isStructVal(e));
       assert(!strct::isStructVal(e->arg(1)));
       assert(!strct::isStructVal(e->arg(2)));
-
-      assert(e->arity() == g_num_slots);
       m_v = e;
     }
 

--- a/lib/seahorn/BvOpSem2FatMemMgr.cc
+++ b/lib/seahorn/BvOpSem2FatMemMgr.cc
@@ -19,7 +19,7 @@ static const unsigned int g_slotByteWidth = g_slotBitWidth / 8;
 
 static const unsigned int g_maxFatSlots = 2;
 /// \brief provides Fat pointers and Fat memory to store them
-class FatMemManager : public OpSemMemManagerBase {
+class FatMemManager : public MemManagerCore {
 public:
   /// PtrTy representation for this manager
   ///
@@ -575,9 +575,8 @@ public:
 
 FatMemManager::FatMemManager(Bv2OpSem &sem, Bv2OpSemContext &ctx,
                              unsigned ptrSz, unsigned wordSz, bool useLambdas)
-    : OpSemMemManagerBase(
-          sem, ctx, ptrSz, wordSz,
-          false /* this is a nop since we delegate to RawMemMgr */),
+    : MemManagerCore(sem, ctx, ptrSz, wordSz,
+                     false /* this is a nop since we delegate to RawMemMgr */),
       m_main(sem, ctx, ptrSz, wordSz, useLambdas),
       m_nullPtr(mkFatPtr(m_main.nullPtr())),
       m_slot0(sem, ctx, ptrSz, g_slotByteWidth, useLambdas),

--- a/lib/seahorn/BvOpSem2MemManager.cc
+++ b/lib/seahorn/BvOpSem2MemManager.cc
@@ -21,6 +21,17 @@ OpSemMemManagerBase::OpSemMemManagerBase(Bv2OpSem &sem, Bv2OpSemContext &ctx,
   // assert((m_wordSz >= m_ptrSz) && "Word size is less than pointer size");
 }
 
+MemManagerCore::MemManagerCore(Bv2OpSem &sem, Bv2OpSemContext &ctx,
+                               unsigned ptrSz, unsigned wordSz,
+                               bool ignoreAlignment)
+    : m_sem(sem), m_ctx(ctx), m_efac(ctx.getExprFactory()), m_ptrSz(ptrSz),
+      m_wordSz(wordSz), m_alignment(m_wordSz),
+      m_ignoreAlignment(ignoreAlignment) {
+  assert((m_wordSz == 1 || m_wordSz == 4 || m_wordSz == 8) &&
+         "Untested word size");
+  assert((m_ptrSz == 4 || m_ptrSz == 8) && "Untested pointer size");
+}
+
 OpSemMemManager::OpSemMemManager(Bv2OpSem &sem, Bv2OpSemContext &ctx,
                                  unsigned ptrSz, unsigned wordSz,
                                  bool ignoreAlignment)

--- a/lib/seahorn/BvOpSem2MemManagerMixin.hh
+++ b/lib/seahorn/BvOpSem2MemManagerMixin.hh
@@ -37,8 +37,8 @@ public:
   template <typename... Ts>
   OpSemMemManagerMixin(Ts &&... Args)
       : BaseT(std::forward<Ts>(Args)...),
-        OpSemMemManager(base().sem(), base().ctx(), base().ptrSzInBytes(),
-                        base().wordSzInBytes(), base().isIgnoreAlignment()) {}
+        OpSemMemManager(base().sem(), base().ctx(), base().ptrSizeInBytes(),
+                        base().wordSizeInBytes(), base().isIgnoreAlignment()) {}
   virtual ~OpSemMemManagerMixin() = default;
 
   PtrSortTy ptrSort() const override {
@@ -179,6 +179,7 @@ public:
     return toMemValTy(std::move(res));
   }
 
+  // TODO: move common logic from memmgr to mixin.
   Expr loadValueFromMem(PtrTy ptr, MemValTy mem, const llvm::Type &ty,
                         uint64_t align) override {
     auto res = base().loadValueFromMem(BasePtrTy(std::move(ptr)),

--- a/lib/seahorn/BvOpSem2MemRepr.cc
+++ b/lib/seahorn/BvOpSem2MemRepr.cc
@@ -1,5 +1,6 @@
-#include "BvOpSem2Context.hh"
+#include "BvOpSem2MemRepr.hh"
 #include "seahorn/Expr/ExprOpBinder.hh"
+
 namespace {
 template <typename T, typename... Rest>
 auto as_std_array(const T &t, const Rest &... rest) ->
@@ -13,9 +14,11 @@ auto as_std_array(const T &t, const Rest &... rest) ->
 namespace seahorn {
 namespace details {
 
-Expr OpSemMemArrayRepr::MemSet(Expr ptr, Expr _val, unsigned len, Expr mem,
-                               unsigned wordSzInBytes, Expr ptrSort,
-                               uint32_t align) {
+OpSemMemRepr::MemValTy OpSemMemArrayRepr::MemSet(PtrTy ptr, Expr _val,
+                                                 unsigned len, MemValTy mem,
+                                                 unsigned wordSzInBytes,
+                                                 PtrSortTy ptrSort,
+                                                 uint32_t align) {
   // MemSet operates at word level.
   // _val must fit within a byte
   // _val is converted to a byte.
@@ -31,23 +34,25 @@ Expr OpSemMemArrayRepr::MemSet(Expr ptr, Expr _val, unsigned len, Expr mem,
     unsigned long val = 0;
     memset(&val, byte, wordSzInBytes);
 
-    res = mem;
+    res = mem.toExpr();
     for (unsigned i = 0; i < len; i += wordSzInBytes) {
-      Expr idx = m_memManager.ptrAdd(ptr, i);
+      Expr idx = m_memManager.ptrAdd(ptr, i).toExpr();
       res = op::array::store(
           res, idx, bv::bvnum(val, wordSzInBytes * m_BitsPerByte, m_efac));
     }
-    return res;
+    return MemValTy(res);
   }
 
-  return res;
+  return MemValTy(res);
 }
 
 // len is in bytes
 // _val must fit within a byte
-Expr OpSemMemArrayRepr::MemSet(Expr ptr, Expr _val, Expr len, Expr mem,
-                               unsigned wordSzInBytes, Expr ptrSort,
-                               uint32_t align) {
+OpSemMemRepr::MemValTy OpSemMemArrayRepr::MemSet(PtrTy ptr, Expr _val, Expr len,
+                                                 MemValTy mem,
+                                                 unsigned wordSzInBytes,
+                                                 PtrSortTy ptrSort,
+                                                 uint32_t align) {
   Expr res;
 
   unsigned width;
@@ -68,48 +73,48 @@ Expr OpSemMemArrayRepr::MemSet(Expr ptr, Expr _val, Expr len, Expr mem,
   }
 
   // write into memory
-  res = mem;
-  // XXX assume that bit-width(len) == ptrSzInBits
-  auto bitWidth = m_memManager.ptrSzInBits();
+  res = mem.toExpr();
+  // XXX assume that bit-width(len) == ptrSizeInBits
+  auto bitWidth = m_memManager.ptrSizeInBits();
   Expr upperBound = m_ctx.alu().doAdd(
       len, m_ctx.alu().si(-wordSzInBytes, bitWidth), bitWidth);
 
   for (unsigned i = 0; i < m_memCpyUnrollCnt; i += wordSzInBytes) {
-    Expr idx = m_memManager.ptrAdd(ptr, i);
-    auto cmp = m_ctx.alu().doUle(m_ctx.alu().si(i, m_memManager.ptrSzInBits()),
-                                 upperBound, m_memManager.ptrSzInBits());
-    Expr ite = boolop::lite(cmp, bvVal, op::array::select(mem, idx));
+    Expr idx = m_memManager.ptrAdd(ptr, i).toExpr();
+    auto cmp =
+        m_ctx.alu().doUle(m_ctx.alu().si(i, m_memManager.ptrSizeInBits()),
+                          upperBound, m_memManager.ptrSizeInBits());
+    Expr ite = boolop::lite(cmp, bvVal, op::array::select(mem.toExpr(), idx));
     res = op::array::store(res, idx, ite);
   }
 
   LOG("opsem.array", errs() << "memset: " << *res << "\n";);
-  return res;
+  return MemValTy(res);
 }
 
 // TODO: This function is untested
-Expr OpSemMemArrayRepr::MemCpy(Expr dPtr, Expr sPtr, Expr len,
-                               Expr memTrsfrRead, Expr memRead,
-                               unsigned wordSzInBytes, Expr ptrSort,
-                               uint32_t align) {
+OpSemMemRepr::MemValTy OpSemMemArrayRepr::MemCpy(
+    PtrTy dPtr, PtrTy sPtr, Expr len, MemValTy memTrsfrRead, MemValTy memRead,
+    unsigned wordSzInBytes, PtrSortTy ptrSort, uint32_t align) {
   (void)ptrSort;
 
-  Expr res = memRead;
-  Expr srcMem = memTrsfrRead;
+  Expr res = memRead.toExpr();
+  Expr srcMem = memTrsfrRead.toExpr();
   if (wordSzInBytes == 1 || (wordSzInBytes == 4 && align == 4) ||
       (wordSzInBytes == 8 && (align == 4 || align == 8)) ||
       m_memManager.isIgnoreAlignment()) {
-    // XXX assume that bit-width(len) == ptrSzInBits
-    auto bitWidth = m_memManager.ptrSzInBits();
+    // XXX assume that bit-width(len) == ptrSizeInBits
+    auto bitWidth = m_memManager.ptrSizeInBits();
     Expr upperBound = m_ctx.alu().doAdd(
         len, m_ctx.alu().si(-wordSzInBytes, bitWidth), bitWidth);
     for (unsigned i = 0; i < m_memCpyUnrollCnt; i += wordSzInBytes) {
-      Expr dIdx = m_memManager.ptrAdd(dPtr, i);
-      Expr sIdx = m_memManager.ptrAdd(sPtr, i);
+      Expr dIdx = m_memManager.ptrAdd(dPtr, i).toExpr();
+      Expr sIdx = m_memManager.ptrAdd(sPtr, i).toExpr();
       auto cmp =
-          m_ctx.alu().doUle(m_ctx.alu().si(i, m_memManager.ptrSzInBits()),
-                            upperBound, m_memManager.ptrSzInBits());
+          m_ctx.alu().doUle(m_ctx.alu().si(i, m_memManager.ptrSizeInBits()),
+                            upperBound, m_memManager.ptrSizeInBits());
       auto ite = boolop::lite(cmp, op::array::select(srcMem, sIdx),
-                              op::array::select(memRead, dIdx));
+                              op::array::select(memRead.toExpr(), dIdx));
       res = op::array::store(res, dIdx, ite);
     }
     LOG("opsem.array", INFO << "memcpy: " << *res << "\n";);
@@ -119,13 +124,14 @@ Expr OpSemMemArrayRepr::MemCpy(Expr dPtr, Expr sPtr, Expr len,
                "alignment is not ignored!");
     assert(false);
   }
-  return res;
+  return MemValTy(res);
 }
 
-Expr OpSemMemArrayRepr::MemCpy(Expr dPtr, Expr sPtr, unsigned len,
-                               Expr memTrsfrRead, Expr memRead,
-                               unsigned wordSzInBytes, Expr ptrSort,
-                               uint32_t align) {
+OpSemMemRepr::MemValTy
+OpSemMemArrayRepr::MemCpy(PtrTy dPtr, PtrTy sPtr, unsigned len,
+                          MemValTy memTrsfrRead, MemValTy memRead,
+                          unsigned wordSzInBytes, PtrSortTy ptrSort,
+                          uint32_t align) {
   (void)ptrSort;
 
   Expr res;
@@ -133,11 +139,11 @@ Expr OpSemMemArrayRepr::MemCpy(Expr dPtr, Expr sPtr, unsigned len,
   if (wordSzInBytes == 1 || (wordSzInBytes == 4 && align == 4) ||
       (wordSzInBytes == 8 && (align == 4 || align == 8)) ||
       m_memManager.isIgnoreAlignment()) {
-    Expr srcMem = memTrsfrRead;
-    res = memRead;
+    Expr srcMem = memTrsfrRead.toExpr();
+    res = memRead.toExpr();
     for (unsigned i = 0; i < len; i += wordSzInBytes) {
-      Expr dIdx = m_memManager.ptrAdd(dPtr, i);
-      Expr sIdx = m_memManager.ptrAdd(sPtr, i);
+      Expr dIdx = m_memManager.ptrAdd(dPtr, i).toExpr();
+      Expr sIdx = m_memManager.ptrAdd(sPtr, i).toExpr();
 
       Expr val = op::array::select(srcMem, sIdx);
       res = op::array::store(res, dIdx, val);
@@ -148,20 +154,22 @@ Expr OpSemMemArrayRepr::MemCpy(Expr dPtr, Expr sPtr, unsigned len,
                            << "\n");
     assert(false);
   }
-  return res;
+  return MemValTy(res);
 }
 
-Expr OpSemMemArrayRepr::MemFill(Expr dPtr, char *sPtr, unsigned len, Expr mem,
-                                unsigned wordSzInBytes, Expr ptrSort,
-                                uint32_t align) {
-  Expr res = mem;
+OpSemMemRepr::MemValTy OpSemMemArrayRepr::MemFill(PtrTy dPtr, char *sPtr,
+                                                  unsigned len, MemValTy mem,
+                                                  unsigned wordSzInBytes,
+                                                  PtrSortTy ptrSort,
+                                                  uint32_t align) {
+  Expr res = mem.toExpr();
   const unsigned sem_word_sz = wordSzInBytes;
 
   // 8 bytes because assumed largest supported sem_word_sz = 8
   assert(sizeof(unsigned long) >= sem_word_sz);
 
   for (unsigned i = 0; i < len; i += sem_word_sz) {
-    Expr dIdx = m_memManager.ptrAdd(dPtr, i);
+    Expr dIdx = m_memManager.ptrAdd(dPtr, i).toExpr();
     // copy bytes from buffer to word - word must accommodate largest
     // supported word size
     // 8 bytes because assumed largest supported sem_word_sz = 8
@@ -170,25 +178,29 @@ Expr OpSemMemArrayRepr::MemFill(Expr dPtr, char *sPtr, unsigned len, Expr mem,
     Expr val = bv::bvnum(word, wordSzInBytes * m_BitsPerByte, m_efac);
     res = op::array::store(res, dIdx, val);
   }
-  return res;
+  return MemValTy(res);
 }
 
-Expr OpSemMemLambdaRepr::storeAlignedWordToMem(Expr val, Expr ptr, Expr ptrSort,
-                                               Expr mem) {
-  Expr b0 = bind::bvar(0, ptrSort);
+OpSemMemRepr::MemValTy
+OpSemMemLambdaRepr::storeAlignedWordToMem(Expr val, PtrTy ptr,
+                                          PtrSortTy ptrSort, MemValTy mem) {
+  PtrTy b0 = PtrTy(bind::bvar(0, ptrSort.toExpr()));
 
-  Expr fappl = op::bind::fapp(mem, b0);
+  Expr fappl = op::bind::fapp(mem.toExpr(), b0.toExpr());
   Expr ite = boolop::lite(m_memManager.ptrEq(b0, ptr), val, fappl);
 
-  Expr addr = bind::mkConst(mkTerm<std::string>("addr", m_efac), ptrSort);
+  Expr addr =
+      bind::mkConst(mkTerm<std::string>("addr", m_efac), ptrSort.toExpr());
   Expr decl = bind::fname(addr);
-  return mk<LAMBDA>(decl, ite);
+  return MemValTy(mk<LAMBDA>(decl, ite));
 }
 
 // len is in bytes
-Expr OpSemMemLambdaRepr::MemSet(Expr ptr, Expr _val, unsigned len, Expr mem,
-                                unsigned wordSzInBytes, Expr ptrSort,
-                                uint32_t align) {
+OpSemMemRepr::MemValTy OpSemMemLambdaRepr::MemSet(PtrTy ptr, Expr _val,
+                                                  unsigned len, MemValTy mem,
+                                                  unsigned wordSzInBytes,
+                                                  PtrSortTy ptrSort,
+                                                  uint32_t align) {
   Expr res;
   Expr bvVal;
   unsigned width;
@@ -209,26 +221,29 @@ Expr OpSemMemLambdaRepr::MemSet(Expr ptr, Expr _val, unsigned len, Expr mem,
 
   assert(bvVal);
 
-  res = mem;
+  res = mem.toExpr();
 
-  Expr last = m_memManager.ptrAdd(ptr, len - wordSzInBytes);
-  Expr b0 = bind::bvar(0, ptrSort);
+  PtrTy last = m_memManager.ptrAdd(ptr, len - wordSzInBytes);
+  PtrTy b0 = PtrTy(bind::bvar(0, ptrSort.toExpr()));
 
   Expr cmp = m_memManager.ptrInRangeCheck(ptr, b0, last);
-  Expr fappl = op::bind::fapp(res, b0);
+  Expr fappl = op::bind::fapp(res, b0.toExpr());
   Expr ite = boolop::lite(cmp, bvVal, fappl);
 
-  Expr addr = bind::mkConst(mkTerm<std::string>("addr", m_efac), ptrSort);
+  Expr addr =
+      bind::mkConst(mkTerm<std::string>("addr", m_efac), ptrSort.toExpr());
   Expr decl = bind::fname(addr);
   res = mk<LAMBDA>(decl, ite);
   LOG("opsem.lambda", errs() << "MemSet " << *res << "\n");
 
-  return res;
+  return MemValTy(res);
 }
 
-Expr OpSemMemLambdaRepr::MemSet(Expr ptr, Expr _val, Expr len, Expr mem,
-                                unsigned wordSzInBytes, Expr ptrSort,
-                                uint32_t align) {
+OpSemMemRepr::MemValTy OpSemMemLambdaRepr::MemSet(PtrTy ptr, Expr _val,
+                                                  Expr len, MemValTy mem,
+                                                  unsigned wordSzInBytes,
+                                                  PtrSortTy ptrSort,
+                                                  uint32_t align) {
   Expr res;
   Expr val;
 
@@ -252,65 +267,63 @@ Expr OpSemMemLambdaRepr::MemSet(Expr ptr, Expr _val, Expr len, Expr mem,
   }
   assert(val);
 
-  Expr last =
+  PtrTy last =
       m_memManager.ptrAdd(m_memManager.ptrAdd(ptr, len), -wordSzInBytes);
 
   Expr bvVal = val;
-  Expr b0 = bind::bvar(0, ptrSort);
+  PtrTy b0 = PtrTy(bind::bvar(0, ptrSort.toExpr()));
 
   Expr cmp = m_memManager.ptrInRangeCheck(ptr, b0, last);
-  Expr fappl = op::bind::fapp(mem, b0);
+  Expr fappl = op::bind::fapp(mem.toExpr(), b0.toExpr());
   Expr ite = boolop::lite(cmp, bvVal, fappl);
 
-  Expr addr = bind::mkConst(mkTerm<std::string>("addr", m_efac), ptrSort);
+  Expr addr =
+      bind::mkConst(mkTerm<std::string>("addr", m_efac), ptrSort.toExpr());
   Expr decl = bind::fname(addr);
   res = mk<LAMBDA>(decl, ite);
   LOG("opsem.lambda", errs() << "MemSet " << *res << "\n");
 
-  return res;
+  return MemValTy(res);
 }
 
-Expr OpSemMemLambdaRepr::MemCpy(Expr dPtr, Expr sPtr, Expr len,
-                                Expr memTrsfrRead, Expr memRead,
-                                unsigned wordSzInBytes, Expr ptrSort,
-                                uint32_t align) {
-  Expr res;
-  Expr srcMem = memTrsfrRead;
+OpSemMemRepr::MemValTy OpSemMemLambdaRepr::MemCpy(
+    PtrTy dPtr, PtrTy sPtr, Expr len, MemValTy memTrsfrRead, MemValTy memRead,
+    unsigned wordSzInBytes, PtrSortTy ptrSort, uint32_t align) {
+  MemValTy srcMem = memTrsfrRead;
   // address of the last word that is copied into dst
-  Expr dstLast =
+  PtrTy dstLast =
       m_memManager.ptrAdd(m_memManager.ptrAdd(dPtr, len), -wordSzInBytes);
-  res = createMemCpyExpr(dPtr, sPtr, memRead, ptrSort, srcMem, dstLast,
-                         wordSzInBytes, align);
-  return res;
+  return createMemCpyExpr(dPtr, sPtr, memRead, ptrSort, srcMem, dstLast,
+                          wordSzInBytes, align);
 }
 
 // TODO: Call this from concrete LambdaRepr::MemCpy also to
 // remove duplicate code
-Expr OpSemMemLambdaRepr::createMemCpyExpr(
-    const Expr &dPtr, const Expr &sPtr, const Expr &memRead,
-    const Expr &ptrSort, const Expr &srcMem, const Expr &dstLast,
+OpSemMemRepr::MemValTy OpSemMemLambdaRepr::createMemCpyExpr(
+    const PtrTy &dPtr, const PtrTy &sPtr, const MemValTy &memRead,
+    const PtrSortTy &ptrSort, const MemValTy &srcMem, const PtrTy &dstLast,
     unsigned wordSzInBytes, uint32_t align) const {
-  Expr res;
+  MemValTy res = MemValTy(Expr());
   if (wordSzInBytes == 1 || (wordSzInBytes == 4 && align == 4) ||
       (wordSzInBytes == 8 && (align == 4 || align == 8)) ||
       m_memManager.isIgnoreAlignment()) {
-    Expr b0 = bind::bvar(0, ptrSort);
+    PtrTy b0 = PtrTy(bind::bvar(0, ptrSort.toExpr()));
     // -- dPtr <= b0 <= dstLast
     Expr cmp = this->m_memManager.ptrInRangeCheck(dPtr, b0, dstLast);
     // -- offset == dPtr - sPtr
     Expr offset = this->m_memManager.ptrOffsetFromBase(dPtr, sPtr);
     // -- maps ptr in dst to ptr in src
-    Expr readPtrInSrc = this->m_memManager.ptrAdd(b0, offset);
+    Expr readPtrInSrc = this->m_memManager.ptrAdd(b0, offset).toExpr();
 
-    Expr readFromSrc = bind::fapp(srcMem, readPtrInSrc);
-    Expr readFromDst = bind::fapp(memRead, b0);
+    Expr readFromSrc = bind::fapp(srcMem.toExpr(), readPtrInSrc);
+    Expr readFromDst = bind::fapp(memRead.toExpr(), b0.toExpr());
 
     Expr ite = boolop::lite(cmp, readFromSrc, readFromDst);
-    Expr addr =
-        bind::mkConst(mkTerm<std::string>("addr", this->m_efac), ptrSort);
+    Expr addr = bind::mkConst(mkTerm<std::string>("addr", this->m_efac),
+                              ptrSort.toExpr());
     Expr decl = bind::fname(addr);
-    res = mk<LAMBDA>(decl, ite);
-    LOG("opsem.lambda", errs() << "MemCpy " << *res << "\n");
+    res = MemValTy(mk<LAMBDA>(decl, ite));
+    LOG("opsem.lambda", errs() << "MemCpy " << &res << "\n");
   } else {
     DOG(ERR << "unsupported memcpy due to size and/or alignment.";);
     DOG(WARN << "Interpreting memcpy as noop");
@@ -319,34 +332,36 @@ Expr OpSemMemLambdaRepr::createMemCpyExpr(
   return res;
 }
 
-Expr OpSemMemLambdaRepr::MemCpy(Expr dPtr, Expr sPtr, unsigned len,
-                                Expr memTrsfrRead, Expr memRead,
-                                unsigned wordSzInBytes, Expr ptrSort,
-                                uint32_t align) {
-  Expr res;
+OpSemMemRepr::MemValTy
+OpSemMemLambdaRepr::MemCpy(PtrTy dPtr, PtrTy sPtr, unsigned len,
+                           MemValTy memTrsfrRead, MemValTy memRead,
+                           unsigned wordSzInBytes, PtrSortTy ptrSort,
+                           uint32_t align) {
+  MemValTy res = MemValTy(Expr());
 
   if (wordSzInBytes == 1 || (wordSzInBytes == 4 && align == 4) ||
       (wordSzInBytes == 8 && (align == 4 || align == 8)) ||
       m_memManager.isIgnoreAlignment()) {
-    Expr srcMem = memTrsfrRead;
+    MemValTy srcMem = memTrsfrRead;
 
     if (len > 0) {
       unsigned bytesToCpy = len - wordSzInBytes;
-      Expr dstLast = m_memManager.ptrAdd(dPtr, bytesToCpy);
+      PtrTy dstLast = m_memManager.ptrAdd(dPtr, bytesToCpy);
 
-      Expr b0 = bind::bvar(0, ptrSort);
+      PtrTy b0 = PtrTy(bind::bvar(0, ptrSort.toExpr()));
       Expr cmp = m_memManager.ptrInRangeCheck(dPtr, b0, dstLast);
       Expr offset = m_memManager.ptrOffsetFromBase(dPtr, sPtr);
-      Expr readPtrInSrc = m_memManager.ptrAdd(b0, offset);
+      PtrTy readPtrInSrc = m_memManager.ptrAdd(b0, offset);
 
-      Expr readFromSrc = op::bind::fapp(srcMem, readPtrInSrc);
-      Expr readFromDst = op::bind::fapp(memRead, b0);
+      Expr readFromSrc = op::bind::fapp(srcMem.toExpr(), readPtrInSrc.toExpr());
+      Expr readFromDst = op::bind::fapp(memRead.toExpr(), b0.toExpr());
 
       Expr ite = boolop::lite(cmp, readFromSrc, readFromDst);
-      Expr addr = bind::mkConst(mkTerm<std::string>("addr", m_efac), ptrSort);
+      Expr addr =
+          bind::mkConst(mkTerm<std::string>("addr", m_efac), ptrSort.toExpr());
       Expr decl = bind::fname(addr);
-      res = mk<LAMBDA>(decl, ite);
-      LOG("opsem.lambda", errs() << "MemCpy " << *res << "\n");
+      res = MemValTy(mk<LAMBDA>(decl, ite));
+      LOG("opsem.lambda", errs() << "MemCpy " << &res << "\n");
     } else {
       // no-op
       res = memRead;
@@ -374,14 +389,15 @@ Expr OpSemMemLambdaRepr::coerceArrayToLambda(Expr arrVal) {
   return bind::abs<LAMBDA>(as_std_array(bvAddr), sel);
 }
 
-Expr OpSemMemLambdaRepr::makeLinearITE(Expr addr, const ExprVector &ptrKeys,
+Expr OpSemMemLambdaRepr::makeLinearITE(PtrTy addr,
+                                       const std::vector<PtrTy> &ptrKeys,
                                        const ExprVector &vals, Expr fallback) {
   assert(ptrKeys.size() == vals.size());
 
   Expr res = fallback;
 
   for (size_t i = ptrKeys.size() - 1; i < ptrKeys.size(); --i) {
-    Expr k = ptrKeys[i];
+    PtrTy k = ptrKeys[i];
     Expr v = vals[i];
 
     Expr cmp = m_memManager.ptrEq(addr, k);
@@ -391,17 +407,19 @@ Expr OpSemMemLambdaRepr::makeLinearITE(Expr addr, const ExprVector &ptrKeys,
   return res;
 }
 
-Expr OpSemMemLambdaRepr::MemFill(Expr dPtr, char *sPtr, unsigned len, Expr mem,
-                                 unsigned wordSzInBytes, Expr ptrSort,
-                                 uint32_t align) {
+OpSemMemRepr::MemValTy OpSemMemLambdaRepr::MemFill(PtrTy dPtr, char *sPtr,
+                                                   unsigned len, MemValTy mem,
+                                                   unsigned wordSzInBytes,
+                                                   PtrSortTy ptrSort,
+                                                   uint32_t align) {
   (void)align;
   const unsigned sem_word_sz = wordSzInBytes;
   assert(sizeof(unsigned long) >= sem_word_sz);
 
-  Expr initial = mem;
-  LOG("opsem.lambda", errs() << "MemFill init: " << *initial << "\n");
+  MemValTy initial = mem;
+  LOG("opsem.lambda", errs() << "MemFill init: " << &initial << "\n");
 
-  ExprVector ptrs;
+  std::vector<PtrTy> ptrs;
   ptrs.reserve(len);
   ExprVector vals;
   vals.reserve(len);
@@ -417,23 +435,26 @@ Expr OpSemMemLambdaRepr::MemFill(Expr dPtr, char *sPtr, unsigned len, Expr mem,
     vals.push_back(val);
   }
 
-  Expr b0 = bind::bvar(0, ptrSort);
+  PtrTy b0 = PtrTy(bind::bvar(0, ptrSort.toExpr()));
   Expr fallback = loadAlignedWordFromMem(b0, initial);
   Expr ite = makeLinearITE(b0, ptrs, vals, fallback);
-  Expr addr = bind::mkConst(mkTerm<std::string>("addr", m_efac), ptrSort);
+  Expr addr =
+      bind::mkConst(mkTerm<std::string>("addr", m_efac), ptrSort.toExpr());
   Expr decl = bind::fname(addr);
   Expr res = mk<LAMBDA>(decl, ite);
 
   LOG("opsem.lambda", errs() << "MemFill: " << *res << "\n");
 
-  return res;
+  return MemValTy(res);
 }
-Expr OpSemMemLambdaRepr::FilledMemory(Expr ptrSort, Expr v) {
-  Expr addr = bind::mkConst(mkTerm<std::string>("addr", m_efac), ptrSort);
+OpSemMemRepr::MemValTy OpSemMemLambdaRepr::FilledMemory(PtrSortTy ptrSort,
+                                                        Expr v) {
+  Expr addr =
+      bind::mkConst(mkTerm<std::string>("addr", m_efac), ptrSort.toExpr());
   Expr decl = bind::fname(addr);
   // -- create constant lambda
   // lambda addr :: v
-  return mk<LAMBDA>(decl, v);
+  return MemValTy(mk<LAMBDA>(decl, v));
 }
 } // namespace details
 } // namespace seahorn

--- a/lib/seahorn/BvOpSem2MemRepr.hh
+++ b/lib/seahorn/BvOpSem2MemRepr.hh
@@ -1,0 +1,142 @@
+#pragma once
+
+#include "BvOpSem2RawMemMgr.hh"
+#include "seahorn/Expr/ExprLlvm.hh"
+#include "seahorn/Expr/Smt/EZ3.hh"
+
+namespace seahorn {
+namespace details {
+
+/// \Brief Base class for memory representation
+class OpSemMemRepr {
+protected:
+  RawMemManagerCore &m_memManager;
+  Bv2OpSemContext &m_ctx;
+  ExprFactory &m_efac;
+  static constexpr unsigned m_BitsPerByte = 8;
+
+public:
+  using PtrTy = RawMemManagerCore::PtrTy;
+  using PtrSortTy = RawMemManagerCore::PtrSortTy;
+  using MemValTy = RawMemManagerCore::MemValTy;
+
+  OpSemMemRepr(RawMemManagerCore &memManager, Bv2OpSemContext &ctx)
+      : m_memManager(memManager), m_ctx(ctx), m_efac(ctx.getExprFactory()) {}
+  virtual ~OpSemMemRepr() = default;
+
+  virtual Expr coerce(Expr sort, Expr val) = 0;
+  virtual Expr loadAlignedWordFromMem(PtrTy ptr, MemValTy mem) = 0;
+  virtual MemValTy storeAlignedWordToMem(Expr val, PtrTy ptr, PtrSortTy ptrSort,
+                                         MemValTy mem) = 0;
+
+  virtual MemValTy MemSet(PtrTy ptr, Expr _val, unsigned len, MemValTy mem,
+                          unsigned wordSzInBytes, PtrSortTy ptrSort,
+                          uint32_t align) = 0;
+  virtual MemValTy MemSet(PtrTy ptr, Expr _val, Expr len, MemValTy mem,
+                          unsigned wordSzInBytes, PtrSortTy ptrSort,
+                          uint32_t align) = 0;
+  virtual MemValTy MemCpy(PtrTy dPtr, PtrTy sPtr, unsigned len,
+                          MemValTy memTrsfrRead, MemValTy memRead,
+                          unsigned wordSzInBytes, PtrSortTy ptrSort,
+                          uint32_t align) = 0;
+  virtual MemValTy MemCpy(PtrTy dPtr, PtrTy sPtr, Expr len,
+                          MemValTy memTrsfrRead, MemValTy memRead,
+                          unsigned wordSzInBytes, PtrSortTy ptrSort,
+                          uint32_t align) = 0;
+
+  virtual MemValTy MemFill(PtrTy dPtr, char *sPtr, unsigned len, MemValTy mem,
+                           unsigned wordSzInBytes, PtrSortTy ptrSort,
+                           uint32_t align) = 0;
+  virtual MemValTy FilledMemory(PtrSortTy ptrSort, Expr val) = 0;
+};
+
+/// \brief Represent memory regions by logical arrays
+class OpSemMemArrayRepr : public OpSemMemRepr {
+public:
+  OpSemMemArrayRepr(RawMemManagerCore &memManager, Bv2OpSemContext &ctx,
+                    unsigned memCpyUnrollCnt)
+      : OpSemMemRepr(memManager, ctx), m_memCpyUnrollCnt(memCpyUnrollCnt) {}
+
+  Expr coerce(Expr _, Expr val) override { return val; }
+
+  Expr loadAlignedWordFromMem(PtrTy ptr, MemValTy mem) override {
+    return op::array::select(mem.toExpr(), ptr.toExpr());
+  }
+
+  MemValTy storeAlignedWordToMem(Expr val, PtrTy ptr, PtrSortTy ptrSort,
+                                 MemValTy mem) override {
+    (void)ptrSort;
+    return MemValTy(op::array::store(mem.toExpr(), ptr.toExpr(), val));
+  }
+
+  MemValTy MemSet(PtrTy ptr, Expr _val, unsigned len, MemValTy mem,
+                  unsigned wordSzInBytes, PtrSortTy ptrSort,
+                  uint32_t align) override;
+  MemValTy MemSet(PtrTy ptr, Expr _val, Expr len, MemValTy mem,
+                  unsigned wordSzInBytes, PtrSortTy ptrSort,
+                  uint32_t align) override;
+  MemValTy MemCpy(PtrTy dPtr, PtrTy sPtr, unsigned len, MemValTy memTrsfrRead,
+                  MemValTy memRead, unsigned wordSzInBytes, PtrSortTy ptrSort,
+                  uint32_t align) override;
+
+  MemValTy MemCpy(PtrTy dPtr, PtrTy sPtr, Expr len, MemValTy memTrsfrRead,
+                  MemValTy memRead, unsigned wordSzInBytes, PtrSortTy ptrSort,
+                  uint32_t align) override;
+
+  MemValTy MemFill(PtrTy dPtr, char *sPtr, unsigned len, MemValTy mem,
+                   unsigned wordSzInBytes, PtrSortTy ptrSort,
+                   uint32_t align) override;
+  MemValTy FilledMemory(PtrSortTy ptrSort, Expr val) override {
+    return MemValTy(op::array::constArray(ptrSort.toExpr(), val));
+  }
+
+private:
+  unsigned m_memCpyUnrollCnt;
+};
+
+/// \brief Represent memory regions by lambda functions
+class OpSemMemLambdaRepr : public OpSemMemRepr {
+public:
+  OpSemMemLambdaRepr(RawMemManagerCore &memManager, Bv2OpSemContext &ctx)
+      : OpSemMemRepr(memManager, ctx) {}
+
+  Expr coerce(Expr sort, Expr val) override {
+    return isOp<ARRAY_TY>(sort) ? coerceArrayToLambda(val) : val;
+  }
+
+  Expr loadAlignedWordFromMem(PtrTy ptr, MemValTy mem) override {
+    return bind::fapp(mem.toExpr(), ptr.toExpr());
+  }
+
+  MemValTy storeAlignedWordToMem(Expr val, PtrTy ptr, PtrSortTy ptrSort,
+                                 MemValTy mem) override;
+  MemValTy MemSet(PtrTy ptr, Expr _val, unsigned len, MemValTy mem,
+                  unsigned wordSzInBytes, PtrSortTy ptrSort,
+                  uint32_t align) override;
+  MemValTy MemSet(PtrTy ptr, Expr _val, Expr len, MemValTy mem,
+                  unsigned wordSzInBytes, PtrSortTy ptrSort,
+                  uint32_t align) override;
+  MemValTy MemCpy(PtrTy dPtr, PtrTy sPtr, unsigned len, MemValTy memTrsfrRead,
+                  MemValTy memRead, unsigned wordSzInBytes, PtrSortTy ptrSort,
+                  uint32_t align) override;
+  MemValTy MemCpy(PtrTy dPtr, PtrTy sPtr, Expr len, MemValTy memTrsfrRead,
+                  MemValTy memRead, unsigned wordSzInBytes, PtrSortTy ptrSort,
+                  uint32_t align) override;
+  MemValTy MemFill(PtrTy dPtr, char *sPtr, unsigned len, MemValTy mem,
+                   unsigned wordSzInBytes, PtrSortTy ptrSort,
+                   uint32_t align) override;
+  MemValTy FilledMemory(PtrSortTy ptrSort, Expr v) override;
+
+private:
+  Expr coerceArrayToLambda(Expr arrVal);
+  Expr makeLinearITE(PtrTy addr, const std::vector<PtrTy> &ptrKeys,
+                     const ExprVector &vals, Expr fallback);
+  // address of the last word that is copied into dst
+  MemValTy createMemCpyExpr(const PtrTy &dPtr, const PtrTy &sPtr,
+                            const MemValTy &memRead, const PtrSortTy &ptrSort,
+                            const MemValTy &srcMem, const PtrTy &dstLast,
+                            unsigned wordSzInBytes, uint32_t align) const;
+};
+
+} // namespace details
+} // namespace seahorn

--- a/lib/seahorn/BvOpSem2TrackingRawMemMgr.cc
+++ b/lib/seahorn/BvOpSem2TrackingRawMemMgr.cc
@@ -3,13 +3,16 @@
 namespace seahorn {
 namespace details {
 
+static const unsigned int g_MetadataBitWidth = 8;
+static const unsigned int g_MetadataByteWidth = g_MetadataBitWidth / 8;
+static const unsigned int g_num_slots = 2;
+
 TrackingRawMemManager::TrackingRawMemManager(Bv2OpSem &sem,
                                              Bv2OpSemContext &ctx,
                                              unsigned ptrSz, unsigned wordSz,
                                              bool useLambdas)
-    : OpSemMemManagerBase(
-          sem, ctx, ptrSz, wordSz,
-          false /* this is a nop since we delegate to RawMemMgr */),
+    : MemManagerCore(sem, ctx, ptrSz, wordSz,
+                     false /* this is a nop since we delegate to RawMemMgr */),
       m_main(sem, ctx, ptrSz, wordSz, useLambdas),
       m_metadata(sem, ctx, ptrSz, g_MetadataByteWidth, useLambdas, true) {}
 
@@ -18,9 +21,8 @@ TrackingRawMemManager::TrackingRawMemManager(Bv2OpSem &sem,
                                              unsigned ptrSz, unsigned wordSz,
                                              bool useLambdas,
                                              bool ignoreAlignment)
-    : OpSemMemManagerBase(
-          sem, ctx, ptrSz, wordSz,
-          false /* this is a nop since we delegate to RawMemMgr */),
+    : MemManagerCore(sem, ctx, ptrSz, wordSz,
+                     false /* this is a nop since we delegate to RawMemMgr */),
       m_main(sem, ctx, ptrSz, wordSz, useLambdas, ignoreAlignment),
       m_metadata(sem, ctx, ptrSz, g_MetadataByteWidth, useLambdas, true) {}
 TrackingRawMemManager::PtrTy
@@ -107,7 +109,7 @@ TrackingRawMemManager::MemValTy TrackingRawMemManager::storeValueToMem(
   ExprFactory &efac = ptr->efac();
   // TODO: use zeroed memory on m_main, m_metadata instead of explicit
   // init
-  MemValTy res(m_ctx.alu().si(0UL, wordSzInBits()),
+  MemValTy res(m_ctx.alu().si(0UL, wordSizeInBits()),
                m_ctx.alu().si(0UL, g_MetadataBitWidth));
   switch (ty.getTypeID()) {
   case Type::IntegerTyID:

--- a/lib/seahorn/BvOpSem2TrackingRawMemMgr.hh
+++ b/lib/seahorn/BvOpSem2TrackingRawMemMgr.hh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "BvOpSem2Context.hh"
+#include "BvOpSem2MemManagerMixin.hh"
 #include "BvOpSem2RawMemMgr.hh"
 
 #include "seahorn/Expr/ExprOpStruct.hh"
@@ -20,14 +21,10 @@ namespace details {
 // Currently this implementation has a metadata memory word size of 1 byte.
 // For every byte written to conventional memory, we set the corresponding
 // metadata memory address to value 1.
-class TrackingRawMemManager : public OpSemMemManagerBase {
+class TrackingRawMemManager : public MemManagerCore {
 private:
   RawMemManager m_main;
   RawMemManager m_metadata;
-
-  static const unsigned int g_MetadataBitWidth = 8;
-  static const unsigned int g_MetadataByteWidth = g_MetadataBitWidth / 8;
-  static const unsigned int g_num_slots = 2;
 
 public:
   // This memory manager supports tracking
@@ -58,7 +55,6 @@ public:
       assert(strct::isStructVal(e));
       assert(!strct::isStructVal(e->arg(0)));
       assert(!strct::isStructVal(e->arg(1)));
-      assert(e->arity() == g_num_slots);
       m_v = e;
     }
 

--- a/lib/seahorn/BvOpSem2WideMemManagerMixin.hh
+++ b/lib/seahorn/BvOpSem2WideMemManagerMixin.hh
@@ -44,8 +44,8 @@ public:
   template <typename... Ts>
   OpSemWideMemManagerMixin(Ts &&... Args)
       : BaseT(std::forward<Ts>(Args)...),
-        OpSemMemManager(base().sem(), base().ctx(), base().ptrSzInBytes(),
-                        base().wordSzInBytes(), base().isIgnoreAlignment()) {}
+        OpSemMemManager(base().sem(), base().ctx(), base().ptrSizeInBytes(),
+                        base().wordSizeInBytes(), base().isIgnoreAlignment()) {}
   virtual ~OpSemWideMemManagerMixin() = default;
 
   PtrSortTy ptrSort() const override;

--- a/lib/seahorn/BvOpSem2WideMemMgr.hh
+++ b/lib/seahorn/BvOpSem2WideMemMgr.hh
@@ -1,15 +1,13 @@
 #pragma once
 
 #include "BvOpSem2Context.hh"
+#include "BvOpSem2MemManagerMixin.hh"
 #include "BvOpSem2RawMemMgr.hh"
 
 namespace seahorn {
 namespace details {
 
-class WideMemManager : public OpSemMemManagerBase {
-
-  /// \brief Knows the memory representation and how to access it
-  std::unique_ptr<OpSemMemRepr> m_memRepr;
+class WideMemManager : public MemManagerCore {
 
   /// \brief Base name for non-deterministic pointer
   Expr m_freshPtrName;
@@ -26,12 +24,6 @@ class WideMemManager : public OpSemMemManagerBase {
   /// \brief Memory manager for raw pointers
   RawMemManager m_main;
   RawMemManager m_size;
-
-  static const unsigned int g_slotBitWidth = 64;
-  static const unsigned int g_slotByteWidth = g_slotBitWidth / 8;
-
-  static const unsigned int g_uninit = 0xDEADBEEF;
-  static const unsigned int g_num_slots = 2;
 
 public:
   // setting TrackingTag to int disqualifies this class as having tracking
@@ -57,7 +49,6 @@ public:
     explicit PtrTyImpl(const Expr &e) {
       // Our ptr is a struct of two exprs
       assert(strct::isStructVal(e));
-      assert(e->arity() == g_num_slots);
       m_v = e;
     }
 
@@ -84,7 +75,6 @@ public:
     explicit MemValTyImpl(const Expr &e) {
       // Our ptr is a struct of two exprs
       assert(strct::isStructVal(e));
-      assert(e->arity() == g_num_slots);
       m_v = e;
     }
 


### PR DESCRIPTION
Moved MemRepr and Allocator interfaces to separate header files to make it easy to reason about cross dependencies since RawMemMgr, MemRepr and Allocator are strongly coupled together. 

TODO:
1. fold OpSemMemManagerBase into derived class since it is not used anywhere else
2. remove widememmanagermixin and use only one mixin
3. remove static eval_if decisions from extrawidememmanager such that these decisions are only taken in the mixin.