### PR TITLE
refactor(cex): new system for executable cex

### DIFF
--- a/include/seahorn/Bmc.hh
+++ b/include/seahorn/Bmc.hh
@@ -103,6 +103,14 @@ public:
     }
     return reg;
   }
+
+  // given an Expr encoding of pointer, return only addressable part
+  Expr getPtrAddressable(Expr e) {
+    if (!m_semCtx)
+      return Expr();
+    return m_semCtx->ptrToAddr(e);
+  }
+
   /// Dump unsat core
   /// Exposes internal details. Intendent to be used for debugging only
   virtual void unsatCore(ExprVector &out);

--- a/include/seahorn/CexExeGenerator.hh
+++ b/include/seahorn/CexExeGenerator.hh
@@ -1,0 +1,104 @@
+#pragma once
+
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Bitcode/BitcodeWriter.h"
+#include "llvm/IR/DataLayout.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/ValueMap.h"
+#include "llvm/IR/Verifier.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/ToolOutputFile.h"
+
+#include "boost/algorithm/string/replace.hpp"
+
+#include "seahorn/Bmc.hh"
+#include "seahorn/Expr/ExprLlvm.hh"
+#include "seahorn/Expr/ExprMemMap.hh"
+#include "seahorn/Expr/ExprOpBinder.hh"
+#include "seahorn/MemSimulator.hh"
+#include "seahorn/SolverBmc.hh"
+#include "seahorn/Support/SeaDebug.h"
+#include "seahorn/Transforms/Instrumentation/ShadowMemDsa.hh"
+#include <memory>
+
+namespace llvm {
+class TargetLibraryInfo;
+class DataLayout;
+class LLVMContext;
+class Module;
+} // namespace llvm
+
+/*
+    Converts bmc trace into a linkable LLVM IR
+    with all non-det functions implemented
+ */
+
+namespace seahorn {
+namespace cexGen {
+
+using MemMap = expr::exprMemMap::ExprMemMap;
+
+// helper functions
+namespace utils {
+
+/// \brief extract content from memory expression \p e using ExprMemMap;
+/// if sucessful, store default to \p e defaultValue, special id/value pairs
+/// to \p out
+template <typename kv>
+bool extractArrayContents(Expr e, kv &out, Expr &defaultValue);
+
+} // namespace utils
+
+template <class Trace> class CexExeGenerator {
+  Trace &m_trace;
+  const DataLayout &m_dl;
+  const TargetLibraryInfo &m_tli;
+  LLVMContext &m_context;
+  std::unique_ptr<Module> m_harness;
+
+  // map function calls to return value(s)
+  ValueMap<const Function *, ExprVector> m_func_val_map;
+  // list of <start addr, size> of havoc pointers
+  std::vector<std::pair<Expr, Expr>> m_memhavoc_args;
+
+  /// \brief fills m_memhavoc_args and m_func_val_map
+  void storeMemHavoc(unsigned loc, const Function *func, ImmutableCallSite cs,
+                     ImmutableCallSite prevCS);
+
+  /// \brief fills func val map, dsa data and memhavoc ptr info
+  void storeDataFromTrace();
+
+  /// \brief: Given llvm::Function \p func and a list of return values (Expr)
+  /// \p values in order of execution, convert \p values to a constant array,
+  /// implement \p func to return items in array in order per invocation
+  void buildNonDetFunction(const Function *func, ExprVector &values);
+
+  void buildMemhavoc(const Function *func, ExprVector &values);
+
+  /* build nd functions with primitive type return values, memhavoc and
+     shadow.mem.init */
+  void buildCexModule();
+
+  /// \brief converts Expr \p e into LLVM Constant with LLVM Type \p ty
+  Constant *exprToConstant(Type *ty, Expr e);
+
+  /// \brief extract default value and special id-val pairs from Expr encoding
+  /// of a shadow mem segment \p segment using ExprMemMap; returns a
+  /// ConstantArray of length \p size divided by content width, filled with
+  /// default and special values
+  Constant *exprToMemSegment(Expr segment, Expr startAddr, Expr size);
+
+public:
+  CexExeGenerator(Trace &trace, const DataLayout &dl,
+                  const TargetLibraryInfo &tli, LLVMContext &context)
+      : m_trace(trace), m_dl(dl), m_tli(tli), m_context(context) {
+    storeDataFromTrace();
+    buildCexModule();
+  }
+
+  void saveCexModuleToFile(llvm::StringRef CexFile);
+};
+
+} // namespace cexGen
+} // namespace seahorn

--- a/include/seahorn/OperationalSemantics.hh
+++ b/include/seahorn/OperationalSemantics.hh
@@ -149,6 +149,10 @@ public:
   virtual OpSemContextPtr fork(SymStore &values, ExprVector &side) {
     return OpSemContextPtr(new OpSemContext(values, side, *this));
   }
+
+  /// \brief Given Expr encoding of a ptr \p p, extract and return addressable
+  /// part only
+  virtual Expr ptrToAddr(Expr p) { return p; }
 };
 
 /// \brief Tracks information about a function

--- a/include/seahorn/SolverBmc.hh
+++ b/include/seahorn/SolverBmc.hh
@@ -87,6 +87,13 @@ public:
     return reg;
   }
 
+  // given an Expr encoding of pointer, return only addressable part
+  Expr getPtrAddressable(Expr e) {
+    if (!m_semCtx)
+      return Expr();
+    return m_semCtx->ptrToAddr(e);
+  }
+
   /// output current path condition in SMT-LIB2 format
   virtual raw_ostream &toSmtLib(raw_ostream &out);
 

--- a/lib/seahorn/BvOpSem2.cc
+++ b/lib/seahorn/BvOpSem2.cc
@@ -2486,6 +2486,8 @@ void Bv2OpSemContext::addToSolver(const Expr e) {
 
 boost::tribool Bv2OpSemContext::solve() { return m_z3_solver->solve(); }
 
+Expr Bv2OpSemContext::ptrToAddr(Expr p) { return mem().ptrToAddr(p); }
+
 } // namespace details
 
 Bv2OpSem::Bv2OpSem(ExprFactory &efac, Pass &pass, const DataLayout &dl,

--- a/lib/seahorn/BvOpSem2Context.hh
+++ b/lib/seahorn/BvOpSem2Context.hh
@@ -325,6 +325,8 @@ public:
     return OpSemContextPtr(new Bv2OpSemContext(values, side, *this));
   }
 
+  Expr ptrToAddr(Expr p) override;
+
   void resetSolver();
   void addToSolver(const Expr e);
   boost::tribool solve();
@@ -713,6 +715,14 @@ public:
 
   /// \brief reset memory modified state; used in conjuction with isModified
   virtual MemValTy resetModified(PtrTy p, MemValTy mem) = 0;
+
+  /// \brief given an Expression \p e , return true if \p e has expected
+  /// encoding of a PtrTyImpl
+  virtual bool isPtrTyVal(Expr e) = 0;
+
+  /// \brief given a properly encoded pointer Expr \p p , return the raw
+  /// expression representing memory address only
+  virtual Expr ptrToAddr(Expr p) = 0;
 };
 
 OpSemMemManager *mkRawMemManager(Bv2OpSem &sem, Bv2OpSemContext &ctx,
@@ -730,8 +740,6 @@ OpSemMemManager *mkWideMemManager(Bv2OpSem &sem, Bv2OpSemContext &ctx,
 OpSemMemManager *mkExtraWideMemManager(Bv2OpSem &sem, Bv2OpSemContext &ctx,
                                        unsigned ptrSz, unsigned wordSz,
                                        bool useLambdas = false);
-
-
 
 /// Evaluates constant expressions
 class ConstantExprEvaluator {

--- a/lib/seahorn/BvOpSem2ExtraWideMemMgr.cc
+++ b/lib/seahorn/BvOpSem2ExtraWideMemMgr.cc
@@ -97,6 +97,11 @@ ExtraWideMemManager<T>::getAddressable(ExtraWideMemManager::PtrTy p) const {
   }
   return m_ctx.alu().doAdd(p.getBase(), p.getOffset(), ptrSizeInBits());
 }
+
+template <class T> bool ExtraWideMemManager<T>::isPtrTyVal(Expr e) const {
+  return strct::isStructVal(e) && e->arity() == g_num_slots;
+}
+
 template <class T>
 Expr ExtraWideMemManager<T>::isDereferenceable(ExtraWideMemManager::PtrTy p,
                                                Expr byteSz) {

--- a/lib/seahorn/BvOpSem2ExtraWideMemMgr.hh
+++ b/lib/seahorn/BvOpSem2ExtraWideMemMgr.hh
@@ -295,6 +295,8 @@ public:
 
   RawPtrTy getAddressable(PtrTy p) const;
 
+  bool isPtrTyVal(Expr e) const;
+
   Expr getSize(PtrTy p) const;
 
   const OpSemMemManager &getMainMemMgr() const;

--- a/lib/seahorn/BvOpSem2FatMemMgr.cc
+++ b/lib/seahorn/BvOpSem2FatMemMgr.cc
@@ -574,6 +574,13 @@ public:
     LOG("opsem", WARN << "isDereferenceable() not implemented!\n");
     return m_ctx.alu().getFalse();
   }
+
+  RawPtrTy getAddressable(FatPtrTy p) const { return mkRawPtr(p); }
+
+  bool isPtrTyVal(Expr e) const {
+    // struct with raw ptr + fat slots
+    return strct::isStructVal(e) && e->arity() <= (1 + g_maxFatSlots);
+  }
 };
 
 FatMemManager::FatMemManager(Bv2OpSem &sem, Bv2OpSemContext &ctx,

--- a/lib/seahorn/BvOpSem2MemManagerMixin.hh
+++ b/lib/seahorn/BvOpSem2MemManagerMixin.hh
@@ -407,6 +407,14 @@ public:
         },
         [&] { return memIn; });
   }
+
+  bool isPtrTyVal(Expr e) { return base().isPtrTyVal(e); }
+
+  Expr ptrToAddr(Expr p) {
+    if (!isPtrTyVal(p))
+      return Expr();
+    return Expr(base().getAddressable(BasePtrTy(p)));
+  }
 };
 } // namespace details
 } // namespace seahorn

--- a/lib/seahorn/BvOpSem2RawMemMgr.cc
+++ b/lib/seahorn/BvOpSem2RawMemMgr.cc
@@ -812,5 +812,10 @@ std::pair<char *, unsigned>
 RawMemManagerCore::getGlobalVariableInitValue(const GlobalVariable &gv) {
   return m_allocator->getGlobalVariableInitValue(gv);
 }
+
+bool RawMemManagerCore::isPtrTyVal(Expr e) {
+  return (!e || !strct::isStructVal(e));
+}
+
 } // namespace details
 } // namespace seahorn

--- a/lib/seahorn/BvOpSem2RawMemMgr.hh
+++ b/lib/seahorn/BvOpSem2RawMemMgr.hh
@@ -355,6 +355,8 @@ public:
 
   Expr isModified(PtrTy p, MemValTy mem);
 
+  bool isPtrTyVal(Expr e);
+
   MemValTy resetModified(PtrTy p, MemValTy mem);
 
   PtrTy getAddressable(PtrTy p);

--- a/lib/seahorn/BvOpSem2TrackingRawMemMgr.cc
+++ b/lib/seahorn/BvOpSem2TrackingRawMemMgr.cc
@@ -29,6 +29,12 @@ TrackingRawMemManager::PtrTy
 TrackingRawMemManager::getAddressable(TrackingRawMemManager::PtrTy p) const {
   return p;
 }
+
+bool TrackingRawMemManager::isPtrTyVal(Expr e) const {
+  // same PtrTy as RawMemManager
+  return !e || !strct::isStructVal(e);
+}
+
 Expr TrackingRawMemManager::isDereferenceable(TrackingRawMemManager::PtrTy p,
                                               Expr byteSz) {
   // isDereferenceable should never be called in a 'RawMemMgr'

--- a/lib/seahorn/BvOpSem2TrackingRawMemMgr.hh
+++ b/lib/seahorn/BvOpSem2TrackingRawMemMgr.hh
@@ -229,6 +229,8 @@ public:
 
   PtrTy getAddressable(PtrTy p) const;
 
+  bool isPtrTyVal(Expr e) const;
+
   Expr isModified(PtrTy p, MemValTy mem);
 
   MemValTy resetModified(PtrTy p, MemValTy mem);

--- a/lib/seahorn/BvOpSem2WideMemMgr.cc
+++ b/lib/seahorn/BvOpSem2WideMemMgr.cc
@@ -478,6 +478,11 @@ Expr WideMemManager::ptrSub(WideMemManager::PtrTy p1,
                             WideMemManager::PtrTy p2) const {
   return m_main.ptrSub(getAddressable(p1), getAddressable(p2));
 }
+
+bool WideMemManager::isPtrTyVal(Expr e) const {
+  return strct::isStructVal(e) && e->arity() == g_num_slots;
+}
+
 OpSemMemManager *mkWideMemManager(Bv2OpSem &sem, Bv2OpSemContext &ctx,
                                   unsigned ptrSz, unsigned wordSz,
                                   bool useLambdas) {

--- a/lib/seahorn/BvOpSem2WideMemMgr.hh
+++ b/lib/seahorn/BvOpSem2WideMemMgr.hh
@@ -250,6 +250,8 @@ public:
 
   RawPtrTy getAddressable(PtrTy p) const;
 
+  bool isPtrTyVal(Expr e) const;
+
   Expr getSize(PtrTy p);
 
   const OpSemMemManager &getMainMemMgr() const;

--- a/lib/seahorn/CMakeLists.txt
+++ b/lib/seahorn/CMakeLists.txt
@@ -18,6 +18,7 @@ add_llvm_library (seahorn.LIB DISABLE_LLVM_LINK_LLVM_DYLIB
   GuessCandidates.cc
   HornCex.cc
   CexHarness.cc
+  CexExeGenerator.cc
   ClpWrite.cc
   HornClauseDB.cc
   HornClauseDBTransf.cc

--- a/lib/seahorn/CexExeGenerator.cc
+++ b/lib/seahorn/CexExeGenerator.cc
@@ -1,0 +1,462 @@
+#include "seahorn/CexExeGenerator.hh"
+
+namespace seahorn {
+namespace cexGen {
+namespace utils {
+
+template <typename kv>
+bool extractArrayContents(Expr e, kv &out, Expr &defaultValue) {
+  if (!e)
+    return false;
+
+  const MemMap a_map(e);
+  if (!a_map.isValid()) {
+    WARN << "cannot extract array contents " << *e;
+    out.clear();
+    return false;
+  }
+  Expr arrayDefault = a_map.getDefault();
+  if (!arrayDefault) {
+    WARN << "extract array contents, no default value" << *e;
+    out.clear();
+    return false;
+  }
+  defaultValue = arrayDefault;
+  for (auto begin = a_map.cbegin(), end = a_map.cend(); begin != end; begin++) {
+    Expr index = begin->getIdxExpr();
+    Expr val = begin->getValueExpr();
+    auto it = out.find(index);
+    if (it != out.end()) {
+      // we assume that indexes cannot be overwritten during
+      // initialization
+      WARN << "cannot extract array contents, duplicate found: " << *index;
+      out.clear();
+      return false;
+    }
+    out.insert(std::make_pair(index, val));
+  }
+  return true;
+}
+} // namespace utils
+
+template <class Trace>
+void CexExeGenerator<Trace>::storeMemHavoc(unsigned loc, const Function *func,
+                                           ImmutableCallSite cs,
+                                           ImmutableCallSite prevCS) {
+  const Value *prevCV = prevCS.getCalledValue();
+  const Function *prevF = dyn_cast<Function>(prevCV->stripPointerCasts());
+  if (!(prevF && prevF->getName().equals("shadow.mem.load"))) {
+    LOG("cex", errs() << "Skipping harness for memhavoc"
+                      << " because shadow.mem.load cannot be found\n");
+    return;
+  }
+  // get memhavoc content from corresponding shadow mem region
+  auto *shadowMemI = dyn_cast<Instruction>(prevCS.getArgOperand(1));
+  if (!shadowMemI)
+    return;
+  Expr shadowMem = m_trace.eval(loc, *shadowMemI, true);
+  // get memhavoc size from second operand of memhavoc
+  const Value *sizeArg = cs.getArgOperand(1);
+  Expr size;
+  if (auto *sizeI = dyn_cast<Instruction>(sizeArg)) {
+    size = m_trace.eval(loc, *sizeI, true);
+  } else if (auto *sizeConst = dyn_cast<ConstantInt>(sizeArg)) {
+    expr::mpz_class sz = toMpz(sizeConst);
+    size = expr::mkTerm<expr::mpz_class>(sz, m_trace.engine().efac());
+  } else {
+    LOG("cex",
+        errs() << "unhandled Value of memhavoc size: " << *sizeArg << "\n");
+    return;
+  }
+  // get info of ptr to havoc
+  const Value *hPtrAlloc = cs.getArgOperand(0)->stripPointerCasts();
+  Expr hPtrStart;
+  if (auto *hPtrAllocInst = dyn_cast<Instruction>(hPtrAlloc)) {
+    hPtrStart = m_trace.eval(loc, *hPtrAllocInst, true);
+  } else {
+    LOG("cex",
+        errs() << "unhandled Value of memhavoc ptr: " << *hPtrAlloc << "\n");
+    return;
+  }
+  Expr shadowMemRaw = m_trace.engine().getPtrAddressable(shadowMem);
+  Expr hPtrStartRaw = m_trace.engine().getPtrAddressable(hPtrStart);
+  if (!shadowMemRaw || !hPtrStartRaw || !size) {
+    LOG("cex", errs() << "Skipping harness for memhavoc due to lacking info");
+    return;
+  }
+  LOG("cex", errs() << "Producing harness for " << func->getName() << "\n";);
+  m_func_val_map[func].push_back(shadowMemRaw);
+  m_memhavoc_args.push_back(std::make_pair(hPtrStartRaw, size));
+}
+
+template <class Trace> void CexExeGenerator<Trace>::storeDataFromTrace() {
+  for (unsigned loc = 0; loc < m_trace.size(); loc++) {
+    const BasicBlock &BB = *m_trace.bb(loc);
+    for (auto &I : BB) {
+      if (const CallInst *ci = dyn_cast<CallInst>(&I)) {
+        ImmutableCallSite CS(ci);
+        // Go through bitcasts
+        const Value *CV = CS.getCalledValue();
+        const Function *CF = dyn_cast<Function>(CV->stripPointerCasts());
+        if (!CF) {
+          LOG("cex", errs() << "Skipping harness for " << *ci
+                            << " because callee cannot be resolved\n");
+          continue;
+        }
+
+        LOG("cex_verbose",
+            errs() << "Considering harness for: " << CF->getName() << "\n";);
+
+        if (CF->getName().equals("memhavoc")) {
+          // previous instruction should be
+          // shadow.mem.load(i32 x, i32 %sm_n, i8* null)
+          if (I.getPrevNonDebugInstruction() == nullptr)
+            continue;
+          const Instruction *prevI = I.getPrevNonDebugInstruction();
+          if (const CallInst *prevCi = dyn_cast<CallInst>(prevI)) {
+            ImmutableCallSite prevCS(prevCi);
+            storeMemHavoc(loc, CF, CS, prevCS);
+          }
+          continue;
+        }
+
+        if (!CF->hasName())
+          continue;
+        if (CF->isIntrinsic())
+          continue;
+        // We want to ignore seahorn functions, but not nondet
+        // functions created by strip-extern or dummyMainFunction
+        if (CF->getName().find_first_of('.') != StringRef::npos &&
+            !CF->getName().startswith("verifier.nondet"))
+          continue;
+        if (!CF->isExternalLinkage(CF->getLinkage()))
+          continue;
+        if (!CF->getReturnType()->isIntegerTy() &&
+            !CF->getReturnType()->isPointerTy()) {
+          continue;
+        }
+
+        // KleeInternalize
+        if (CF->getName().equals("calloc"))
+          continue;
+
+        // -- known library function
+        LibFunc libfn;
+        if (m_tli.getLibFunc(CF->getName(), libfn))
+          continue;
+
+        Expr V = m_trace.eval(loc, I, true);
+        if (!V)
+          continue;
+        LOG("cex",
+            errs() << "Producing harness for " << CF->getName() << "\n";);
+        m_func_val_map[CF].push_back(V);
+      }
+    }
+  }
+}
+
+template <class Trace>
+void CexExeGenerator<Trace>::buildNonDetFunction(const Function *func,
+                                                 ExprVector &values) {
+  Function *func_impl = cast<Function>(
+      m_harness
+          ->getOrInsertFunction(func->getName(),
+                                cast<FunctionType>(func->getFunctionType()))
+          .getCallee());
+
+  Type *RT = func->getReturnType();
+  Type *pRT =
+      RT->isIntegerTy() ? RT->getPointerTo() : Type::getInt8PtrTy(m_context);
+  ArrayType *AT = ArrayType::get(RT, values.size());
+
+  // Convert Expr to LLVM constants
+  SmallVector<Constant *, 20> LLVMarray;
+  std::transform(values.begin(), values.end(), std::back_inserter(LLVMarray),
+                 [&RT, this](Expr e) { return exprToConstant(RT, e); });
+
+  // This is an array containing the values to be returned
+  GlobalVariable *CA =
+      new GlobalVariable(*m_harness, AT, true, GlobalValue::PrivateLinkage,
+                         ConstantArray::get(AT, LLVMarray));
+
+  // Build the body of the harness function
+  BasicBlock *BB = BasicBlock::Create(m_context, "entry", func_impl);
+  IRBuilder<> Builder(BB);
+
+  // invocation counter
+  Type *CountType = Type::getInt32Ty(m_context);
+  GlobalVariable *Counter = new GlobalVariable(*m_harness, CountType, false,
+                                               GlobalValue::PrivateLinkage,
+                                               ConstantInt::get(CountType, 0));
+  Value *curCounter = Builder.CreateLoad(Counter);
+  // increment counter
+  Builder.CreateStore(
+      Builder.CreateAdd(curCounter, ConstantInt::get(CountType, 1)), Counter);
+
+  // build __seahorn_get_value_<type>(idx, CA, CA.size())
+  std::string name;
+  std::vector<Type *> ArgTypes = {CountType, pRT, CountType};
+  std::vector<Value *> Args = {curCounter, Builder.CreateBitCast(CA, pRT),
+                               ConstantInt::get(CountType, values.size())};
+
+  if (RT->isIntegerTy()) {
+    std::string RS;
+    llvm::raw_string_ostream RSO(RS);
+    RT->print(RSO);
+    name = Twine("__seahorn_get_value_").concat(RSO.str()).str();
+  } else if (RT->isPointerTy() ||
+             RT->getTypeID() == llvm::ArrayType::ArrayTyID) {
+    Type *elmTy = (RT->isPointerTy()) ? RT->getPointerElementType()
+                                      : RT->getSequentialElementType();
+
+    name = "__seahorn_get_value_ptr";
+    ArgTypes.push_back(Type::getInt32Ty(m_context));
+
+    // If we can tell how big the return type is, tell the
+    // callback function.  Otherwise pass zero.
+    if (elmTy->isSized())
+      Args.push_back(ConstantInt::get(Type::getInt32Ty(m_context),
+                                      m_dl.getTypeStoreSizeInBits(elmTy)));
+    else
+      Args.push_back(ConstantInt::get(Type::getInt32Ty(m_context), 0));
+  } else {
+    errs() << "WARNING: Unknown type: " << *RT << "\n";
+    assert(false && "Unknown return type");
+  }
+  FunctionCallee GetValue = m_harness->getOrInsertFunction(
+      name, FunctionType::get(RT, makeArrayRef(ArgTypes), false));
+  assert(GetValue);
+  Value *RetValue = Builder.CreateCall(GetValue, makeArrayRef(Args));
+  Builder.CreateRet(RetValue);
+}
+
+template <class Trace>
+void CexExeGenerator<Trace>::buildMemhavoc(const Function *func,
+                                           ExprVector &values) {
+  Function *func_impl = cast<Function>(
+      m_harness
+          ->getOrInsertFunction(func->getName(),
+                                cast<FunctionType>(func->getFunctionType()))
+          .getCallee());
+  if (!func->getReturnType()->isVoidTy()) {
+    LOG("cex", errs() << "memhavoc has non-void return type. Skipping...\n";);
+    return;
+  }
+  Type *i8PtrTy = Type::getInt8PtrTy(m_context);
+  // Convert Expr to LLVM constants
+  SmallVector<Constant *, 20> LLVMarray;
+  // one nested array for segments
+  for (size_t i = 0; i < values.size(); i++) {
+    auto havocPtr = m_memhavoc_args[i];
+    Constant *segmentCA =
+        exprToMemSegment(values[i], havocPtr.first, havocPtr.second);
+    GlobalVariable *segmentGA =
+        new GlobalVariable(*m_harness, segmentCA->getType(), true,
+                           GlobalValue::PrivateLinkage, segmentCA);
+    LLVMarray.push_back(ConstantExpr::getBitCast(segmentGA, i8PtrTy));
+  }
+  ArrayType *AT = ArrayType::get(i8PtrTy, LLVMarray.size());
+  // This is an array containing the values to be returned
+  GlobalVariable *CA =
+      new GlobalVariable(*m_harness, AT, true, GlobalValue::PrivateLinkage,
+                         ConstantArray::get(AT, LLVMarray));
+  // Build the body of the harness function
+  BasicBlock *BB = BasicBlock::Create(m_context, "entry", func_impl);
+  IRBuilder<> Builder(BB);
+
+  // invocation counter
+  Type *CountType = Type::getInt32Ty(m_context);
+  GlobalVariable *Counter = new GlobalVariable(*m_harness, CountType, false,
+                                               GlobalValue::PrivateLinkage,
+                                               ConstantInt::get(CountType, 0));
+  Value *curCounter = Builder.CreateLoad(Counter);
+  // increment counter
+  Builder.CreateStore(
+      Builder.CreateAdd(curCounter, ConstantInt::get(CountType, 1)), Counter);
+
+  // build __seahorn_get_value_ptr(idx, CA, CA.size(), ebits = 0)
+  // ebits = 0 since we are retrieving ptr to an array
+  std::string name = "__seahorn_get_value_ptr";
+  std::vector<Type *> ArgTypes = {CountType, i8PtrTy, CountType,
+                                  Type::getInt32Ty(m_context)};
+  std::vector<Value *> Args = {
+      curCounter, Builder.CreateBitCast(CA, i8PtrTy),
+      ConstantInt::get(CountType, values.size()),
+      ConstantInt::get(Type::getInt32Ty(m_context), 0)};
+  FunctionCallee GetValue = m_harness->getOrInsertFunction(
+      name, FunctionType::get(i8PtrTy, makeArrayRef(ArgTypes), false));
+  assert(GetValue);
+  Value *RetValue = Builder.CreateCall(GetValue, makeArrayRef(Args));
+
+  // void memcpy(i8* dst, i8* src, size_t block_len)
+  FunctionCallee memCpy = m_harness->getOrInsertFunction(
+      "memcpy", Type::getVoidTy(m_context), i8PtrTy, i8PtrTy,
+      m_dl.getIntPtrType(m_context, 0));
+  Builder.CreateCall(
+      memCpy, {Builder.CreateBitCast(func_impl->getArg(0), i8PtrTy),
+               Builder.CreateBitCast(RetValue, i8PtrTy), func_impl->getArg(1)});
+  Builder.CreateRetVoid();
+}
+
+template <class Trace> void CexExeGenerator<Trace>::buildCexModule() {
+  m_harness = std::make_unique<Module>("harness", m_context);
+  m_harness->setDataLayout(m_dl);
+  for (auto CFV : m_func_val_map) {
+
+    auto CF = CFV.first;
+    auto &values = CFV.second;
+    if (CF->getName().equals("memhavoc")) {
+      buildMemhavoc(CF, values);
+    } else {
+      buildNonDetFunction(CF, values);
+    }
+  }
+}
+
+template <class Trace>
+void CexExeGenerator<Trace>::saveCexModuleToFile(llvm::StringRef CexFile) {
+  std::error_code error_code;
+  llvm::ToolOutputFile out(CexFile, error_code, sys::fs::F_None);
+  assert(!error_code);
+  verifyModule(*m_harness, &errs());
+  if (CexFile.endswith(".ll"))
+    out.os() << *m_harness;
+  else
+    WriteBitcodeToFile(*m_harness, out.os());
+  out.os().close();
+  out.keep();
+}
+
+template <class Trace>
+Constant *CexExeGenerator<Trace>::exprToConstant(Type *ty, Expr e) {
+  // sometimes ptr expression has struct encoding
+  if (strct::isStructVal(e)) {
+    Expr ePtr = m_trace.engine().getPtrAddressable(e);
+    if (ePtr)
+      return exprToConstant(ty, ePtr);
+    else {
+      LOG("cex", WARN << "Unhandled value: " << *e;);
+      return Constant::getNullValue(ty);
+    }
+  }
+
+  if (!ty->isIntegerTy() && !ty->isPointerTy()) {
+    llvm_unreachable("[cex gen]: Unhandled type");
+  }
+  if (ty->isIntegerTy(1)) {
+    // special handling for i1 types (true or false) because
+    // getTypeStoreSizeInBits returns 8 for i1; instead use
+    // getTrue and getFalse which always return i1
+    if (isOpX<TRUE>(e)) {
+      return ConstantInt::getTrue(m_context);
+    } else if (isOpX<FALSE>(e)) {
+      return ConstantInt::getFalse(m_context);
+    } else {
+      LOG("cex", WARN << "incompatible expression for i1 type: " << *e);
+      return ConstantInt::getFalse(m_context);
+    }
+  }
+  if (isOpX<TRUE>(e)) {
+    return Constant::getIntegerValue(ty,
+                                     APInt(m_dl.getTypeStoreSizeInBits(ty), 1));
+  } else if (isOpX<FALSE>(e)) {
+    return Constant::getIntegerValue(ty,
+                                     APInt(m_dl.getTypeStoreSizeInBits(ty), 0));
+  } else if (isOpX<MPZ>(e) || bv::is_bvnum(e)) {
+    expr::mpz_class mpz;
+    mpz = isOpX<MPZ>(e) ? getTerm<expr::mpz_class>(e)
+                        : getTerm<expr::mpz_class>(e->arg(0));
+    return Constant::getIntegerValue(
+        ty, toAPInt(m_dl.getTypeStoreSizeInBits(ty), mpz));
+  } else {
+    LOG("cex",
+        WARN << "value: " << *e << " is not compatible with type: " << *ty;);
+    return Constant::getNullValue(ty);
+  }
+}
+
+template <class Trace>
+Constant *CexExeGenerator<Trace>::exprToMemSegment(Expr segment, Expr startAddr,
+                                                   Expr size) {
+
+  SmallVector<Constant *, 20> LLVMValueSegment;
+
+  // total block size in bytes;
+  expr::mpz_class sizeMpz;
+  size_t blockWidth = 0;
+  if (expr::numeric::getNum(size, sizeMpz)) {
+    blockWidth = sizeMpz.get_ui();
+  } else {
+    LOG("cex",
+        errs() << "memhavoc: cannot get concrete size (" << *size << ")\n");
+    ArrayType *placeholderT = ArrayType::get(Type::getInt8PtrTy(m_context), 0);
+    return ConstantArray::get(placeholderT, LLVMValueSegment);
+  }
+
+  // starting address
+  expr::mpz_class startAddrMpz;
+  size_t startAddrInt = 0;
+  if (expr::numeric::getNum(startAddr, startAddrMpz)) {
+    startAddrInt = startAddrMpz.get_ui();
+  } else {
+    LOG("cex", errs() << "memhavoc: cannot get concrete starting address: "
+                      << *startAddr << "\n");
+    ArrayType *placeholderT = ArrayType::get(Type::getInt8PtrTy(m_context), 0);
+    return ConstantArray::get(placeholderT, LLVMValueSegment);
+  }
+
+  const MemMap m_map(segment);
+  if (!m_map.isValid()) {
+    LOG("cex", errs() << "memhavoc: cannot extract content from: " << *segment
+                      << "\n");
+    ArrayType *placeholderT = ArrayType::get(Type::getInt8PtrTy(m_context), 0);
+    return ConstantArray::get(placeholderT, LLVMValueSegment);
+  }
+  size_t elmWidth = m_map.getContentWidth();
+  size_t blocks = std::ceil((float)blockWidth / (float)elmWidth);
+  auto *segmentElmTy = IntegerType::get(m_context, elmWidth * 8);
+  ArrayType *segmentAT = ArrayType::get(segmentElmTy, blocks);
+
+  Expr defaultE = m_map.getDefault();
+  // get default value or use 0 as fallback
+  Constant *defaultConst;
+  if (defaultE) {
+    defaultConst = exprToConstant(segmentElmTy, defaultE);
+  } else {
+    LOG("cex", errs() << "havocing mem with default 0 \n");
+    defaultConst = Constant::getIntegerValue(
+        segmentElmTy, APInt(m_dl.getTypeStoreSizeInBits(segmentElmTy), 0));
+  }
+
+  // fill with default values
+  for (size_t i = 0; i < blocks; i++) {
+    LLVMValueSegment.push_back(defaultConst);
+  }
+
+  // fill special value indicated by ID
+  for (auto begin = m_map.cbegin(), end = m_map.cend(); begin != end; begin++) {
+    Expr segmentID = begin->getIdxExpr();
+    expr::mpz_class idE = 0;
+    if (expr::numeric::getNum(segmentID, idE)) {
+      size_t curAddrInt = idE.get_ui();
+      size_t index = (curAddrInt - startAddrInt) / elmWidth;
+      if (index >= blocks) {
+        LOG("cex", errs() << "memhavoc: out of bound index: [" << index
+                          << "] with only " << blocks << " blocks \n");
+        continue;
+      }
+      Expr segmentE = begin->getValueExpr();
+      auto *segmentConst = exprToConstant(segmentElmTy, segmentE);
+      LLVMValueSegment[index] = segmentConst;
+    } else
+      continue;
+  }
+  return ConstantArray::get(segmentAT, LLVMValueSegment);
+}
+
+template class CexExeGenerator<ZBmcTraceTy>;
+template class CexExeGenerator<SolverBmcTraceTy>;
+
+} // namespace cexGen
+} // namespace seahorn


### PR DESCRIPTION
- created new class `CexExeGenerator` to replace `CexHarness`; the new system modularized the process of storing evaluated expression and building LLVM IR for different type of functions.
- created APIs `bool isPtrTy(Expr e)` and `Expr ptrToAddr(Expr p)` for each BvOpsem2 memory managers; `isPtrTy` takes an expression and checks whether it is the correct format under current memory manager; `ptrToAddr` takes an expression and checks whether `isPtrTy` is true; if true, extracts and returns addressable part from it, otherwise returns empty expression.
- Added `Expr getPtrAddressable(Expr e)` function to `BmcEngine` and `SolverBmcEngine`; `getPtrAddressable` checks whether current opsem context is BvOpsem 2, if so, use the context's memory manager to convert encoded memory expression to addressable part only using `ptrToAddr`;  not sure if other operational semantics have special encoding as well, currently implementing special handling for BvOpsem 2 in `getPtrAddressable`.
