### PR TITLE
feat(opsem): track alloc/free for memory objects

### DIFF
--- a/include/seahorn/Analysis/SeaBuiltinsInfo.hh
+++ b/include/seahorn/Analysis/SeaBuiltinsInfo.hh
@@ -21,8 +21,12 @@ enum class SeaBuiltinsOp {
   BRANCH_SENTINEL,    /* sea.branch_sentinel */
   IS_MODIFIED,        /* sea.is_modified */
   RESET_MODIFIED,     /* sea.reset_modified */
+  IS_READ,            /* sea.is_read */
+  RESET_READ,         /* sea.reset_read */
+  IS_ALLOC,           /* sea.is_alloc */
   TRACKING_ON,        /* sea.tracking_on */
   TRACKING_OFF,       /* sea.tracking_off */
+  FREE,               /* sea.free */
   UNKNOWN
 };
 
@@ -39,6 +43,10 @@ class SeaBuiltinsInfo {
   llvm::Function *mkResetModifiedFn(llvm::Module &M);
   llvm::Function *mkTrackingOnFn(llvm::Module &M);
   llvm::Function *mkTrackingOffFn(llvm::Module &M);
+  llvm::Function *mkIsReadFn(llvm::Module &M);
+  llvm::Function *mkResetReadFn(llvm::Module &M);
+  llvm::Function *mkIsAllocFn(llvm::Module &M);
+  llvm::Function *mkFreeFn(llvm::Module &M);
 
 public:
   SeaBuiltinsOp getSeaBuiltinOp(const llvm::CallBase &cb) const;

--- a/include/seahorn/Transforms/Scalar/PromoteVerifierCalls.hh
+++ b/include/seahorn/Transforms/Scalar/PromoteVerifierCalls.hh
@@ -25,8 +25,12 @@ namespace seahorn
     Function *m_assert_if;
     Function *m_is_modified;
     Function *m_reset_modified;
+    Function *m_is_read;
+    Function *m_reset_read;
+    Function *m_is_alloc;
     Function *m_tracking_on;
     Function *m_tracking_off;
+    Function *m_free;
 
     PromoteVerifierCalls() : ModulePass(ID) {}
 

--- a/lib/Analysis/SeaBuiltinsInfo.cc
+++ b/lib/Analysis/SeaBuiltinsInfo.cc
@@ -315,7 +315,6 @@ Function *SeaBuiltinsInfo::mkTrackingOnFn(Module &M) {
   auto FC = M.getOrInsertFunction(SEA_TRACKING_ON, Type::getVoidTy(C));
   auto *FN = dyn_cast<Function>(FC.getCallee());
   if (FN) {
-    FN->setDoesNotReadMemory();
     FN->setDoesNotThrow();
     FN->setDoesNotFreeMemory();
     FN->setDoesNotRecurse();
@@ -328,7 +327,6 @@ Function *SeaBuiltinsInfo::mkTrackingOffFn(Module &M) {
   auto FC = M.getOrInsertFunction(SEA_TRACKING_OFF, Type::getVoidTy(C));
   auto *FN = dyn_cast<Function>(FC.getCallee());
   if (FN) {
-    FN->setDoesNotReadMemory();
     FN->setDoesNotThrow();
     FN->setDoesNotFreeMemory();
     FN->setDoesNotRecurse();
@@ -344,6 +342,9 @@ Function *SeaBuiltinsInfo::mkFreeFn(Module &M) {
   if (FN) {
     FN->setDoesNotThrow();
     FN->setDoesNotRecurse();
+    // This only marks the memory as freed an does not have the semantics for
+    // actually freeing memory.
+    FN->setDoesNotFreeMemory();
     FN->addParamAttr(0, Attribute::NoCapture);
     // XXX maybe even add the following
     // FN->setDoesNotAccessMemory();

--- a/lib/Analysis/SeaBuiltinsInfo.cc
+++ b/lib/Analysis/SeaBuiltinsInfo.cc
@@ -23,8 +23,12 @@ using namespace llvm;
 #define SEA_BRANCH_SENTINEL "sea.branch_sentinel"
 #define SEA_IS_MODIFIED "sea.is_modified"
 #define SEA_RESET_MODIFIED "sea.reset_modified"
+#define SEA_IS_READ "sea.is_read"
+#define SEA_RESET_READ "sea.reset_read"
+#define SEA_IS_ALLOC "sea.is_alloc"
 #define SEA_TRACKING_ON "sea.tracking_on"
 #define SEA_TRACKING_OFF "sea.tracking_off"
+#define SEA_FREE "sea.free"
 
 SeaBuiltinsOp
 seahorn::SeaBuiltinsInfo::getSeaBuiltinOp(const llvm::CallBase &cb) const {
@@ -45,8 +49,12 @@ seahorn::SeaBuiltinsInfo::getSeaBuiltinOp(const llvm::CallBase &cb) const {
       .Case(SEA_BRANCH_SENTINEL, SBIOp::BRANCH_SENTINEL)
       .Case(SEA_IS_MODIFIED, SBIOp::IS_MODIFIED)
       .Case(SEA_RESET_MODIFIED, SBIOp::RESET_MODIFIED)
+      .Case(SEA_IS_READ, SBIOp::IS_READ)
+      .Case(SEA_RESET_READ, SBIOp::RESET_READ)
+      .Case(SEA_IS_ALLOC, SBIOp::IS_ALLOC)
       .Case(SEA_TRACKING_ON, SBIOp::TRACKING_ON)
       .Case(SEA_TRACKING_OFF, SBIOp::TRACKING_OFF)
+      .Case(SEA_FREE, SBIOp::FREE)
       .Default(SBIOp::UNKNOWN);
 }
 
@@ -76,10 +84,18 @@ llvm::Function *SeaBuiltinsInfo::mkSeaBuiltinFn(SeaBuiltinsOp op,
     return mkIsModifiedFn(M);
   case SBIOp::RESET_MODIFIED:
     return mkResetModifiedFn(M);
+  case SBIOp::IS_READ:
+    return mkIsReadFn(M);
+  case SBIOp::RESET_READ:
+    return mkResetReadFn(M);
+  case SBIOp::IS_ALLOC:
+    return mkIsAllocFn(M);
   case SBIOp::TRACKING_ON:
     return mkTrackingOnFn(M);
   case SBIOp::TRACKING_OFF:
     return mkTrackingOffFn(M);
+  case SBIOp::FREE:
+    return mkFreeFn(M);
   }
   llvm_unreachable(nullptr);
 }
@@ -163,6 +179,56 @@ Function *SeaBuiltinsInfo::mkResetModifiedFn(Module &M) {
                                   Type::getInt8PtrTy(C));
   auto *FN = dyn_cast<Function>(FC.getCallee());
   if (FN) {
+    FN->setDoesNotThrow();
+    FN->setDoesNotFreeMemory();
+    FN->setDoesNotRecurse();
+    FN->addParamAttr(0, Attribute::NoCapture);
+    // XXX maybe even add the following
+    // FN->setDoesNotAccessMemory();
+  }
+  return FN;
+}
+
+Function *SeaBuiltinsInfo::mkIsReadFn(Module &M) {
+  auto &C = M.getContext();
+  auto FC = M.getOrInsertFunction(SEA_IS_READ, Type::getInt1Ty(C),
+                                  Type::getInt8PtrTy(C));
+  auto *FN = dyn_cast<Function>(FC.getCallee());
+  if (FN) {
+    FN->setOnlyReadsMemory();
+    FN->setDoesNotThrow();
+    FN->setDoesNotFreeMemory();
+    FN->setDoesNotRecurse();
+    FN->addParamAttr(0, Attribute::NoCapture);
+    // XXX maybe even add the following
+    // FN->setDoesNotAccessMemory();
+  }
+  return FN;
+}
+
+Function *SeaBuiltinsInfo::mkResetReadFn(Module &M) {
+  auto &C = M.getContext();
+  auto FC = M.getOrInsertFunction(SEA_RESET_READ, Type::getVoidTy(C),
+                                  Type::getInt8PtrTy(C));
+  auto *FN = dyn_cast<Function>(FC.getCallee());
+  if (FN) {
+    FN->setDoesNotThrow();
+    FN->setDoesNotFreeMemory();
+    FN->setDoesNotRecurse();
+    FN->addParamAttr(0, Attribute::NoCapture);
+    // XXX maybe even add the following
+    // FN->setDoesNotAccessMemory();
+  }
+  return FN;
+}
+
+Function *SeaBuiltinsInfo::mkIsAllocFn(Module &M) {
+  auto &C = M.getContext();
+  auto FC = M.getOrInsertFunction(SEA_IS_ALLOC, Type::getInt1Ty(C),
+                                  Type::getInt8PtrTy(C));
+  auto *FN = dyn_cast<Function>(FC.getCallee());
+  if (FN) {
+    FN->setOnlyReadsMemory();
     FN->setDoesNotThrow();
     FN->setDoesNotFreeMemory();
     FN->setDoesNotRecurse();
@@ -266,6 +332,21 @@ Function *SeaBuiltinsInfo::mkTrackingOffFn(Module &M) {
     FN->setDoesNotThrow();
     FN->setDoesNotFreeMemory();
     FN->setDoesNotRecurse();
+  }
+  return FN;
+}
+
+Function *SeaBuiltinsInfo::mkFreeFn(Module &M) {
+  auto &C = M.getContext();
+  auto FC = M.getOrInsertFunction(SEA_FREE, Type::getVoidTy(C),
+                                  Type::getInt8PtrTy(C));
+  auto *FN = dyn_cast<Function>(FC.getCallee());
+  if (FN) {
+    FN->setDoesNotThrow();
+    FN->setDoesNotRecurse();
+    FN->addParamAttr(0, Attribute::NoCapture);
+    // XXX maybe even add the following
+    // FN->setDoesNotAccessMemory();
   }
   return FN;
 }

--- a/lib/Transforms/Scalar/PromoteMalloc.cc
+++ b/lib/Transforms/Scalar/PromoteMalloc.cc
@@ -55,8 +55,7 @@ public:
         if (!nv)
           nv = new AllocaInst(v->getType()->getPointerElementType(), addrSpace,
                               CS.getArgument(0), "malloc", &I);
-        IRBuilder<> Builder(F.getContext());
-        Builder.SetInsertPoint(&I);
+
         v->replaceAllUsesWith(nv);
 
         changed = true;

--- a/lib/Transforms/Scalar/PromoteMalloc.cc
+++ b/lib/Transforms/Scalar/PromoteMalloc.cc
@@ -53,9 +53,10 @@ public:
         }
 
         if (!nv)
-          nv = new AllocaInst(v->getType()->getPointerElementType(),
-                              addrSpace, CS.getArgument(0), "malloc", &I);
-
+          nv = new AllocaInst(v->getType()->getPointerElementType(), addrSpace,
+                              CS.getArgument(0), "malloc", &I);
+        IRBuilder<> Builder(F.getContext());
+        Builder.SetInsertPoint(&I);
         v->replaceAllUsesWith(nv);
 
         changed = true;

--- a/lib/Transforms/Scalar/PromoteVerifierCalls.cc
+++ b/lib/Transforms/Scalar/PromoteVerifierCalls.cc
@@ -51,8 +51,12 @@ bool PromoteVerifierCalls::runOnModule(Module &M) {
   m_assert_if = SBI.mkSeaBuiltinFn(SBIOp::ASSERT_IF, M);
   m_is_modified = SBI.mkSeaBuiltinFn(SBIOp::IS_MODIFIED, M);
   m_reset_modified = SBI.mkSeaBuiltinFn(SBIOp::RESET_MODIFIED, M);
+  m_is_read = SBI.mkSeaBuiltinFn(SBIOp::IS_READ, M);
+  m_reset_read = SBI.mkSeaBuiltinFn(SBIOp::RESET_READ, M);
+  m_is_alloc = SBI.mkSeaBuiltinFn(SBIOp::IS_ALLOC, M);
   m_tracking_on = SBI.mkSeaBuiltinFn(SBIOp::TRACKING_ON, M);
   m_tracking_off = SBI.mkSeaBuiltinFn(SBIOp::TRACKING_OFF, M);
+  m_free = SBI.mkSeaBuiltinFn(SBIOp::FREE, M);
 
   // XXX DEPRECATED
   // Do not keep unused functions in llvm.used
@@ -211,6 +215,33 @@ bool PromoteVerifierCalls::runOnFunction(Function &F) {
 
       I.replaceAllUsesWith(ci);
       toKill.push_back(&I);
+    } else if (fn && (fn->getName().equals("sea_is_read"))) {
+      IRBuilder<> Builder(F.getContext());
+      Builder.SetInsertPoint(&I);
+      CallInst *ci = Builder.CreateCall(m_is_read, {CS.getArgument(0)});
+      if (cg)
+        (*cg)[&F]->addCalledFunction(ci, (*cg)[ci->getCalledFunction()]);
+
+      I.replaceAllUsesWith(ci);
+      toKill.push_back(&I);
+    } else if (fn && (fn->getName().equals("sea_reset_read"))) {
+      IRBuilder<> Builder(F.getContext());
+      Builder.SetInsertPoint(&I);
+      CallInst *ci = Builder.CreateCall(m_reset_read, {CS.getArgument(0)});
+      if (cg)
+        (*cg)[&F]->addCalledFunction(ci, (*cg)[ci->getCalledFunction()]);
+
+      I.replaceAllUsesWith(ci);
+      toKill.push_back(&I);
+    } else if (fn && (fn->getName().equals("sea_is_alloc"))) {
+      IRBuilder<> Builder(F.getContext());
+      Builder.SetInsertPoint(&I);
+      CallInst *ci = Builder.CreateCall(m_is_alloc, {CS.getArgument(0)});
+      if (cg)
+        (*cg)[&F]->addCalledFunction(ci, (*cg)[ci->getCalledFunction()]);
+
+      I.replaceAllUsesWith(ci);
+      toKill.push_back(&I);
     } else if (fn && (fn->getName().equals("sea_tracking_on"))) {
       IRBuilder<> Builder(F.getContext());
       Builder.SetInsertPoint(&I);
@@ -224,6 +255,15 @@ bool PromoteVerifierCalls::runOnFunction(Function &F) {
       IRBuilder<> Builder(F.getContext());
       Builder.SetInsertPoint(&I);
       CallInst *ci = Builder.CreateCall(m_tracking_off);
+      if (cg)
+        (*cg)[&F]->addCalledFunction(ci, (*cg)[ci->getCalledFunction()]);
+
+      I.replaceAllUsesWith(ci);
+      toKill.push_back(&I);
+    } else if (fn && (fn->getName().equals("free"))) {
+      IRBuilder<> Builder(F.getContext());
+      Builder.SetInsertPoint(&I);
+      CallInst *ci = Builder.CreateCall(m_free, {CS.getArgument(0)});
       if (cg)
         (*cg)[&F]->addCalledFunction(ci, (*cg)[ci->getCalledFunction()]);
 

--- a/lib/Transforms/Scalar/PromoteVerifierCalls.cc
+++ b/lib/Transforms/Scalar/PromoteVerifierCalls.cc
@@ -34,6 +34,7 @@ Value *coerceToBool(Value *arg, IRBuilder<> &builder, Instruction &I) {
 }
 } // namespace
 namespace seahorn {
+
 char PromoteVerifierCalls::ID = 0;
 
 bool PromoteVerifierCalls::runOnModule(Module &M) {
@@ -112,6 +113,39 @@ bool PromoteVerifierCalls::runOnFunction(Function &F) {
 
   SmallVector<Instruction *, 16> toKill;
 
+  std::map<StringRef, std::pair<Function *, unsigned>> functionMap = {
+      {"sea_is_dereferenceable", {m_is_deref, 2}},
+      {"sea_is_modified", {m_is_modified, 1}},
+      {"sea_reset_modified", {m_reset_modified, 1}},
+      {"sea_is_read", {m_is_read, 1}},
+      {"sea_reset_read", {m_reset_read, 1}},
+      {"sea_is_alloc", {m_is_alloc, 1}},
+      {"sea_tracking_on", {m_tracking_on, 0}},
+      {"sea_tracking_off", {m_tracking_off, 0}},
+      {"free", {m_free, 1}}};
+
+  auto replaceFnWithOneArg = [](Instruction &I,
+                                std::pair<Function *, unsigned> f, Function &F,
+                                SmallVector<Instruction *, 16> &toKill,
+                                CallGraph *cg) {
+    IRBuilder<> Builder(F.getContext());
+    Builder.SetInsertPoint(&I);
+    CallSite CS(&I);
+    CallInst *ci;
+    if (f.second == 0) {
+      ci = Builder.CreateCall(f.first);
+    } else if (f.second == 1) {
+      ci = Builder.CreateCall(f.first, {CS.getArgument(0)});
+    } else if (f.second == 2) {
+      ci = Builder.CreateCall(f.first, {CS.getArgument(0), CS.getArgument(1)});
+    }
+    assert(ci);
+    if (cg)
+      (*cg)[&F]->addCalledFunction(ci, (*cg)[ci->getCalledFunction()]);
+    I.replaceAllUsesWith(ci);
+    toKill.push_back(&I);
+  };
+
   bool Changed = false;
   for (auto &I : boost::make_iterator_range(inst_begin(F), inst_end(F))) {
     if (!isa<CallInst>(&I))
@@ -187,88 +221,8 @@ bool PromoteVerifierCalls::runOnFunction(Function &F) {
         (*cg)[&F]->addCalledFunction(ci, (*cg)[ci->getCalledFunction()]);
 
       toKill.push_back(&I);
-    } else if (fn && (fn->getName().equals("sea_is_dereferenceable"))) {
-      IRBuilder<> Builder(F.getContext());
-      Builder.SetInsertPoint(&I);
-      CallInst *ci = Builder.CreateCall(m_is_deref,
-                                        {CS.getArgument(0), CS.getArgument(1)});
-      if (cg)
-        (*cg)[&F]->addCalledFunction(ci, (*cg)[ci->getCalledFunction()]);
-
-      I.replaceAllUsesWith(ci);
-      toKill.push_back(&I);
-    } else if (fn && (fn->getName().equals("sea_is_modified"))) {
-      IRBuilder<> Builder(F.getContext());
-      Builder.SetInsertPoint(&I);
-      CallInst *ci = Builder.CreateCall(m_is_modified, {CS.getArgument(0)});
-      if (cg)
-        (*cg)[&F]->addCalledFunction(ci, (*cg)[ci->getCalledFunction()]);
-
-      I.replaceAllUsesWith(ci);
-      toKill.push_back(&I);
-    } else if (fn && (fn->getName().equals("sea_reset_modified"))) {
-      IRBuilder<> Builder(F.getContext());
-      Builder.SetInsertPoint(&I);
-      CallInst *ci = Builder.CreateCall(m_reset_modified, {CS.getArgument(0)});
-      if (cg)
-        (*cg)[&F]->addCalledFunction(ci, (*cg)[ci->getCalledFunction()]);
-
-      I.replaceAllUsesWith(ci);
-      toKill.push_back(&I);
-    } else if (fn && (fn->getName().equals("sea_is_read"))) {
-      IRBuilder<> Builder(F.getContext());
-      Builder.SetInsertPoint(&I);
-      CallInst *ci = Builder.CreateCall(m_is_read, {CS.getArgument(0)});
-      if (cg)
-        (*cg)[&F]->addCalledFunction(ci, (*cg)[ci->getCalledFunction()]);
-
-      I.replaceAllUsesWith(ci);
-      toKill.push_back(&I);
-    } else if (fn && (fn->getName().equals("sea_reset_read"))) {
-      IRBuilder<> Builder(F.getContext());
-      Builder.SetInsertPoint(&I);
-      CallInst *ci = Builder.CreateCall(m_reset_read, {CS.getArgument(0)});
-      if (cg)
-        (*cg)[&F]->addCalledFunction(ci, (*cg)[ci->getCalledFunction()]);
-
-      I.replaceAllUsesWith(ci);
-      toKill.push_back(&I);
-    } else if (fn && (fn->getName().equals("sea_is_alloc"))) {
-      IRBuilder<> Builder(F.getContext());
-      Builder.SetInsertPoint(&I);
-      CallInst *ci = Builder.CreateCall(m_is_alloc, {CS.getArgument(0)});
-      if (cg)
-        (*cg)[&F]->addCalledFunction(ci, (*cg)[ci->getCalledFunction()]);
-
-      I.replaceAllUsesWith(ci);
-      toKill.push_back(&I);
-    } else if (fn && (fn->getName().equals("sea_tracking_on"))) {
-      IRBuilder<> Builder(F.getContext());
-      Builder.SetInsertPoint(&I);
-      CallInst *ci = Builder.CreateCall(m_tracking_on);
-      if (cg)
-        (*cg)[&F]->addCalledFunction(ci, (*cg)[ci->getCalledFunction()]);
-
-      I.replaceAllUsesWith(ci);
-      toKill.push_back(&I);
-    } else if (fn && (fn->getName().equals("sea_tracking_off"))) {
-      IRBuilder<> Builder(F.getContext());
-      Builder.SetInsertPoint(&I);
-      CallInst *ci = Builder.CreateCall(m_tracking_off);
-      if (cg)
-        (*cg)[&F]->addCalledFunction(ci, (*cg)[ci->getCalledFunction()]);
-
-      I.replaceAllUsesWith(ci);
-      toKill.push_back(&I);
-    } else if (fn && (fn->getName().equals("free"))) {
-      IRBuilder<> Builder(F.getContext());
-      Builder.SetInsertPoint(&I);
-      CallInst *ci = Builder.CreateCall(m_free, {CS.getArgument(0)});
-      if (cg)
-        (*cg)[&F]->addCalledFunction(ci, (*cg)[ci->getCalledFunction()]);
-
-      I.replaceAllUsesWith(ci);
-      toKill.push_back(&I);
+    } else if (fn && functionMap.count(fn->getName())) {
+      replaceFnWithOneArg(I, functionMap.at(fn->getName()), F, toKill, cg);
     } else if (fn && (fn->getName().equals(
                          "__VERIFIER_assert_if"))) { // sea_assert_if is the
                                                      // user facing name

--- a/lib/Transforms/Scalar/PromoteVerifierCalls.cc
+++ b/lib/Transforms/Scalar/PromoteVerifierCalls.cc
@@ -122,7 +122,7 @@ bool PromoteVerifierCalls::runOnFunction(Function &F) {
       {"sea_is_alloc", {m_is_alloc, 1}},
       {"sea_tracking_on", {m_tracking_on, 0}},
       {"sea_tracking_off", {m_tracking_off, 0}},
-      {"free", {m_free, 1}}};
+      {"sea_free", {m_free, 1}}};
 
   auto replaceFnWithOneArg = [](Instruction &I,
                                 std::pair<Function *, unsigned> f, Function &F,

--- a/lib/seahorn/BvOpSem2.cc
+++ b/lib/seahorn/BvOpSem2.cc
@@ -466,7 +466,7 @@ public:
     // TODO: check that addr is valid
     auto memIn = m_ctx.read(m_ctx.getMemReadRegister());
     OpSemMemManager &memManager = m_ctx.mem();
-    auto res = memManager.setMetadata(ALLOC, addr, memIn, 1);
+    auto res = memManager.setMetadata(MetadataKind::ALLOC, addr, memIn, 1);
     m_ctx.write(m_ctx.getMemWriteRegister(), res);
 
     m_ctx.setMemReadRegister(Expr());
@@ -751,7 +751,7 @@ public:
     Expr ptr = lookup(*CS.getArgument(0));
     auto memIn = m_ctx.read(m_ctx.getMemReadRegister());
     OpSemMemManager &memManager = m_ctx.mem();
-    auto res = memManager.isMetadataSet(WRITE, ptr, memIn);
+    auto res = memManager.isMetadataSet(MetadataKind::WRITE, ptr, memIn);
     setValue(*CS.getInstruction(), res);
     m_ctx.setMemReadRegister(Expr());
   }
@@ -768,7 +768,7 @@ public:
     Expr ptr = lookup(*CS.getArgument(0));
     auto memIn = m_ctx.read(m_ctx.getMemReadRegister());
     OpSemMemManager &memManager = m_ctx.mem();
-    auto res = memManager.setMetadata(WRITE, ptr, memIn, 0);
+    auto res = memManager.setMetadata(MetadataKind::WRITE, ptr, memIn, 0);
     m_ctx.write(m_ctx.getMemWriteRegister(), res);
 
     m_ctx.setMemReadRegister(Expr());
@@ -789,7 +789,7 @@ public:
     Expr ptr = lookup(*CS.getArgument(0));
     auto memIn = m_ctx.read(m_ctx.getMemReadRegister());
     OpSemMemManager &memManager = m_ctx.mem();
-    auto res = memManager.isMetadataSet(ALLOC, ptr, memIn);
+    auto res = memManager.isMetadataSet(MetadataKind::ALLOC, ptr, memIn);
     setValue(*CS.getInstruction(), res);
     m_ctx.setMemReadRegister(Expr());
   }
@@ -810,7 +810,7 @@ public:
     Expr ptr = lookup(*CS.getArgument(0));
     auto memIn = m_ctx.read(m_ctx.getMemReadRegister());
     OpSemMemManager &memManager = m_ctx.mem();
-    auto res = memManager.setMetadata(ALLOC, ptr, memIn, 0);
+    auto res = memManager.setMetadata(MetadataKind::ALLOC, ptr, memIn, 0);
     m_ctx.write(m_ctx.getMemWriteRegister(), res);
 
     m_ctx.setMemReadRegister(Expr());

--- a/lib/seahorn/BvOpSem2.cc
+++ b/lib/seahorn/BvOpSem2.cc
@@ -569,12 +569,20 @@ public:
         visitIsModified(CS);
       } else if (f->getName().startswith("sea.reset_modified")) {
         visitResetModified(CS);
+      } else if (f->getName().startswith("sea.is_read")) {
+        visitIsRead(CS);
+      } else if (f->getName().startswith("sea.reset_read")) {
+        visitResetRead(CS);
+      } else if (f->getName().startswith("sea.is_alloc")) {
+        visitIsAlloc(CS);
       } else if (f->getName().startswith("sea.reset_modified")) {
         visitResetModified(CS);
       } else if (f->getName().startswith("sea.tracking_on")) {
         visitSetTrackingOn(CS);
       } else if (f->getName().startswith(("sea.tracking_off"))) {
         visitSetTrackingOff(CS);
+      } else if (f->getName().startswith("sea.free")) {
+        visitFree(CS);
       } else if (f->getName().startswith(("sea.assert.if"))) {
         visitSeaAssertIfCall(CS);
       } else if (f->getName().startswith(("verifier.assert"))) {
@@ -725,7 +733,7 @@ public:
     Expr ptr = lookup(*CS.getArgument(0));
     auto memIn = m_ctx.read(m_ctx.getMemReadRegister());
     OpSemMemManager &memManager = m_ctx.mem();
-    auto res = memManager.isModified(ptr, memIn);
+    auto res = memManager.isMetadataSet(WRITE, ptr, memIn);
     setValue(*CS.getInstruction(), res);
     m_ctx.setMemReadRegister(Expr());
   }
@@ -742,16 +750,54 @@ public:
     Expr ptr = lookup(*CS.getArgument(0));
     auto memIn = m_ctx.read(m_ctx.getMemReadRegister());
     OpSemMemManager &memManager = m_ctx.mem();
-    auto res = memManager.resetModified(ptr, memIn);
+    auto res = memManager.resetMetadata(WRITE, ptr, memIn);
     m_ctx.write(m_ctx.getMemWriteRegister(), res);
 
     m_ctx.setMemReadRegister(Expr());
     m_ctx.setMemWriteRegister(Expr());
   }
 
+  void visitIsRead(CallSite CS) {}
+
+  void visitResetRead(CallSite CS) {}
+
+  void visitIsAlloc(CallSite CS) {
+    if (!m_ctx.getMemReadRegister()) {
+      LOG("opsem", ERR << "No read register found - check if corresponding"
+                          "shadow instruction is present.");
+      m_ctx.setMemReadRegister(Expr());
+      return;
+    }
+    Expr ptr = lookup(*CS.getArgument(0));
+    auto memIn = m_ctx.read(m_ctx.getMemReadRegister());
+    OpSemMemManager &memManager = m_ctx.mem();
+    auto res = memManager.isMetadataSet(ALLOC, ptr, memIn);
+    setValue(*CS.getInstruction(), res);
+    m_ctx.setMemReadRegister(Expr());
+  }
+
   void visitSetTrackingOn(CallSite CS) { m_ctx.setTracking(true); }
 
   void visitSetTrackingOff(CallSite CS) { m_ctx.setTracking(false); }
+
+  void visitFree(CallSite &CS) {
+    if (!m_ctx.getMemReadRegister() || !m_ctx.getMemWriteRegister()) {
+      LOG("opsem",
+          ERR << "No read/write register found - check if corresponding"
+                 "shadow instruction is present.");
+      m_ctx.setMemReadRegister(Expr());
+      m_ctx.setMemWriteRegister(Expr());
+      return;
+    }
+    Expr ptr = lookup(*CS.getArgument(0));
+    auto memIn = m_ctx.read(m_ctx.getMemReadRegister());
+    OpSemMemManager &memManager = m_ctx.mem();
+    auto res = memManager.resetMetadata(ALLOC, ptr, memIn);
+    m_ctx.write(m_ctx.getMemWriteRegister(), res);
+
+    m_ctx.setMemReadRegister(Expr());
+    m_ctx.setMemWriteRegister(Expr());
+  }
 
   /// Report outcome of vacuity and incremental assertion checking
   void reportDoAssert(char *tag, const Instruction &I, boost::tribool res,

--- a/lib/seahorn/BvOpSem2Context.hh
+++ b/lib/seahorn/BvOpSem2Context.hh
@@ -18,7 +18,7 @@ namespace details {
 // This enumerates the different kinds of metadata memory used in Tracking
 // memory.
 // TODO: move to enum class when int value is not needed.
-enum MetadataKind {
+enum class MetadataKind {
   READ = 0,
   WRITE = 1,
   ALLOC = 2,

--- a/lib/seahorn/BvOpSem2Context.hh
+++ b/lib/seahorn/BvOpSem2Context.hh
@@ -15,6 +15,14 @@
 namespace seahorn {
 namespace details {
 
+// This enumerates the different kinds of metadata memory used in Tracking
+// memory.
+enum MetadataKind {
+  READ = 0,
+  WRITE = 1,
+  ALLOC = 2,
+};
+
 namespace MemoryFeatures {
 auto tracking_tag_of =
     [](auto t) -> hana::type<typename decltype(t)::type::TrackingTag> {
@@ -698,6 +706,9 @@ public:
   /// \brief returns a constant that represents zero-initialized memory region
   virtual MemValTy zeroedMemory() const = 0;
 
+  /// \brief returns a constant that represents zero-initialized memory region
+  virtual MemValTy setMemory(unsigned int val) const = 0;
+
   /// \brief Checks if \p a <= b <= c.
   Expr ptrInRangeCheck(PtrTy a, PtrTy b, PtrTy c) {
     return mk<AND>(ptrUle(a, b), ptrUle(b, c));
@@ -715,12 +726,12 @@ public:
   /// bounds, False expr otherwise.
   virtual Expr isDereferenceable(PtrTy p, Expr byteSz) = 0;
 
-  /// \brief return True expr if memory has been modified since resetModified
+  /// \brief return True expr if memory has been modified since resetMetadata
   // or allocation, whichever is later.
-  virtual Expr isModified(PtrTy p, MemValTy mem) = 0;
+  virtual Expr isMetadataSet(MetadataKind kind, PtrTy p, MemValTy mem) = 0;
 
-  /// \brief reset memory modified state; used in conjuction with isModified
-  virtual MemValTy resetModified(PtrTy p, MemValTy mem) = 0;
+  /// \brief reset memory modified state; used in conjuction with isMetadataSet
+  virtual MemValTy resetMetadata(MetadataKind kind, PtrTy p, MemValTy mem) = 0;
 
   /// \brief given an Expression \p e , return true if \p e has expected
   /// encoding of a PtrTyImpl

--- a/lib/seahorn/BvOpSem2Context.hh
+++ b/lib/seahorn/BvOpSem2Context.hh
@@ -17,7 +17,6 @@ namespace details {
 
 // This enumerates the different kinds of metadata memory used in Tracking
 // memory.
-// TODO: move to enum class when int value is not needed.
 enum class MetadataKind {
   READ = 0,
   WRITE = 1,

--- a/lib/seahorn/BvOpSem2ExtraWideMemMgr.cc
+++ b/lib/seahorn/BvOpSem2ExtraWideMemMgr.cc
@@ -42,13 +42,7 @@ template <class T>
 typename ExtraWideMemManager<T>::RawMemValTy
 ExtraWideMemManager<T>::setModified(ExtraWideMemManager::PtrTy ptr,
                                     ExtraWideMemManager::MemValTy mem) {
-  if (!m_ctx.isTrackingOn()) {
-    LOG("opsem.memtrack.verbose",
-        errs() << "Ignoring setModified(); Memory tracking is off"
-               << "\n";);
-    return mem.getRaw();
-  }
-  return memsetMetaData(WRITE, ptr, 1 /* len */, mem, 1U /* val */).getRaw();
+  return setMetadata(MetadataKind::WRITE, ptr, mem, 1U /* val */).getRaw();
 }
 
 template <class T>
@@ -640,10 +634,10 @@ template <class T>
 typename ExtraWideMemManager<T>::MemValTy ExtraWideMemManager<T>::setMetadata(
     MetadataKind kind, ExtraWideMemManager::PtrTy ptr,
     ExtraWideMemManager::MemValTy mem, unsigned val) {
-  if (!m_ctx.isTrackingOn() && kind != ALLOC) {
+  if (!m_ctx.isTrackingOn() && kind != MetadataKind::ALLOC) {
     LOG("opsem.memtrack.verbose",
-        errs() << "Ignoring setMetadata();Memory tracking is off"
-               << "\n";);
+        WARN << "Ignoring setMetadata();Memory tracking is off"
+             << "\n";);
     return mem;
   }
   return memsetMetaData(kind, ptr, 1 /* len */, mem, val);

--- a/lib/seahorn/BvOpSem2ExtraWideMemMgr.cc
+++ b/lib/seahorn/BvOpSem2ExtraWideMemMgr.cc
@@ -141,12 +141,7 @@ ExtraWideMemManager<T>::zeroedMemory() const {
   return MemValTy(m_main.zeroedMemory(), m_offset.zeroedMemory(),
                   m_size.zeroedMemory());
 }
-template <class T>
-typename ExtraWideMemManager<T>::MemValTy
-ExtraWideMemManager<T>::setMemory(unsigned int val) const {
-  return MemValTy(m_main.setMemory(val), m_offset.setMemory(val),
-                  m_size.setMemory(val));
-}
+
 template <class T>
 std::pair<char *, unsigned int>
 ExtraWideMemManager<T>::getGlobalVariableInitValue(const GlobalVariable &gv) {
@@ -642,17 +637,16 @@ unsigned int ExtraWideMemManager<T>::getMetaDataMemWordSzInBits() {
   return m_main.getMetaDataMemWordSzInBits();
 }
 template <class T>
-typename ExtraWideMemManager<T>::MemValTy
-ExtraWideMemManager<T>::resetMetadata(MetadataKind kind,
-                                      ExtraWideMemManager::PtrTy ptr,
-                                      ExtraWideMemManager::MemValTy mem) {
-  if (!m_ctx.isTrackingOn()) {
+typename ExtraWideMemManager<T>::MemValTy ExtraWideMemManager<T>::setMetadata(
+    MetadataKind kind, ExtraWideMemManager::PtrTy ptr,
+    ExtraWideMemManager::MemValTy mem, unsigned val) {
+  if (!m_ctx.isTrackingOn() && kind != ALLOC) {
     LOG("opsem.memtrack.verbose",
-        errs() << "Ignoring resetMetadata();Memory tracking is off"
+        errs() << "Ignoring setMetadata();Memory tracking is off"
                << "\n";);
     return mem;
   }
-  return memsetMetaData(kind, ptr, 1 /* len */, mem, 0U /* val */);
+  return memsetMetaData(kind, ptr, 1 /* len */, mem, val);
 }
 template <class T>
 Expr ExtraWideMemManager<T>::ptrUlt(ExtraWideMemManager::PtrTy p1,

--- a/lib/seahorn/BvOpSem2ExtraWideMemMgr.hh
+++ b/lib/seahorn/BvOpSem2ExtraWideMemMgr.hh
@@ -20,10 +20,6 @@ template <class T> class ExtraWideMemManager : public MemManagerCore {
   /// \brief Base name for non-deterministic pointer
   Expr m_freshPtrName;
 
-  /// \brief Register that contains the value of the stack pointer on
-  /// function entry
-  Expr m_sp0;
-
   /// \brief Source of unique identifiers
   mutable unsigned m_id;
 
@@ -268,28 +264,32 @@ public:
 
   MemValTy zeroedMemory() const;
 
+  MemValTy setMemory(unsigned int val) const;
+
   Expr isDereferenceable(PtrTy p, Expr byteSz);
 
   typename ExtraWideMemManager<T>::RawMemValTy
   setModified(ExtraWideMemManager::PtrTy ptr,
               ExtraWideMemManager::MemValTy mem);
 
-  Expr isModified(ExtraWideMemManager::PtrTy ptr,
-                  ExtraWideMemManager::MemValTy mem);
+  Expr isMetadataSet(MetadataKind kind, ExtraWideMemManager::PtrTy ptr,
+                     ExtraWideMemManager::MemValTy mem);
 
   typename ExtraWideMemManager<T>::MemValTy
-  resetModified(ExtraWideMemManager::PtrTy ptr,
+  resetMetadata(MetadataKind kind, ExtraWideMemManager::PtrTy ptr,
                 ExtraWideMemManager::MemValTy mem);
 
   typename ExtraWideMemManager<T>::MemValTy
-  memsetMetaData(ExtraWideMemManager::PtrTy ptr, unsigned int len,
-                 ExtraWideMemManager::MemValTy memIn, unsigned int val);
+  memsetMetaData(MetadataKind kind, ExtraWideMemManager::PtrTy ptr,
+                 unsigned int len, ExtraWideMemManager::MemValTy memIn,
+                 unsigned int val);
 
   typename ExtraWideMemManager<T>::MemValTy
-  memsetMetaData(ExtraWideMemManager::PtrTy ptr, Expr len,
+  memsetMetaData(MetadataKind kind, ExtraWideMemManager::PtrTy ptr, Expr len,
                  ExtraWideMemManager::MemValTy memIn, unsigned int val);
 
-  Expr getMetaData(PtrTy ptr, MemValTy memIn, unsigned int byteSz);
+  Expr getMetaData(MetadataKind kind, PtrTy ptr, MemValTy memIn,
+                   unsigned int byteSz);
 
   unsigned int getMetaDataMemWordSzInBits();
 

--- a/lib/seahorn/BvOpSem2ExtraWideMemMgr.hh
+++ b/lib/seahorn/BvOpSem2ExtraWideMemMgr.hh
@@ -39,6 +39,7 @@ public:
   using TrackingTag = typename T::TrackingTag;
   // We don't support composing ExtraWideMemManager using FatMemManager
   using FatMemTag = int;
+  using WideMemTag = MemoryFeatures::WideMem_tag;
 
   using RawPtrTy = typename T::PtrTy;
   using RawMemValTy = typename T::MemValTy;
@@ -264,8 +265,6 @@ public:
 
   MemValTy zeroedMemory() const;
 
-  MemValTy setMemory(unsigned int val) const;
-
   Expr isDereferenceable(PtrTy p, Expr byteSz);
 
   typename ExtraWideMemManager<T>::RawMemValTy
@@ -276,8 +275,8 @@ public:
                      ExtraWideMemManager::MemValTy mem);
 
   typename ExtraWideMemManager<T>::MemValTy
-  resetMetadata(MetadataKind kind, ExtraWideMemManager::PtrTy ptr,
-                ExtraWideMemManager::MemValTy mem);
+  setMetadata(MetadataKind kind, ExtraWideMemManager::PtrTy ptr,
+              ExtraWideMemManager::MemValTy mem, unsigned val);
 
   typename ExtraWideMemManager<T>::MemValTy
   memsetMetaData(MetadataKind kind, ExtraWideMemManager::PtrTy ptr,

--- a/lib/seahorn/BvOpSem2FatMemMgr.cc
+++ b/lib/seahorn/BvOpSem2FatMemMgr.cc
@@ -49,6 +49,7 @@ public:
 
   using FatMemTag = MemoryFeatures::FatMem_tag;
   using TrackingTag = int;
+  using WideMemTag = int;
 
   /// Right now everything is an expression. In the future, we might have
   /// other types for PtrTy, such as a tuple of expressions
@@ -558,11 +559,6 @@ public:
                     m_slot1.zeroedMemory());
   }
 
-  FatMemValTy setMemory(unsigned int val) const {
-    return mkFatMem(m_main.setMemory(val), m_slot0.setMemory(val),
-                    m_slot1.setMemory(val));
-  }
-
   Expr getFatData(FatPtrTy p, unsigned SlotIdx) {
     assert(strct::isStructVal(p.v()));
     assert(SlotIdx < g_maxFatSlots);
@@ -573,11 +569,6 @@ public:
     assert(strct::isStructVal(p.v()));
     assert(SlotIdx < g_maxFatSlots);
     return strct::insertVal(p.v(), 1 + SlotIdx, data);
-  }
-
-  Expr isDereferenceable(FatPtrTy p, Expr byteSz) {
-    LOG("opsem", WARN << "isDereferenceable() not implemented!\n");
-    return m_ctx.alu().getFalse();
   }
 
   RawPtrTy getAddressable(FatPtrTy p) const { return mkRawPtr(p); }

--- a/lib/seahorn/BvOpSem2FatMemMgr.cc
+++ b/lib/seahorn/BvOpSem2FatMemMgr.cc
@@ -558,6 +558,11 @@ public:
                     m_slot1.zeroedMemory());
   }
 
+  FatMemValTy setMemory(unsigned int val) const {
+    return mkFatMem(m_main.setMemory(val), m_slot0.setMemory(val),
+                    m_slot1.setMemory(val));
+  }
+
   Expr getFatData(FatPtrTy p, unsigned SlotIdx) {
     assert(strct::isStructVal(p.v()));
     assert(SlotIdx < g_maxFatSlots);

--- a/lib/seahorn/BvOpSem2MemManagerMixin.hh
+++ b/lib/seahorn/BvOpSem2MemManagerMixin.hh
@@ -308,6 +308,11 @@ public:
     return toMemValTy(std::move(res));
   }
 
+  MemValTy setMemory(unsigned int val) const override {
+    auto res = base().setMemory(val);
+    return toMemValTy(std::move(res));
+  }
+
   Expr getFatData(PtrTy p, unsigned SlotIdx) override {
     return hana::eval_if(
         MemoryFeatures::has_fatmem(hana::type<BaseT>{}),
@@ -336,19 +341,19 @@ public:
         });
   }
 
-  Expr isDereferenceable(PtrTy p, Expr byteSz) {
+  Expr isDereferenceable(PtrTy p, Expr byteSz) override {
     return base().isDereferenceable(BasePtrTy(std::move(p)), byteSz);
   }
 
-  MemValTy resetModified(PtrTy p, MemValTy mem) {
+  MemValTy resetMetadata(MetadataKind kind, PtrTy p, MemValTy mem) override {
     return hana::eval_if(
         MemoryFeatures::has_tracking(hana::type<BaseT>{}),
         [&](auto _) {
-          return toMemValTy(std::move(_(base()).resetModified(
-              BasePtrTy(std::move(p)), BaseMemValTy(std::move(mem)))));
+          return toMemValTy(std::move(_(base()).resetMetadata(
+              kind, BasePtrTy(std::move(p)), BaseMemValTy(std::move(mem)))));
         },
         [&] {
-          LOG("opsem", WARN << "resetModified() not implemented!\n");
+          LOG("opsem", WARN << "resetMetadata() not implemented!\n");
           return mem;
         });
   }
@@ -360,48 +365,50 @@ public:
         [&] { return 0; });
   }
 
-  Expr isModified(PtrTy p, MemValTy mem) {
+  Expr isMetadataSet(MetadataKind kind, PtrTy p, MemValTy mem) override {
     return hana::eval_if(
         MemoryFeatures::has_tracking(hana::type<BaseT>{}),
         [&](auto _) {
-          return _(base()).isModified(BasePtrTy(std::move(p)),
-                                      BaseMemValTy(std::move(mem)));
+          return _(base()).isMetadataSet(kind, BasePtrTy(std::move(p)),
+                                         BaseMemValTy(std::move(mem)));
         },
         [&] {
-          LOG("opsem", WARN << "isModified() not implemented!\n");
+          LOG("opsem", WARN << "isMetadataSet() not implemented!\n");
           return Expr();
         });
   }
 
-  Expr getMetaData(PtrTy p, MemValTy memIn, unsigned int byteSz) {
+  Expr getMetaData(MetadataKind kind, PtrTy p, MemValTy memIn,
+                   unsigned int byteSz) {
     return hana::eval_if(
         MemoryFeatures::has_tracking(hana::type<BaseT>{}),
         [&](auto _) {
-          return _(base()).getMetaData(BasePtrTy(std::move(p)),
+          return _(base()).getMetaData(kind, BasePtrTy(std::move(p)),
                                        BaseMemValTy(std::move(memIn)), byteSz);
         },
         [&] { return Expr(); });
   }
 
-  MemValTy memsetMetaData(PtrTy p, Expr len, MemValTy memIn, unsigned int val) {
+  MemValTy memsetMetaData(MetadataKind kind, PtrTy p, Expr len, MemValTy memIn,
+                          unsigned int val) {
     return hana::eval_if(
         MemoryFeatures::has_tracking(hana::type<BaseT>{}),
         [&](auto _) {
           auto r =
-              _(base()).memsetMetaData(BasePtrTy(std::move(p)), len,
+              _(base()).memsetMetaData(kind, BasePtrTy(std::move(p)), len,
                                        BaseMemValTy(std::move(memIn)), val);
           return toMemValTy(std::move(r));
         },
         [&] { return memIn; });
   }
 
-  MemValTy memsetMetaData(PtrTy p, unsigned int len, MemValTy memIn,
-                          unsigned int val) {
+  MemValTy memsetMetaData(MetadataKind kind, PtrTy p, unsigned int len,
+                          MemValTy memIn, unsigned int val) {
     return hana::eval_if(
         MemoryFeatures::has_tracking(hana::type<BaseT>{}),
         [&](auto _) {
           auto r =
-              _(base()).memsetMetaData(BasePtrTy(std::move(p)), len,
+              _(base()).memsetMetaData(kind, BasePtrTy(std::move(p)), len,
                                        BaseMemValTy(std::move(memIn)), val);
           return toMemValTy(std::move(r));
         },

--- a/lib/seahorn/BvOpSem2MemManagerMixin.hh
+++ b/lib/seahorn/BvOpSem2MemManagerMixin.hh
@@ -359,7 +359,8 @@ public:
                                     BaseMemValTy(std::move(mem)), val)));
         },
         [&] {
-          LOG("opsem", WARN << "setMetadata() not implemented!\n");
+          LOG("opsem.memtrack.verbose",
+              WARN << "setMetadata() not implemented!\n");
           return mem;
         });
   }
@@ -379,7 +380,8 @@ public:
                                          BaseMemValTy(std::move(mem)));
         },
         [&] {
-          LOG("opsem", WARN << "isMetadataSet() not implemented!\n");
+          LOG("opsem.memtrack.verbose",
+              WARN << "isMetadataSet() not implemented!\n");
           return Expr();
         });
   }

--- a/lib/seahorn/BvOpSem2RawMemMgr.cc
+++ b/lib/seahorn/BvOpSem2RawMemMgr.cc
@@ -353,7 +353,7 @@ Expr RawMemManagerCore::extractUnalignedByte(MemValTy mem, const PtrTy &address,
 /// \param[in] ptr pointer being accessed
 /// \param[in] memReg memory register into which \p ptr points
 /// \param[in] byteSz size of the integer in bytes
-/// \param[in] align known alignment of \p ptr
+/// \param[in] align known alignment of \p ptr (in bytes)
 /// \return symbolic value of the read integer
 Expr RawMemManagerCore::loadIntFromMem(const PtrTy &ptr, const MemValTy &mem,
                                        unsigned byteSz, uint64_t align) {
@@ -719,16 +719,6 @@ Expr RawMemManagerCore::ptrSub(PtrTy p1, PtrTy p2) const {
   return m_ctx.alu().doSub(p1.toExpr(), p2.toExpr(), ptrSizeInBits());
 }
 
-Expr RawMemManagerCore::isDereferenceable(PtrTy p, Expr byteSz) {
-  LOG("opsem", ERR << "isDeferenceable() not implemented");
-  return Expr();
-}
-
-Expr RawMemManagerCore::isModified(PtrTy p, MemValTy mem) {
-  LOG("opsem", ERR << "()isMetadataSet() not implemented");
-  return Expr();
-}
-
 /// \brief Executes ptrtoint conversion
 Expr RawMemManagerCore::ptrtoint(PtrTy ptr, const Type &ptrTy,
                                  const Type &intTy) const {
@@ -793,12 +783,6 @@ OpSemAllocator &RawMemManagerCore::getMAllocator() const {
 }
 bool RawMemManagerCore::ignoreAlignment() const { return m_ignoreAlignment; }
 
-RawMemManagerCore::MemValTy
-RawMemManagerCore::resetModified(PtrTy p, RawMemManagerCore::MemValTy mem) {
-  LOG("opsem", WARN << "resetMetadata() not implemented!\n");
-  return mem;
-}
-
 PtrTy RawMemManagerCore::getAddressable(PtrTy p) { return p; }
 
 // An empty destructor is needed because the class uses unique_ptr of
@@ -815,12 +799,6 @@ RawMemManagerCore::getGlobalVariableInitValue(const GlobalVariable &gv) {
 
 bool RawMemManagerCore::isPtrTyVal(Expr e) {
   return (!e || !strct::isStructVal(e));
-}
-RawMemManagerCore::MemValTy
-RawMemManagerCore::setMemory(unsigned int val) const {
-  assert(llvm::Log2_64(val) + 1 <= wordSizeInBits());
-  return MemValTy(m_memRepr->FilledMemory(
-      ptrSort(), m_ctx.alu().ui(val, wordSizeInBits())));
 }
 
 } // namespace details

--- a/lib/seahorn/BvOpSem2RawMemMgr.cc
+++ b/lib/seahorn/BvOpSem2RawMemMgr.cc
@@ -725,7 +725,7 @@ Expr RawMemManagerCore::isDereferenceable(PtrTy p, Expr byteSz) {
 }
 
 Expr RawMemManagerCore::isModified(PtrTy p, MemValTy mem) {
-  LOG("opsem", ERR << "()isModified() not implemented");
+  LOG("opsem", ERR << "()isMetadataSet() not implemented");
   return Expr();
 }
 
@@ -795,7 +795,7 @@ bool RawMemManagerCore::ignoreAlignment() const { return m_ignoreAlignment; }
 
 RawMemManagerCore::MemValTy
 RawMemManagerCore::resetModified(PtrTy p, RawMemManagerCore::MemValTy mem) {
-  LOG("opsem", WARN << "resetModified() not implemented!\n");
+  LOG("opsem", WARN << "resetMetadata() not implemented!\n");
   return mem;
 }
 
@@ -815,6 +815,12 @@ RawMemManagerCore::getGlobalVariableInitValue(const GlobalVariable &gv) {
 
 bool RawMemManagerCore::isPtrTyVal(Expr e) {
   return (!e || !strct::isStructVal(e));
+}
+RawMemManagerCore::MemValTy
+RawMemManagerCore::setMemory(unsigned int val) const {
+  assert(llvm::Log2_64(val) + 1 <= wordSizeInBits());
+  return MemValTy(m_memRepr->FilledMemory(
+      ptrSort(), m_ctx.alu().ui(val, wordSizeInBits())));
 }
 
 } // namespace details

--- a/lib/seahorn/BvOpSem2RawMemMgr.hh
+++ b/lib/seahorn/BvOpSem2RawMemMgr.hh
@@ -119,6 +119,7 @@ public:
   // setting TrackingTag to int disqualifies this class as having tracking
   using TrackingTag = int;
   using FatMemTag = int;
+  using WideMemTag = int;
 
   /// \brief A null pointer expression (cache)
   PtrTy m_nullPtr;
@@ -351,15 +352,7 @@ public:
 
   MemValTy zeroedMemory() const;
 
-  MemValTy setMemory(unsigned int val) const;
-
-  Expr isDereferenceable(PtrTy p, Expr byteSz);
-
-  Expr isModified(PtrTy p, MemValTy mem);
-
   bool isPtrTyVal(Expr e);
-
-  MemValTy resetModified(PtrTy p, MemValTy mem);
 
   PtrTy getAddressable(PtrTy p);
 

--- a/lib/seahorn/BvOpSem2RawMemMgr.hh
+++ b/lib/seahorn/BvOpSem2RawMemMgr.hh
@@ -351,6 +351,8 @@ public:
 
   MemValTy zeroedMemory() const;
 
+  MemValTy setMemory(unsigned int val) const;
+
   Expr isDereferenceable(PtrTy p, Expr byteSz);
 
   Expr isModified(PtrTy p, MemValTy mem);

--- a/lib/seahorn/BvOpSem2TrackingRawMemMgr.cc
+++ b/lib/seahorn/BvOpSem2TrackingRawMemMgr.cc
@@ -3,9 +3,10 @@
 namespace seahorn {
 namespace details {
 
-static const unsigned int g_MetadataBitWidth = 8;
-static const unsigned int g_MetadataByteWidth = g_MetadataBitWidth / 8;
-static const unsigned int g_num_slots = 4;
+const unsigned int TrackingRawMemManager::g_MetadataBitWidth = 8;
+const unsigned int TrackingRawMemManager::g_MetadataByteWidth =
+    TrackingRawMemManager::g_MetadataBitWidth / 8;
+const unsigned int TrackingRawMemManager::g_num_slots = 4;
 
 TrackingRawMemManager::TrackingRawMemManager(Bv2OpSem &sem,
                                              Bv2OpSemContext &ctx,
@@ -14,13 +15,16 @@ TrackingRawMemManager::TrackingRawMemManager(Bv2OpSem &sem,
     : MemManagerCore(sem, ctx, ptrSz, wordSz,
                      false /* this is a nop since we delegate to RawMemMgr */),
       m_main(sem, ctx, ptrSz, wordSz, useLambdas),
-      m_w_metadata(sem, ctx, ptrSz, g_MetadataByteWidth, useLambdas, true),
-      m_r_metadata(sem, ctx, ptrSz, g_MetadataByteWidth, useLambdas, true),
-      m_a_metadata(sem, ctx, ptrSz, g_MetadataByteWidth, useLambdas, true) {
+      m_w_metadata(sem, ctx, ptrSz, TrackingRawMemManager::g_MetadataByteWidth,
+                   useLambdas, true),
+      m_r_metadata(sem, ctx, ptrSz, TrackingRawMemManager::g_MetadataByteWidth,
+                   useLambdas, true),
+      m_a_metadata(sem, ctx, ptrSz, TrackingRawMemManager::g_MetadataByteWidth,
+                   useLambdas, true) {
   m_metadata_map = {
-      {READ, &m_r_metadata},
-      {WRITE, &m_w_metadata},
-      {ALLOC, &m_a_metadata},
+      {MetadataKind::READ, &m_r_metadata},
+      {MetadataKind::WRITE, &m_w_metadata},
+      {MetadataKind::ALLOC, &m_a_metadata},
   };
 }
 
@@ -32,13 +36,16 @@ TrackingRawMemManager::TrackingRawMemManager(Bv2OpSem &sem,
     : MemManagerCore(sem, ctx, ptrSz, wordSz,
                      false /* this is a nop since we delegate to RawMemMgr */),
       m_main(sem, ctx, ptrSz, wordSz, useLambdas, ignoreAlignment),
-      m_w_metadata(sem, ctx, ptrSz, g_MetadataByteWidth, useLambdas, true),
-      m_r_metadata(sem, ctx, ptrSz, g_MetadataByteWidth, useLambdas, true),
-      m_a_metadata(sem, ctx, ptrSz, g_MetadataByteWidth, useLambdas, true) {
+      m_w_metadata(sem, ctx, ptrSz, TrackingRawMemManager::g_MetadataByteWidth,
+                   useLambdas, true),
+      m_r_metadata(sem, ctx, ptrSz, TrackingRawMemManager::g_MetadataByteWidth,
+                   useLambdas, true),
+      m_a_metadata(sem, ctx, ptrSz, TrackingRawMemManager::g_MetadataByteWidth,
+                   useLambdas, true) {
   m_metadata_map = {
-      {READ, &m_r_metadata},
-      {WRITE, &m_w_metadata},
-      {ALLOC, &m_a_metadata},
+      {MetadataKind::READ, &m_r_metadata},
+      {MetadataKind::WRITE, &m_w_metadata},
+      {MetadataKind::ALLOC, &m_a_metadata},
   };
 }
 
@@ -59,9 +66,9 @@ Expr TrackingRawMemManager::isDereferenceable(TrackingRawMemManager::PtrTy p,
 }
 TrackingRawMemManager::MemValTy TrackingRawMemManager::zeroedMemory() const {
   return MemValTy(m_main.zeroedMemory(),
-                  m_metadata_map.at(READ)->zeroedMemory(),
-                  m_metadata_map.at(WRITE)->zeroedMemory(),
-                  m_metadata_map.at(ALLOC)->zeroedMemory());
+                  m_metadata_map.at(MetadataKind::READ)->zeroedMemory(),
+                  m_metadata_map.at(MetadataKind::WRITE)->zeroedMemory(),
+                  m_metadata_map.at(MetadataKind::ALLOC)->zeroedMemory());
 }
 
 std::pair<char *, unsigned int>
@@ -95,8 +102,9 @@ TrackingRawMemManager::MemValTy TrackingRawMemManager::MemFill(
     TrackingRawMemManager::PtrTy dPtr, char *sPtr, unsigned int len,
     TrackingRawMemManager::MemValTy mem, uint32_t align) {
   RawMemValTy rawVal = m_main.MemFill(dPtr, sPtr, len, mem.getRaw(), align);
-  return MemValTy(rawVal, mem.getMetadata(READ), mem.getMetadata(WRITE),
-                  mem.getMetadata(ALLOC));
+  return MemValTy(rawVal, mem.getMetadata(MetadataKind::READ),
+                  mem.getMetadata(MetadataKind::WRITE),
+                  mem.getMetadata(MetadataKind::ALLOC));
 }
 TrackingRawMemManager::MemValTy TrackingRawMemManager::MemCpy(
     TrackingRawMemManager::PtrTy dPtr, TrackingRawMemManager::PtrTy sPtr,
@@ -104,8 +112,9 @@ TrackingRawMemManager::MemValTy TrackingRawMemManager::MemCpy(
     TrackingRawMemManager::MemValTy memRead, uint32_t align) {
   RawMemValTy rawVal = m_main.MemCpy(dPtr, sPtr, len, memTrsfrRead.getRaw(),
                                      memRead.getRaw(), align);
-  return MemValTy(rawVal, memRead.getMetadata(READ), memRead.getMetadata(WRITE),
-                  memRead.getMetadata(ALLOC));
+  return MemValTy(rawVal, memRead.getMetadata(MetadataKind::READ),
+                  memRead.getMetadata(MetadataKind::WRITE),
+                  memRead.getMetadata(MetadataKind::ALLOC));
 }
 TrackingRawMemManager::MemValTy TrackingRawMemManager::MemCpy(
     TrackingRawMemManager::PtrTy dPtr, TrackingRawMemManager::PtrTy sPtr,
@@ -113,24 +122,29 @@ TrackingRawMemManager::MemValTy TrackingRawMemManager::MemCpy(
     TrackingRawMemManager::MemValTy memRead, uint32_t align) {
   RawMemValTy rawVal = m_main.MemCpy(dPtr, sPtr, len, memTrsfrRead.getRaw(),
                                      memRead.getRaw(), align);
-  return MemValTy(rawVal, memRead.getMetadata(READ), memRead.getMetadata(WRITE),
-                  memRead.getMetadata(ALLOC));
+  return MemValTy(rawVal, memRead.getMetadata(MetadataKind::READ),
+                  memRead.getMetadata(MetadataKind::WRITE),
+                  memRead.getMetadata(MetadataKind::ALLOC));
 }
 TrackingRawMemManager::MemValTy
 TrackingRawMemManager::MemSet(TrackingRawMemManager::PtrTy ptr, Expr _val,
                               Expr len, TrackingRawMemManager::MemValTy mem,
                               uint32_t align) {
   RawMemValTy rawVal = m_main.MemSet(ptr, _val, len, mem.getRaw(), align);
-  return MemValTy(rawVal, mem.getMetadata(READ), mem.getMetadata(WRITE),
-                  mem.getMetadata(ALLOC));
+  return MemValTy(rawVal, mem.getMetadata(MetadataKind::READ),
+                  mem.getMetadata(MetadataKind::WRITE),
+                  mem.getMetadata(MetadataKind::ALLOC));
 }
 TrackingRawMemManager::MemValTy TrackingRawMemManager::MemSet(
     TrackingRawMemManager::PtrTy ptr, Expr _val, unsigned int len,
     TrackingRawMemManager::MemValTy mem, uint32_t align) {
   RawMemValTy rawVal = m_main.MemSet(ptr, _val, len, mem.getRaw(), align);
-  return MemValTy(rawVal, mem.getMetadata(READ), mem.getMetadata(WRITE),
-                  mem.getMetadata(ALLOC));
+  return MemValTy(rawVal, mem.getMetadata(MetadataKind::READ),
+                  mem.getMetadata(MetadataKind::WRITE),
+                  mem.getMetadata(MetadataKind::ALLOC));
 }
+
+// TODO: refactor this dispatch function in Mixin class
 TrackingRawMemManager::MemValTy TrackingRawMemManager::storeValueToMem(
     Expr _val, TrackingRawMemManager::PtrTy ptr,
     TrackingRawMemManager::MemValTy memIn, const Type &ty, uint32_t align) {
@@ -139,10 +153,7 @@ TrackingRawMemManager::MemValTy TrackingRawMemManager::storeValueToMem(
   const unsigned byteSz =
       m_sem.getTD().getTypeStoreSize(const_cast<llvm::Type *>(&ty));
   ExprFactory &efac = ptr->efac();
-  MemValTy res(m_ctx.alu().ui(0UL, wordSizeInBits()),
-               m_ctx.alu().ui(0UL, g_MetadataBitWidth),
-               m_ctx.alu().ui(0UL, g_MetadataBitWidth),
-               m_ctx.alu().ui(0UL, g_MetadataBitWidth));
+  MemValTy res = MemValTy(Expr());
   switch (ty.getTypeID()) {
   case Type::IntegerTyID:
     if (ty.getScalarSizeInBits() < byteSz * 8) {
@@ -213,8 +224,9 @@ TrackingRawMemManager::MemValTy TrackingRawMemManager::storePtrToMem(
     TrackingRawMemManager::MemValTy mem, unsigned int byteSz, uint64_t align) {
   RawMemValTy rawVal =
       m_main.storePtrToMem(val, ptr, mem.getRaw(), byteSz, align);
-  return MemValTy(rawVal, mem.getMetadata(READ), mem.getMetadata(WRITE),
-                  mem.getMetadata(ALLOC));
+  return MemValTy(rawVal, mem.getMetadata(MetadataKind::READ),
+                  mem.getMetadata(MetadataKind::WRITE),
+                  mem.getMetadata(MetadataKind::ALLOC));
 }
 TrackingRawMemManager::MemValTy TrackingRawMemManager::storeIntToMem(
     Expr _val, TrackingRawMemManager::PtrTy ptr,
@@ -223,8 +235,9 @@ TrackingRawMemManager::MemValTy TrackingRawMemManager::storeIntToMem(
   assert(!strct::isStructVal(_val));
   RawMemValTy rawVal =
       m_main.storeIntToMem(_val, ptr, mem.getRaw(), byteSz, align);
-  return MemValTy(rawVal, mem.getMetadata(READ), mem.getMetadata(WRITE),
-                  mem.getMetadata(ALLOC));
+  return MemValTy(rawVal, mem.getMetadata(MetadataKind::READ),
+                  mem.getMetadata(MetadataKind::WRITE),
+                  mem.getMetadata(MetadataKind::ALLOC));
 }
 TrackingRawMemManager::PtrTy
 TrackingRawMemManager::loadPtrFromMem(TrackingRawMemManager::PtrTy ptr,
@@ -288,9 +301,9 @@ Expr TrackingRawMemManager::coerce(Expr sort, Expr val) {
     kids.push_back(m_main.coerce(sort->arg(0), val->arg(0)));
     // when havocing a value; don't havoc(ignore) value for metadata memory,
     // instead intialize memory to a constant value.
-    kids.push_back(m_metadata_map.at(READ)->zeroedMemory());
-    kids.push_back(m_metadata_map.at(WRITE)->zeroedMemory());
-    kids.push_back(m_metadata_map.at(ALLOC)->zeroedMemory());
+    kids.push_back(m_metadata_map.at(MetadataKind::READ)->zeroedMemory());
+    kids.push_back(m_metadata_map.at(MetadataKind::WRITE)->zeroedMemory());
+    kids.push_back(m_metadata_map.at(MetadataKind::ALLOC)->zeroedMemory());
     return strct::mk(kids);
   }
   return m_main.coerce(sort, val);
@@ -303,10 +316,11 @@ TrackingRawMemManager::PtrTy TrackingRawMemManager::freshPtr() {
 }
 TrackingRawMemManager::MemSortTy
 TrackingRawMemManager::mkMemRegisterSort(const Instruction &inst) const {
-  return MemSortTy(m_main.mkMemRegisterSort(inst),
-                   m_metadata_map.at(READ)->mkMemRegisterSort(inst),
-                   m_metadata_map.at(WRITE)->mkMemRegisterSort(inst),
-                   m_metadata_map.at(ALLOC)->mkMemRegisterSort(inst));
+  return MemSortTy(
+      m_main.mkMemRegisterSort(inst),
+      m_metadata_map.at(MetadataKind::READ)->mkMemRegisterSort(inst),
+      m_metadata_map.at(MetadataKind::WRITE)->mkMemRegisterSort(inst),
+      m_metadata_map.at(MetadataKind::ALLOC)->mkMemRegisterSort(inst));
 }
 TrackingRawMemManager::PtrSortTy
 TrackingRawMemManager::mkPtrRegisterSort(const GlobalVariable &gv) const {
@@ -363,11 +377,11 @@ TrackingRawMemManager::mkStackPtr(unsigned int offset) {
   return m_main.mkStackPtr(offset);
 }
 unsigned int TrackingRawMemManager::getMetaDataMemWordSzInBits() {
-  assert(m_metadata_map.at(READ)->wordSzInBits() ==
-         m_metadata_map.at(WRITE)->wordSzInBits());
-  assert(m_metadata_map.at(READ)->wordSzInBits() ==
-         m_metadata_map.at(ALLOC)->wordSzInBits());
-  return m_metadata_map.at(READ)->wordSzInBits();
+  assert(m_metadata_map.at(MetadataKind::READ)->wordSzInBits() ==
+         m_metadata_map.at(MetadataKind::WRITE)->wordSzInBits());
+  assert(m_metadata_map.at(MetadataKind::READ)->wordSzInBits() ==
+         m_metadata_map.at(MetadataKind::ALLOC)->wordSzInBits());
+  return m_metadata_map.at(MetadataKind::READ)->wordSzInBits();
 }
 Expr TrackingRawMemManager::isMetadataSet(MetadataKind kind, PtrTy p,
                                           MemValTy mem) {

--- a/lib/seahorn/BvOpSem2TrackingRawMemMgr.cc
+++ b/lib/seahorn/BvOpSem2TrackingRawMemMgr.cc
@@ -257,7 +257,8 @@ TrackingRawMemManager::MemValTy
 TrackingRawMemManager::memsetMetaData(MetadataKind kind, PtrTy ptr, Expr len,
                                       MemValTy memIn, unsigned int val) {
   // make sure we can fit the supplied value in metadata memory slot
-  assert(llvm::Log2_64(val) + 1 <= g_MetadataBitWidth);
+  assert(llvm::Log2_64(val) + 1 <= g_MetadataBitWidth &&
+         "Metadata cannot fit!");
   return MemValTy(
       kind, memIn,
       m_metadata_map[kind]->MemSet(ptr, m_ctx.alu().ui(val, g_MetadataBitWidth),
@@ -269,7 +270,8 @@ TrackingRawMemManager::memsetMetaData(MetadataKind kind, PtrTy ptr,
                                       unsigned int len, MemValTy memIn,
                                       unsigned int val) {
   // make sure we can fit the supplied value in metadata memory slot
-  assert(llvm::Log2_64(val) + 1 <= g_MetadataBitWidth);
+  assert(llvm::Log2_64(val) + 1 <= g_MetadataBitWidth &&
+         "Metadata cannot fit!");
   return MemValTy(
       kind, memIn,
       m_metadata_map[kind]->MemSet(ptr, m_ctx.alu().ui(val, g_MetadataBitWidth),
@@ -278,6 +280,7 @@ TrackingRawMemManager::memsetMetaData(MetadataKind kind, PtrTy ptr,
 }
 Expr TrackingRawMemManager::getMetaData(MetadataKind kind, PtrTy ptr,
                                         MemValTy memIn, unsigned int byteSz) {
+  // TODO: expose a method in OpSemMemManager to loadAlignedWordFromMem
   return m_metadata_map.at(kind)->loadIntFromMem(
       ptr, memIn.getMetadata(kind), byteSz,
       m_metadata_map.at(kind)->wordSizeInBytes());

--- a/lib/seahorn/BvOpSem2WideMemMgr.cc
+++ b/lib/seahorn/BvOpSem2WideMemMgr.cc
@@ -74,10 +74,6 @@ WideMemManager::MemValTy WideMemManager::zeroedMemory() const {
   return MemValTy(m_main.zeroedMemory(), m_size.zeroedMemory());
 }
 
-WideMemManager::MemValTy WideMemManager::setMemory(unsigned int val) const {
-  return MemValTy(m_main.setMemory(val), m_size.setMemory(val));
-}
-
 std::pair<char *, unsigned int>
 WideMemManager::getGlobalVariableInitValue(const GlobalVariable &gv) {
   return m_main.getGlobalVariableInitValue(gv);

--- a/lib/seahorn/BvOpSem2WideMemMgr.cc
+++ b/lib/seahorn/BvOpSem2WideMemMgr.cc
@@ -73,6 +73,11 @@ Expr WideMemManager::isDereferenceable(WideMemManager::PtrTy p, Expr byteSz) {
 WideMemManager::MemValTy WideMemManager::zeroedMemory() const {
   return MemValTy(m_main.zeroedMemory(), m_size.zeroedMemory());
 }
+
+WideMemManager::MemValTy WideMemManager::setMemory(unsigned int val) const {
+  return MemValTy(m_main.setMemory(val), m_size.setMemory(val));
+}
+
 std::pair<char *, unsigned int>
 WideMemManager::getGlobalVariableInitValue(const GlobalVariable &gv) {
   return m_main.getGlobalVariableInitValue(gv);

--- a/lib/seahorn/BvOpSem2WideMemMgr.hh
+++ b/lib/seahorn/BvOpSem2WideMemMgr.hh
@@ -29,6 +29,7 @@ public:
   // setting TrackingTag to int disqualifies this class as having tracking
   using TrackingTag = int;
   using FatMemTag = int;
+  using WideMemTag = MemoryFeatures::WideMem_tag;
 
   using RawPtrTy = OpSemMemManager::PtrTy;
   using RawMemValTy = OpSemMemManager::MemValTy;
@@ -245,8 +246,6 @@ public:
   getGlobalVariableInitValue(const GlobalVariable &gv);
 
   MemValTy zeroedMemory() const;
-
-  MemValTy setMemory(unsigned int val) const;
 
   Expr isDereferenceable(PtrTy p, Expr byteSz);
 

--- a/lib/seahorn/BvOpSem2WideMemMgr.hh
+++ b/lib/seahorn/BvOpSem2WideMemMgr.hh
@@ -246,6 +246,8 @@ public:
 
   MemValTy zeroedMemory() const;
 
+  MemValTy setMemory(unsigned int val) const;
+
   Expr isDereferenceable(PtrTy p, Expr byteSz);
 
   RawPtrTy getAddressable(PtrTy p) const;

--- a/lib/seahorn/DfCoiAnalysis.cc
+++ b/lib/seahorn/DfCoiAnalysis.cc
@@ -42,9 +42,10 @@ void DfCoiAnalysis::analyze(User &user) {
           assert(it != CI->getParent()->end());
           workList.push_back(&*it);
         } else if (CS.getCalledFunction()->getName().equals(
-                       "sea.is_modified")) {
+                       "sea.is_modified") ||
+                   (CS.getCalledFunction()->getName().equals("sea.is_alloc"))) {
           //  instruction that precedes has to be
-          //  1. shadowmem.load load
+          //  1. shadowmem.load
           BasicBlock::iterator it(CI);
           --it;
           if (auto *CI = dyn_cast<CallInst>(&*it)) {
@@ -52,9 +53,10 @@ void DfCoiAnalysis::analyze(User &user) {
             assert(CS.getCalledFunction()->getName().equals("shadow.mem.load"));
             workList.push_back(&*it);
           } else if (CS.getCalledFunction()->getName().equals(
-                         "sea.reset_modified")) {
+                         "sea.reset_modified") ||
+                     (CS.getCalledFunction()->getName().equals("sea.free"))) {
             //  instruction that precedes has to be
-            //  1. shadowmem.store load
+            //  1. shadowmem.store
             BasicBlock::iterator it(CI);
             --it;
             if (auto *CI = dyn_cast<CallInst>(&*it)) {

--- a/py/sea/commands.py
+++ b/py/sea/commands.py
@@ -1,11 +1,8 @@
-import sea
-
 import os.path
-import sys
+import sea
 import shutil
-
 import subprocess
-
+import sys
 from sea import add_in_args, add_in_out_args, add_tmp_dir_args, add_bool_argument, which, createWorkDir
 
 # To disable printing of commands and some warnings
@@ -1168,7 +1165,7 @@ class Seahorn(sea.LimitedCmd):
                 argv.append('--horn-bv2')
                 argv.append('--log=opsem')
                 argv.append('--lower-gv-init-struct=false')
-
+                argv.append('--horn-shadow-mem-alloc-is-def')
         if args.crab:
             argv.append ('--horn-crab')
 
@@ -1366,7 +1363,6 @@ class LegacyFrontEnd (sea.LimitedCmd):
             print ('Only supported on Linux')
             return 1
 
-        import subprocess
         self.lfeCmd = sea.ExtCmd (cmd_name,'',quiet)
 
         argv = ['--no-seahorn', '-o', args.out_file]

--- a/test/mcfuzz/issue_50.c
+++ b/test/mcfuzz/issue_50.c
@@ -1,8 +1,8 @@
-// RUN: %sea bpf -m32 -O0 --bmc=mono --horn-bv2=true --inline --bound=8 --keep-shadows=true --horn-stats --log=opsem "%s" 2>&1 | OutputCheck %s
-// RUN: %sea bpf -m32 -O3 --bmc=mono --horn-bv2=true --inline --bound=8 --keep-shadows=true --horn-stats --log=opsem "%s" 2>&1 | OutputCheck %s
+// RUN: %sea bpf -m32 -O0 --bmc=mono --horn-bv2=true --inline --bound=8 --keep-shadows=true --horn-stats --log=opsem --horn-shadow-mem-alloc-is-def  "%s" 2>&1 | OutputCheck %s
+// RUN: %sea bpf -m32 -O3 --bmc=mono --horn-bv2=true --inline --bound=8 --keep-shadows=true --horn-stats --log=opsem --horn-shadow-mem-alloc-is-def "%s" 2>&1 | OutputCheck %s
 
-// RUN: %sea bpf -m64 -O0 --bmc=mono --inline --bound=8 --keep-shadows=true --horn-stats --log=opsem "%s" 2>&1 | OutputCheck %s --check-prefix=OLD
-// RUN: %sea bpf -m64 -O3 --bmc=mono --inline --bound=8 --keep-shadows=true --horn-stats --log=opsem "%s" 2>&1 | OutputCheck %s --check-prefix=OLD
+// RUN: %sea bpf -m64 -O0 --bmc=mono --inline --bound=8 --keep-shadows=true --horn-stats --log=opsem --horn-shadow-mem-alloc-is-def "%s" 2>&1 | OutputCheck %s --check-prefix=OLD
+// RUN: %sea bpf -m64 -O3 --bmc=mono --inline --bound=8 --keep-shadows=true --horn-stats --log=opsem --horn-shadow-mem-alloc-is-def "%s" 2>&1 | OutputCheck %s --check-prefix=OLD
 
 // CHECK-L: unsat
 // OLD-L: sat

--- a/test/opsem/lit.cfg
+++ b/test/opsem/lit.cfg
@@ -62,14 +62,16 @@ if not isexec(seahorn_cmd):
 
 config.substitutions.append(('%seahorn', seahorn_cmd))
 seabmc = [seahorn_cmd, '--horn-bmc-engine=mono',
-          '--horn-bmc', '--horn-bv2=true', '--log=opsem',
+          '--horn-bmc', '--horn-shadow-mem-alloc-is-def', '--horn-bv2=true', '--log=opsem',
           '--keep-shadows=true', '--horn-solve'] + [opsem_extra_params]         
 # no --horn-solve
-seasmt = [seahorn_cmd, '--horn-bmc-engine=mono',   
+seasmt = [seahorn_cmd, '--horn-bmc-engine=mono',
+          '--horn-shadow-mem-alloc-is-def',
           '--horn-bmc', '--horn-bv2=true', '--log=opsem',
           '--keep-shadows=true' ]
 sea = [sea_cmd, 'bpf', '--horn-bmc-engine=mono',
        '--horn-bmc', '--horn-bv2=true', '--log=opsem',
+       '--horn-shadow-mem-alloc-is-def'
       ]
 config.substitutions.append(('%seabmc', ' '.join(seabmc)))
 config.substitutions.append(('%seasmt', ' '.join(seasmt)))

--- a/test/opsem2/lit.cfg
+++ b/test/opsem2/lit.cfg
@@ -69,8 +69,7 @@ seasmt = [seahorn_cmd, '--horn-bmc-engine=mono',
           '--horn-bmc', '--horn-bv2=true', '--log=opsem',
           '--keep-shadows=true' ]
 sea = [sea_cmd, 'bpf', '--horn-bmc-engine=mono',
-       '--horn-bmc', '--horn-bv2=true', '--log=opsem',
-       '--horn-bv2-vacuity-check=all'
+       '--bmc=opsem', '--horn-bv2-vacuity-check=all'
       ]
 config.substitutions.append(('%seabmc', ' '.join(seabmc)))
 config.substitutions.append(('%seasmt', ' '.join(seasmt)))

--- a/test/opsem2/trackingmem/freed_sat.c
+++ b/test/opsem2/trackingmem/freed_sat.c
@@ -1,0 +1,19 @@
+//; RUN: %sea "%s" --horn-bv2-extra-widemem --horn-bv2-tracking-mem 2>&1 | OutputCheck %s
+// CHECK: ^sat$
+
+#include "seahorn/seahorn.h"
+#include <stdlib.h>
+
+extern void sea_reset_modified(char *);
+extern bool sea_is_alloc(char *);
+extern void sea_tracking_on();
+extern void sea_tracking_off();
+
+extern int nd_int();
+int main() {
+  sea_tracking_on();
+  int *a = malloc(1024);
+  *a = nd_int();
+  sassert(!sea_is_alloc((char *) a));
+  return 0;
+}

--- a/test/opsem2/trackingmem/freed_unsat.c
+++ b/test/opsem2/trackingmem/freed_unsat.c
@@ -9,13 +9,15 @@ extern void sea_reset_modified(char *);
 extern bool sea_is_alloc(char *);
 extern void sea_tracking_on();
 extern void sea_tracking_off();
+extern void sea_free(char *);
 
 extern int nd_int();
+
 int main() {
   sea_tracking_on();
   int *a = malloc(1024);
   *a = nd_int();
-  free(a);
+  sea_free((char *)a);
   sassert(!sea_is_alloc((char *) a));
   return 0;
 }

--- a/test/opsem2/trackingmem/freed_unsat.c
+++ b/test/opsem2/trackingmem/freed_unsat.c
@@ -1,0 +1,21 @@
+//; RUN: %sea "%s" --horn-bv2-extra-widemem --horn-bv2-tracking-mem 2>&1 | OutputCheck %s
+// CHECK: ^unsat$
+// This test mainly checks that we can write multiple metadata about tracking
+// memory independently of each other.
+#include "seahorn/seahorn.h"
+#include <stdlib.h>
+
+extern void sea_reset_modified(char *);
+extern bool sea_is_alloc(char *);
+extern void sea_tracking_on();
+extern void sea_tracking_off();
+
+extern int nd_int();
+int main() {
+  sea_tracking_on();
+  int *a = malloc(1024);
+  *a = nd_int();
+  free(a);
+  sassert(!sea_is_alloc((char *) a));
+  return 0;
+}

--- a/test/opsem2/trackingmem/written_free_unsat.c
+++ b/test/opsem2/trackingmem/written_free_unsat.c
@@ -10,6 +10,7 @@ extern bool sea_is_alloc(char *);
 extern void sea_tracking_on();
 extern void sea_tracking_off();
 extern bool sea_is_modified(char *);
+extern void sea_free(char *);
 
 extern int nd_int();
 
@@ -17,7 +18,7 @@ int main() {
   sea_tracking_on();
   int *a = malloc(1024);
   *a = nd_int();
-  free(a);
+  sea_free((char *)a);
   sassert(!sea_is_alloc((char *) a));
   sassert(sea_is_modified((char *) a));
   return 0;

--- a/test/opsem2/trackingmem/written_free_unsat.c
+++ b/test/opsem2/trackingmem/written_free_unsat.c
@@ -1,0 +1,24 @@
+//; RUN: %sea "%s" --horn-bv2-extra-widemem --horn-bv2-tracking-mem 2>&1 | OutputCheck %s
+// CHECK: ^unsat$
+
+// This test exists to
+#include "seahorn/seahorn.h"
+#include <stdlib.h>
+
+extern void sea_reset_modified(char *);
+extern bool sea_is_alloc(char *);
+extern void sea_tracking_on();
+extern void sea_tracking_off();
+extern bool sea_is_modified(char *);
+
+extern int nd_int();
+
+int main() {
+  sea_tracking_on();
+  int *a = malloc(1024);
+  *a = nd_int();
+  free(a);
+  sassert(!sea_is_alloc((char *) a));
+  sassert(sea_is_modified((char *) a));
+  return 0;
+}

--- a/tools/seahorn/seahorn.cpp
+++ b/tools/seahorn/seahorn.cpp
@@ -316,8 +316,8 @@ int main(int argc, char **argv) {
   }
   pass_manager.add(new seahorn::RemoveUnreachableBlocksPass());
 
-  pass_manager.add(seahorn::createPromoteVerifierCallsPass());
   pass_manager.add(seahorn::createPromoteMallocPass());
+  pass_manager.add(seahorn::createPromoteVerifierCallsPass());
 
   // -- attempt to lower any left sea.is_dereferenceable()
   // -- they might be preventing some register promotion

--- a/tools/seahorn/seahorn.cpp
+++ b/tools/seahorn/seahorn.cpp
@@ -316,8 +316,8 @@ int main(int argc, char **argv) {
   }
   pass_manager.add(new seahorn::RemoveUnreachableBlocksPass());
 
-  pass_manager.add(seahorn::createPromoteMallocPass());
   pass_manager.add(seahorn::createPromoteVerifierCallsPass());
+  pass_manager.add(seahorn::createPromoteMallocPass());
 
   // -- attempt to lower any left sea.is_dereferenceable()
   // -- they might be preventing some register promotion


### PR DESCRIPTION
1. Generalize Tracking memory managers to track read, writes and allocations.

2. Add builtins for
isRead(...)
resetRead(...)
isAlloc(...)
free(...)

3. read instructions are currently not wired in opsem