### PR TITLE
refactor(cex): cleanup new cex gen system; add tests and python pipeline

### DIFF
--- a/.github/workflows/test-seahorn-docker.yml
+++ b/.github/workflows/test-seahorn-docker.yml
@@ -39,5 +39,8 @@ jobs:
       - name: Run mcfuzz tests
         run: docker run -v $(pwd):/host seahorn_container /bin/bash -c "cd seahorn/share/seahorn && lit -a --time-tests --max-time=1200 test/mcfuzz"
       - name: Run smc tests
-        run: docker run -v $(pwd):/host seahorn_container /bin/bash -c "cd seahorn/share/seahorn && lit -a --time-tests --max-time=1200 test/smc" 
-
+        run: docker run -v $(pwd):/host seahorn_container /bin/bash -c "cd seahorn/share/seahorn && lit -a --time-tests --max-time=1200 test/smc"
+      - name: Run cex tests
+        run: docker run -v $(pwd):/host seahorn_container /bin/bash -c "cd seahorn/share/seahorn && lit -a --time-tests --max-time=1200 test/cex"
+      - name: Run cex tests with new cexgen
+        run: docker run -v $(pwd):/host seahorn_container /bin/bash -c "cd seahorn/share/seahorn && lit -a --time-tests --max-time=1200 -D cex_bmc_opts=--horn-bmc-cexgen test/cex"

--- a/include/seahorn/Bmc.hh
+++ b/include/seahorn/Bmc.hh
@@ -111,6 +111,13 @@ public:
     return m_semCtx->ptrToAddr(e);
   }
 
+  // given an Expr encoding of memory map, return only the raw mem part
+  Expr getRawMem(Expr e) {
+    if (!m_semCtx)
+      return Expr();
+    return m_semCtx->getRawMem(e);
+  }
+
   /// Dump unsat core
   /// Exposes internal details. Intendent to be used for debugging only
   virtual void unsatCore(ExprVector &out);

--- a/include/seahorn/BmcImpl.hh
+++ b/include/seahorn/BmcImpl.hh
@@ -126,6 +126,10 @@ Expr BmcTrace<Engine, Model>::symb(unsigned loc, const llvm::Value &val) {
 template <class Engine, class Model>
 Expr BmcTrace<Engine, Model>::eval(unsigned loc, const llvm::Value &inst,
                                    bool complete) {
+  if (auto *constInt = dyn_cast<ConstantInt>(&inst)) {
+    expr::mpz_class constIntVal = toMpz(constInt);
+    return expr::mkTerm<expr::mpz_class>(constIntVal, engine().efac());
+  }
   Expr v = symb(loc, inst);
   if (v)
     v = m_model->eval(v, complete);

--- a/include/seahorn/OperationalSemantics.hh
+++ b/include/seahorn/OperationalSemantics.hh
@@ -153,6 +153,9 @@ public:
   /// \brief Given Expr encoding of a ptr \p p, extract and return addressable
   /// part only
   virtual Expr ptrToAddr(Expr p) { return p; }
+
+  /// \brief Given Expr encoding of a mem map \p p, extract raw mem part only
+  virtual Expr getRawMem(Expr p) { return p; }
 };
 
 /// \brief Tracks information about a function

--- a/include/seahorn/SolverBmc.hh
+++ b/include/seahorn/SolverBmc.hh
@@ -94,6 +94,12 @@ public:
     return m_semCtx->ptrToAddr(e);
   }
 
+  Expr getRawMem(Expr e) {
+    if (!m_semCtx)
+      return Expr();
+    return m_semCtx->getRawMem(e);
+  }
+
   /// output current path condition in SMT-LIB2 format
   virtual raw_ostream &toSmtLib(raw_ostream &out);
 

--- a/lib/seahorn/BvOpSem2.cc
+++ b/lib/seahorn/BvOpSem2.cc
@@ -2603,6 +2603,8 @@ boost::tribool Bv2OpSemContext::solve() { return m_z3_solver->solve(); }
 
 Expr Bv2OpSemContext::ptrToAddr(Expr p) { return mem().ptrToAddr(p); }
 
+Expr Bv2OpSemContext::getRawMem(Expr p) { return mem().getRawMem(p); }
+
 } // namespace details
 
 Bv2OpSem::Bv2OpSem(ExprFactory &efac, Pass &pass, const DataLayout &dl,

--- a/lib/seahorn/BvOpSem2Context.hh
+++ b/lib/seahorn/BvOpSem2Context.hh
@@ -333,6 +333,8 @@ public:
 
   Expr ptrToAddr(Expr p) override;
 
+  Expr getRawMem(Expr p) override;
+
   void resetSolver();
   void addToSolver(const Expr e);
   boost::tribool solve();
@@ -729,6 +731,14 @@ public:
   /// \brief given a properly encoded pointer Expr \p p , return the raw
   /// expression representing memory address only
   virtual Expr ptrToAddr(Expr p) = 0;
+
+  /// \brief given an Expression \p e , return true if \p e has expected
+  /// encoding of a MemValTy
+  virtual bool isMemVal(Expr e) = 0;
+
+  /// \brief given a properly encoded memory map Expr \p p , return the base
+  /// expression representing raw memory only
+  virtual Expr getRawMem(Expr p) = 0;
 };
 
 OpSemMemManager *mkRawMemManager(Bv2OpSem &sem, Bv2OpSemContext &ctx,

--- a/lib/seahorn/BvOpSem2Context.hh
+++ b/lib/seahorn/BvOpSem2Context.hh
@@ -724,17 +724,9 @@ public:
   /// \brief reset memory modified state; used in conjuction with isModified
   virtual MemValTy resetModified(PtrTy p, MemValTy mem) = 0;
 
-  /// \brief given an Expression \p e , return true if \p e has expected
-  /// encoding of a PtrTyImpl
-  virtual bool isPtrTyVal(Expr e) = 0;
-
   /// \brief given a properly encoded pointer Expr \p p , return the raw
   /// expression representing memory address only
   virtual Expr ptrToAddr(Expr p) = 0;
-
-  /// \brief given an Expression \p e , return true if \p e has expected
-  /// encoding of a MemValTy
-  virtual bool isMemVal(Expr e) = 0;
 
   /// \brief given a properly encoded memory map Expr \p p , return the base
   /// expression representing raw memory only

--- a/lib/seahorn/BvOpSem2ExtraWideMemMgr.cc
+++ b/lib/seahorn/BvOpSem2ExtraWideMemMgr.cc
@@ -106,12 +106,12 @@ ExtraWideMemManager<T>::getAddressable(ExtraWideMemManager::PtrTy p) const {
 }
 
 template <class T> bool ExtraWideMemManager<T>::isPtrTyVal(Expr e) const {
-  return strct::isStructVal(e) && e->arity() == g_num_slots;
+  return e && strct::isStructVal(e) && e->arity() == g_num_slots;
 }
 
 template <class T> bool ExtraWideMemManager<T>::isMemVal(Expr e) const {
   // Our base is a struct of three exprs
-  return strct::isStructVal(e) && e->arity() == 3;
+  return e && strct::isStructVal(e) && e->arity() == g_num_slots;
 }
 
 template <class T>

--- a/lib/seahorn/BvOpSem2ExtraWideMemMgr.cc
+++ b/lib/seahorn/BvOpSem2ExtraWideMemMgr.cc
@@ -109,6 +109,11 @@ template <class T> bool ExtraWideMemManager<T>::isPtrTyVal(Expr e) const {
   return strct::isStructVal(e) && e->arity() == g_num_slots;
 }
 
+template <class T> bool ExtraWideMemManager<T>::isMemVal(Expr e) const {
+  // Our base is a struct of three exprs
+  return strct::isStructVal(e) && e->arity() == 3;
+}
+
 template <class T>
 Expr ExtraWideMemManager<T>::isDereferenceable(ExtraWideMemManager::PtrTy p,
                                                Expr byteSz) {

--- a/lib/seahorn/BvOpSem2ExtraWideMemMgr.hh
+++ b/lib/seahorn/BvOpSem2ExtraWideMemMgr.hh
@@ -297,6 +297,8 @@ public:
 
   bool isPtrTyVal(Expr e) const;
 
+  bool isMemVal(Expr e) const;
+
   Expr getSize(PtrTy p) const;
 
   const OpSemMemManager &getMainMemMgr() const;

--- a/lib/seahorn/BvOpSem2FatMemMgr.cc
+++ b/lib/seahorn/BvOpSem2FatMemMgr.cc
@@ -580,12 +580,12 @@ public:
 
   bool isPtrTyVal(Expr e) const {
     // struct with raw ptr + fat slots
-    return strct::isStructVal(e) && e->arity() <= (1 + g_maxFatSlots);
+    return e && strct::isStructVal(e) && e->arity() <= (1 + g_maxFatSlots);
   }
 
   bool isMemVal(Expr e) const {
-    // struct with 3 fields
-    return (strct::isStructVal(e) && e->arity() == 3);
+    // struct with raw ptr + fat slots
+    return e && strct::isStructVal(e) && e->arity() == (1 + g_maxFatSlots);
   }
 };
 

--- a/lib/seahorn/BvOpSem2FatMemMgr.cc
+++ b/lib/seahorn/BvOpSem2FatMemMgr.cc
@@ -45,6 +45,7 @@ public:
     Expr v() const { return m_v; }
     Expr toExpr() const { return v(); }
     explicit operator Expr() const { return toExpr(); }
+    Expr getRaw() { return strct::extractVal(m_v, 0); }
   };
 
   using FatMemTag = MemoryFeatures::FatMem_tag;
@@ -580,6 +581,11 @@ public:
   bool isPtrTyVal(Expr e) const {
     // struct with raw ptr + fat slots
     return strct::isStructVal(e) && e->arity() <= (1 + g_maxFatSlots);
+  }
+
+  bool isMemVal(Expr e) const {
+    // struct with 3 fields
+    return (strct::isStructVal(e) && e->arity() == 3);
   }
 };
 

--- a/lib/seahorn/BvOpSem2FatMemMgr.cc
+++ b/lib/seahorn/BvOpSem2FatMemMgr.cc
@@ -580,7 +580,7 @@ public:
 
   bool isPtrTyVal(Expr e) const {
     // struct with raw ptr + fat slots
-    return e && strct::isStructVal(e) && e->arity() <= (1 + g_maxFatSlots);
+    return e && strct::isStructVal(e) && e->arity() == (1 + g_maxFatSlots);
   }
 
   bool isMemVal(Expr e) const {

--- a/lib/seahorn/BvOpSem2MemManagerMixin.hh
+++ b/lib/seahorn/BvOpSem2MemManagerMixin.hh
@@ -415,6 +415,14 @@ public:
       return Expr();
     return Expr(base().getAddressable(BasePtrTy(p)));
   }
+
+  bool isMemVal(Expr e) { return base().isMemVal(e); }
+
+  Expr getRawMem(Expr e) {
+    if (!isMemVal(e))
+      return Expr();
+    return Expr(BaseMemValTy(e).getRaw());
+  }
 };
 } // namespace details
 } // namespace seahorn

--- a/lib/seahorn/BvOpSem2RawMemMgr.cc
+++ b/lib/seahorn/BvOpSem2RawMemMgr.cc
@@ -814,11 +814,11 @@ RawMemManagerCore::getGlobalVariableInitValue(const GlobalVariable &gv) {
 }
 
 bool RawMemManagerCore::isPtrTyVal(Expr e) {
-  return (!e || !strct::isStructVal(e));
+  return (e && !strct::isStructVal(e));
 }
 
 bool RawMemManagerCore::isMemVal(Expr e) {
-  return (!e || !strct::isStructVal(e));
+  return (e && !strct::isStructVal(e));
 }
 
 } // namespace details

--- a/lib/seahorn/BvOpSem2RawMemMgr.cc
+++ b/lib/seahorn/BvOpSem2RawMemMgr.cc
@@ -817,5 +817,9 @@ bool RawMemManagerCore::isPtrTyVal(Expr e) {
   return (!e || !strct::isStructVal(e));
 }
 
+bool RawMemManagerCore::isMemVal(Expr e) {
+  return (!e || !strct::isStructVal(e));
+}
+
 } // namespace details
 } // namespace seahorn

--- a/lib/seahorn/BvOpSem2RawMemMgr.hh
+++ b/lib/seahorn/BvOpSem2RawMemMgr.hh
@@ -357,6 +357,8 @@ public:
 
   bool isPtrTyVal(Expr e);
 
+  bool isMemVal(Expr e);
+
   MemValTy resetModified(PtrTy p, MemValTy mem);
 
   PtrTy getAddressable(PtrTy p);

--- a/lib/seahorn/BvOpSem2TrackingRawMemMgr.cc
+++ b/lib/seahorn/BvOpSem2TrackingRawMemMgr.cc
@@ -35,6 +35,11 @@ bool TrackingRawMemManager::isPtrTyVal(Expr e) const {
   return !e || !strct::isStructVal(e);
 }
 
+bool TrackingRawMemManager::isMemVal(Expr e) const {
+  // raw and metadata
+  return strct::isStructVal(e) && e->arity() == 2;
+}
+
 Expr TrackingRawMemManager::isDereferenceable(TrackingRawMemManager::PtrTy p,
                                               Expr byteSz) {
   // isDereferenceable should never be called in a 'RawMemMgr'

--- a/lib/seahorn/BvOpSem2TrackingRawMemMgr.cc
+++ b/lib/seahorn/BvOpSem2TrackingRawMemMgr.cc
@@ -32,12 +32,12 @@ TrackingRawMemManager::getAddressable(TrackingRawMemManager::PtrTy p) const {
 
 bool TrackingRawMemManager::isPtrTyVal(Expr e) const {
   // same PtrTy as RawMemManager
-  return !e || !strct::isStructVal(e);
+  return e && !strct::isStructVal(e);
 }
 
 bool TrackingRawMemManager::isMemVal(Expr e) const {
   // raw and metadata
-  return strct::isStructVal(e) && e->arity() == 2;
+  return e && strct::isStructVal(e) && e->arity() == g_num_slots;
 }
 
 Expr TrackingRawMemManager::isDereferenceable(TrackingRawMemManager::PtrTy p,

--- a/lib/seahorn/BvOpSem2TrackingRawMemMgr.hh
+++ b/lib/seahorn/BvOpSem2TrackingRawMemMgr.hh
@@ -231,6 +231,8 @@ public:
 
   bool isPtrTyVal(Expr e) const;
 
+  bool isMemVal(Expr e) const;
+
   Expr isModified(PtrTy p, MemValTy mem);
 
   MemValTy resetModified(PtrTy p, MemValTy mem);

--- a/lib/seahorn/BvOpSem2WideMemMgr.cc
+++ b/lib/seahorn/BvOpSem2WideMemMgr.cc
@@ -480,12 +480,12 @@ Expr WideMemManager::ptrSub(WideMemManager::PtrTy p1,
 }
 
 bool WideMemManager::isPtrTyVal(Expr e) const {
-  return strct::isStructVal(e) && e->arity() == g_num_slots;
+  return e && strct::isStructVal(e) && e->arity() == g_num_slots;
 }
 
 bool WideMemManager::isMemVal(Expr e) const {
   // struct of raw and size
-  return strct::isStructVal(e) && e->arity() == 2;
+  return e && strct::isStructVal(e) && e->arity() == g_num_slots;
 }
 
 OpSemMemManager *mkWideMemManager(Bv2OpSem &sem, Bv2OpSemContext &ctx,

--- a/lib/seahorn/BvOpSem2WideMemMgr.cc
+++ b/lib/seahorn/BvOpSem2WideMemMgr.cc
@@ -483,6 +483,11 @@ bool WideMemManager::isPtrTyVal(Expr e) const {
   return strct::isStructVal(e) && e->arity() == g_num_slots;
 }
 
+bool WideMemManager::isMemVal(Expr e) const {
+  // struct of raw and size
+  return strct::isStructVal(e) && e->arity() == 2;
+}
+
 OpSemMemManager *mkWideMemManager(Bv2OpSem &sem, Bv2OpSemContext &ctx,
                                   unsigned ptrSz, unsigned wordSz,
                                   bool useLambdas) {

--- a/lib/seahorn/BvOpSem2WideMemMgr.hh
+++ b/lib/seahorn/BvOpSem2WideMemMgr.hh
@@ -252,6 +252,8 @@ public:
 
   bool isPtrTyVal(Expr e) const;
 
+  bool isMemVal(Expr e) const;
+
   Expr getSize(PtrTy p);
 
   const OpSemMemManager &getMainMemMgr() const;

--- a/lib/seahorn/CexExeGenerator.cc
+++ b/lib/seahorn/CexExeGenerator.cc
@@ -77,11 +77,8 @@ public:
       // get memhavoc size from second operand of memhavoc
       const Value *sizeArg = CS.getArgOperand(1);
       Expr size;
-      if (auto *sizeI = dyn_cast<Instruction>(sizeArg)) {
-        size = m_cex.trace().eval(m_loc, *sizeI, true);
-      } else if (auto *sizeConst = dyn_cast<ConstantInt>(sizeArg)) {
-        expr::mpz_class sz = toMpz(sizeConst);
-        size = expr::mkTerm<expr::mpz_class>(sz, m_cex.trace().engine().efac());
+      if (isa<Instruction>(sizeArg) || isa<ConstantInt>(sizeArg)) {
+        size = m_cex.trace().eval(m_loc, *sizeArg, true);
       } else {
         LOG("cex",
             ERR << "unhandled Value of memhavoc size: " << *sizeArg << "\n");

--- a/lib/seahorn/CexExeGenerator.cc
+++ b/lib/seahorn/CexExeGenerator.cc
@@ -37,122 +37,129 @@ bool extractArrayContents(Expr e, kv &out, Expr &defaultValue) {
   }
   return true;
 }
+
+/* InstVisitor that visits all CallSites in a Bmc Trace;
+  if the CallSite calls an external non-deterministic function that needs to
+  be synthesized, push evaluated function return value or modifed pointer value
+  into Cex generator
+ */
+template <class Trace>
+class BmcTraceVisitor : public InstVisitor<BmcTraceVisitor<Trace>> {
+  CexExeGenerator<Trace> &m_cex;
+  unsigned m_loc;
+
+public:
+  BmcTraceVisitor(CexExeGenerator<Trace> &cex) : m_cex(cex) {}
+
+  void setLoc(unsigned loc) { m_loc = loc; }
+
+  void visitMemhavoc(CallSite CS) {
+    Instruction &I = *CS.getInstruction();
+    auto *CF = getCalledFunction(CS);
+    // previous instruction should be
+    // shadow.mem.load(i32 x, i32 %sm_n, i8* null)
+    auto *prevI = I.getPrevNonDebugInstruction();
+    if (!prevI)
+      return;
+    if (const CallInst *prevCI = dyn_cast<CallInst>(prevI)) {
+      ImmutableCallSite prevCS(prevCI);
+      const Function *prevF = prevCS.getCalledFunction();
+      if (!(prevF && prevF->getName().equals("shadow.mem.load"))) {
+        LOG("cex", ERR << "Skipping harness for memhavoc"
+                       << " because shadow.mem.load cannot be found\n");
+        return;
+      }
+      // get memhavoc content from corresponding shadow mem region
+      auto *shadowMemI = dyn_cast<Instruction>(prevCS.getArgOperand(1));
+      if (!shadowMemI)
+        return;
+      Expr shadowMem = m_cex.trace().eval(m_loc, *shadowMemI, true);
+      // get memhavoc size from second operand of memhavoc
+      const Value *sizeArg = CS.getArgOperand(1);
+      Expr size;
+      if (auto *sizeI = dyn_cast<Instruction>(sizeArg)) {
+        size = m_cex.trace().eval(m_loc, *sizeI, true);
+      } else if (auto *sizeConst = dyn_cast<ConstantInt>(sizeArg)) {
+        size = m_cex.trace().eval(m_loc, *sizeConst, true);
+      } else {
+        LOG("cex",
+            ERR << "unhandled Value of memhavoc size: " << *sizeArg << "\n");
+        return;
+      }
+      // get info of ptr to havoc
+      const Value *hPtrAlloc = CS.getArgOperand(0)->stripPointerCasts();
+      Expr hPtrStart;
+      if (auto *hPtrAllocInst = dyn_cast<Instruction>(hPtrAlloc)) {
+        hPtrStart = m_cex.trace().eval(m_loc, *hPtrAllocInst, true);
+      } else {
+        LOG("cex",
+            ERR << "unhandled Value of memhavoc ptr: " << *hPtrAlloc << "\n");
+        return;
+      }
+      Expr shadowMemRaw = m_cex.trace().engine().getPtrAddressable(shadowMem);
+      Expr hPtrStartRaw = m_cex.trace().engine().getPtrAddressable(hPtrStart);
+      if (!shadowMemRaw || !hPtrStartRaw || !size) {
+        LOG("cex",
+            ERR << "Skipping harness for memhavoc due to lacking info \n");
+        return;
+      }
+      LOG("cex", INFO << "Producing harness for " << CF->getName() << "\n";);
+      m_cex.addValueToFunc(CF, shadowMemRaw);
+      m_cex.addNonDetPtr(hPtrStartRaw, size);
+    }
+  }
+
+  void visitCallSite(CallSite CS) {
+    Instruction &I = *CS.getInstruction();
+    const Function *CF = getCalledFunction(CS);
+
+    if (!CF->hasName())
+      return;
+
+    if (CF->getName().equals("memhavoc")) {
+      visitMemhavoc(CS);
+      return;
+    }
+
+    if (CF->isIntrinsic())
+      return;
+    // We want to ignore seahorn functions, but not nondet
+    // functions created by strip-extern or dummyMainFunction
+    if (CF->getName().find_first_of('.') != StringRef::npos &&
+        !CF->getName().startswith("verifier.nondet"))
+      return;
+    if (!CF->isExternalLinkage(CF->getLinkage()))
+      return;
+    if (!CF->getReturnType()->isIntegerTy() &&
+        !CF->getReturnType()->isPointerTy()) {
+      return;
+    }
+
+    // KleeInternalize
+    if (CF->getName().equals("calloc"))
+      return;
+
+    // -- known library function
+    LibFunc libfn;
+    if (m_cex.getTargetLibraryInfo().getLibFunc(CF->getName(), libfn))
+      return;
+
+    Expr V = m_cex.trace().eval(m_loc, I, true);
+    if (!V)
+      return;
+    LOG("cex", INFO << "Producing harness for " << CF->getName() << "\n";);
+    m_cex.addValueToFunc(CF, V);
+  }
+};
+
 } // namespace utils
 
-template <class Trace>
-void CexExeGenerator<Trace>::storeMemHavoc(unsigned loc, const Function *func,
-                                           ImmutableCallSite cs,
-                                           ImmutableCallSite prevCS) {
-  const Value *prevCV = prevCS.getCalledValue();
-  const Function *prevF = dyn_cast<Function>(prevCV->stripPointerCasts());
-  if (!(prevF && prevF->getName().equals("shadow.mem.load"))) {
-    LOG("cex", errs() << "Skipping harness for memhavoc"
-                      << " because shadow.mem.load cannot be found\n");
-    return;
-  }
-  // get memhavoc content from corresponding shadow mem region
-  auto *shadowMemI = dyn_cast<Instruction>(prevCS.getArgOperand(1));
-  if (!shadowMemI)
-    return;
-  Expr shadowMem = m_trace.eval(loc, *shadowMemI, true);
-  // get memhavoc size from second operand of memhavoc
-  const Value *sizeArg = cs.getArgOperand(1);
-  Expr size;
-  if (auto *sizeI = dyn_cast<Instruction>(sizeArg)) {
-    size = m_trace.eval(loc, *sizeI, true);
-  } else if (auto *sizeConst = dyn_cast<ConstantInt>(sizeArg)) {
-    expr::mpz_class sz = toMpz(sizeConst);
-    size = expr::mkTerm<expr::mpz_class>(sz, m_trace.engine().efac());
-  } else {
-    LOG("cex",
-        errs() << "unhandled Value of memhavoc size: " << *sizeArg << "\n");
-    return;
-  }
-  // get info of ptr to havoc
-  const Value *hPtrAlloc = cs.getArgOperand(0)->stripPointerCasts();
-  Expr hPtrStart;
-  if (auto *hPtrAllocInst = dyn_cast<Instruction>(hPtrAlloc)) {
-    hPtrStart = m_trace.eval(loc, *hPtrAllocInst, true);
-  } else {
-    LOG("cex",
-        errs() << "unhandled Value of memhavoc ptr: " << *hPtrAlloc << "\n");
-    return;
-  }
-  Expr shadowMemRaw = m_trace.engine().getPtrAddressable(shadowMem);
-  Expr hPtrStartRaw = m_trace.engine().getPtrAddressable(hPtrStart);
-  if (!shadowMemRaw || !hPtrStartRaw || !size) {
-    LOG("cex", errs() << "Skipping harness for memhavoc due to lacking info");
-    return;
-  }
-  LOG("cex", errs() << "Producing harness for " << func->getName() << "\n";);
-  m_func_val_map[func].push_back(shadowMemRaw);
-  m_memhavoc_args.push_back(std::make_pair(hPtrStartRaw, size));
-}
-
 template <class Trace> void CexExeGenerator<Trace>::storeDataFromTrace() {
+  utils::BmcTraceVisitor<Trace> v(*this);
   for (unsigned loc = 0; loc < m_trace.size(); loc++) {
     const BasicBlock &BB = *m_trace.bb(loc);
-    for (auto &I : BB) {
-      if (const CallInst *ci = dyn_cast<CallInst>(&I)) {
-        ImmutableCallSite CS(ci);
-        // Go through bitcasts
-        const Value *CV = CS.getCalledValue();
-        const Function *CF = dyn_cast<Function>(CV->stripPointerCasts());
-        if (!CF) {
-          LOG("cex", errs() << "Skipping harness for " << *ci
-                            << " because callee cannot be resolved\n");
-          continue;
-        }
-
-        LOG("cex_verbose",
-            errs() << "Considering harness for: " << CF->getName() << "\n";);
-
-        if (CF->getName().equals("memhavoc")) {
-          // previous instruction should be
-          // shadow.mem.load(i32 x, i32 %sm_n, i8* null)
-          if (I.getPrevNonDebugInstruction() == nullptr)
-            continue;
-          const Instruction *prevI = I.getPrevNonDebugInstruction();
-          if (const CallInst *prevCi = dyn_cast<CallInst>(prevI)) {
-            ImmutableCallSite prevCS(prevCi);
-            storeMemHavoc(loc, CF, CS, prevCS);
-          }
-          continue;
-        }
-
-        if (!CF->hasName())
-          continue;
-        if (CF->isIntrinsic())
-          continue;
-        // We want to ignore seahorn functions, but not nondet
-        // functions created by strip-extern or dummyMainFunction
-        if (CF->getName().find_first_of('.') != StringRef::npos &&
-            !CF->getName().startswith("verifier.nondet"))
-          continue;
-        if (!CF->isExternalLinkage(CF->getLinkage()))
-          continue;
-        if (!CF->getReturnType()->isIntegerTy() &&
-            !CF->getReturnType()->isPointerTy()) {
-          continue;
-        }
-
-        // KleeInternalize
-        if (CF->getName().equals("calloc"))
-          continue;
-
-        // -- known library function
-        LibFunc libfn;
-        if (m_tli.getLibFunc(CF->getName(), libfn))
-          continue;
-
-        Expr V = m_trace.eval(loc, I, true);
-        if (!V)
-          continue;
-        LOG("cex",
-            errs() << "Producing harness for " << CF->getName() << "\n";);
-        m_func_val_map[CF].push_back(V);
-      }
-    }
+    v.setLoc(loc);
+    v.visit(const_cast<BasicBlock &>(BB));
   }
 }
 
@@ -221,7 +228,7 @@ void CexExeGenerator<Trace>::buildNonDetFunction(const Function *func,
     else
       Args.push_back(ConstantInt::get(Type::getInt32Ty(m_context), 0));
   } else {
-    errs() << "WARNING: Unknown type: " << *RT << "\n";
+    WARN << "Unknown type: " << *RT << "\n";
     assert(false && "Unknown return type");
   }
   FunctionCallee GetValue = m_harness->getOrInsertFunction(
@@ -240,7 +247,7 @@ void CexExeGenerator<Trace>::buildMemhavoc(const Function *func,
                                 cast<FunctionType>(func->getFunctionType()))
           .getCallee());
   if (!func->getReturnType()->isVoidTy()) {
-    LOG("cex", errs() << "memhavoc has non-void return type. Skipping...\n";);
+    LOG("cex", WARN << "memhavoc has non-void return type. Skipping...\n";);
     return;
   }
   Type *i8PtrTy = Type::getInt8PtrTy(m_context);
@@ -248,9 +255,9 @@ void CexExeGenerator<Trace>::buildMemhavoc(const Function *func,
   SmallVector<Constant *, 20> LLVMarray;
   // one nested array for segments
   for (size_t i = 0; i < values.size(); i++) {
-    auto havocPtr = m_memhavoc_args[i];
+    auto ndPtr = m_nondet_ptrs[i];
     Constant *segmentCA =
-        exprToMemSegment(values[i], havocPtr.first, havocPtr.second);
+        exprToMemSegment(values[i], ndPtr.first, ndPtr.second);
     GlobalVariable *segmentGA =
         new GlobalVariable(*m_harness, segmentCA->getType(), true,
                            GlobalValue::PrivateLinkage, segmentCA);
@@ -303,7 +310,6 @@ template <class Trace> void CexExeGenerator<Trace>::buildCexModule() {
   m_harness = std::make_unique<Module>("harness", m_context);
   m_harness->setDataLayout(m_dl);
   for (auto CFV : m_func_val_map) {
-
     auto CF = CFV.first;
     auto &values = CFV.second;
     if (CF->getName().equals("memhavoc")) {
@@ -388,8 +394,7 @@ Constant *CexExeGenerator<Trace>::exprToMemSegment(Expr segment, Expr startAddr,
   if (expr::numeric::getNum(size, sizeMpz)) {
     blockWidth = sizeMpz.get_ui();
   } else {
-    LOG("cex",
-        errs() << "memhavoc: cannot get concrete size (" << *size << ")\n");
+    LOG("cex", ERR << "memhavoc: cannot get concrete size (" << *size << ")\n");
     ArrayType *placeholderT = ArrayType::get(Type::getInt8PtrTy(m_context), 0);
     return ConstantArray::get(placeholderT, LLVMValueSegment);
   }
@@ -400,16 +405,16 @@ Constant *CexExeGenerator<Trace>::exprToMemSegment(Expr segment, Expr startAddr,
   if (expr::numeric::getNum(startAddr, startAddrMpz)) {
     startAddrInt = startAddrMpz.get_ui();
   } else {
-    LOG("cex", errs() << "memhavoc: cannot get concrete starting address: "
-                      << *startAddr << "\n");
+    LOG("cex", ERR << "memhavoc: cannot get concrete starting address: "
+                   << *startAddr << "\n");
     ArrayType *placeholderT = ArrayType::get(Type::getInt8PtrTy(m_context), 0);
     return ConstantArray::get(placeholderT, LLVMValueSegment);
   }
 
   const MemMap m_map(segment);
   if (!m_map.isValid()) {
-    LOG("cex", errs() << "memhavoc: cannot extract content from: " << *segment
-                      << "\n");
+    LOG("cex",
+        ERR << "memhavoc: cannot extract content from: " << *segment << "\n");
     ArrayType *placeholderT = ArrayType::get(Type::getInt8PtrTy(m_context), 0);
     return ConstantArray::get(placeholderT, LLVMValueSegment);
   }
@@ -424,7 +429,7 @@ Constant *CexExeGenerator<Trace>::exprToMemSegment(Expr segment, Expr startAddr,
   if (defaultE) {
     defaultConst = exprToConstant(segmentElmTy, defaultE);
   } else {
-    LOG("cex", errs() << "havocing mem with default 0 \n");
+    LOG("cex", WARN << "havocing mem with default 0 \n");
     defaultConst = Constant::getIntegerValue(
         segmentElmTy, APInt(m_dl.getTypeStoreSizeInBits(segmentElmTy), 0));
   }
@@ -442,8 +447,8 @@ Constant *CexExeGenerator<Trace>::exprToMemSegment(Expr segment, Expr startAddr,
       size_t curAddrInt = idE.get_ui();
       size_t index = (curAddrInt - startAddrInt) / elmWidth;
       if (index >= blocks) {
-        LOG("cex", errs() << "memhavoc: out of bound index: [" << index
-                          << "] with only " << blocks << " blocks \n");
+        LOG("cex", ERR << "memhavoc: out of bound index: [" << index
+                       << "] with only " << blocks << " blocks \n");
         continue;
       }
       Expr segmentE = begin->getValueExpr();

--- a/py/sea/cex.py
+++ b/py/sea/cex.py
@@ -1,0 +1,253 @@
+import sys
+import os
+import subprocess
+import sea
+import sea.commands
+
+from sea import add_in_args, add_in_out_args, add_tmp_dir_args
+from sea.commands import _remap_file_name, _add_S_arg, Clang, Seapp, WrapMem, \
+    RemoveTargetFeatures, LinkRt, MixedSem, Seaopt, Seahorn
+
+
+'''
+Set of commands for executable counterexample functionality
+'''
+
+
+class CexGen(sea.LimitedCmd):
+    def __init__(self, quiet=False):
+        super(CexGen, self).__init__("cex",
+                                     'Generate Counter-example executable from harness',
+                                     allow_extra=True)
+        self.clangCmd = None
+
+    @property
+    def stdout(self):
+        return self.clangCmd.stdout
+
+    def name_out_file(self, in_files, args=None, work_dir=None):
+        return _remap_file_name(in_files[0], '', work_dir)
+
+    def mk_arg_parser(self, ap):
+        ap = super(CexGen, self).mk_arg_parser(ap)
+        add_tmp_dir_args(ap)
+        add_in_out_args(ap)
+        _add_S_arg(ap)
+
+        ap.add_argument('--run', '-run', dest='run',
+                        help='Run generated executable',
+                        default=False, action='store_true')
+        ap.add_argument('--klee-internalize', '-klee-internalize',
+                        dest='internalize',
+                        help='Apply klee internalize pre-processing',
+                        default=False, action='store_true')
+        ap.add_argument('--only-strip-extern', '-only-strip-extern',
+                        dest='strip_extern',
+                        help='Strip external functions during internalize pre-processing',
+                        default=False, action='store_true')
+        ap.add_argument('--keep-lib-fn', '-keep-lib-fn',
+                        dest='keep_lib_fn',
+                        help='Keep lib functions during internalize pre-processing',
+                        default=False, action='store_true')
+        ap.add_argument('--wrap-mem', '-wrap-mem',
+                        dest='wrapmem',
+                        help='Wrap memory read/access instructions',
+                        default=False, action='store_true')
+        ap.add_argument('--rmtf', '-rmtf',
+                        dest='rmtf',
+                        help='Remove target features for cross platform files',
+                        default=False, action='store_true')
+        ap.add_argument('-m', type=int, dest='machine',
+                        help='Machine architecture MACHINE:[32,64]',
+                        default=32)
+        return ap
+
+    def run(self, args, extra):
+        cmds = [Clang()]
+        # following logic in Seapp, where klee internalize is separate
+        if args.strip_extern:
+            pp = Seapp(strip_extern=True, keep_lib_fn=args.keep_lib_fn)
+            cmds.append(pp)
+        if args.internalize:
+            cmds.append(Seapp(internalize=True))
+
+        if args.wrapmem:
+            cmds.append(WrapMem())
+
+        if args.rmtf:
+            cmds.append(RemoveTargetFeatures())
+
+        if args.out_file is None:
+            target = os.path.basename(args.in_files[0]).split(sep='.')[0]
+            args.out_file = "/tmp/{}_debug.exe".format(target)
+
+        linkRtCmd = LinkRt()
+        self.clangCmd = linkRtCmd
+        cmds.append(linkRtCmd)
+
+        pipeline = sea.SeqCmd('', '', cmds)
+        argv = ["-m{}".format(args.machine), '-g']  # debug info is a must
+        argv.extend(extra)
+        res = pipeline.run(args, argv)
+        if res:
+            print("Executable Counterexample generation failed... \n")
+        else:
+            print("Generated executable counterexample: %s" %
+                  str(args.out_file))
+            if args.run:
+                print("Running executable counterexample: \n")
+                args.in_files = [args.out_file]
+                c = ExecHarness()
+                c.run(args, [])
+
+
+class ExecHarness(sea.LimitedCmd):
+    def __init__(self, quiet=False):
+        super(ExecHarness, self).__init__('exec-harness', 'Execute an executable harness to see if it calls __VERIFIER_error',
+                                          allow_extra=True)
+        self.harnessCmd = None
+
+    @property
+    def stdout(self):
+        return self.harnessCmd.stdout
+
+    def mk_arg_parser(self, ap):
+        ap = super(ExecHarness, self).mk_arg_parser(ap)
+        add_in_args(ap)
+        return ap
+
+    def run(self, args, extra):
+        if len(args.in_files) != 1:
+            raise IOError(
+                'ExecHarness expects the harness executable as an input')
+        eharness = os.path.abspath(args.in_files[0])
+
+        self.harnessCmd = sea.ExtCmd(eharness)
+        if args.cpu is None:
+            args.cpu = 10
+
+        retval = self.harnessCmd.run(
+            args, [], encoding='utf-8', errors='replace', stdout=subprocess.PIPE)
+
+        if "[sea] __VERIFIER_error was executed" in self.harnessCmd.stdout:
+            print("__VERIFIER_error was executed")
+        else:
+            print("__VERIFIER_error was not executed")
+
+        return retval
+
+
+class SeaExeCex(sea.LimitedCmd):
+    def __init__(self, quiet=False):
+        super(SeaExeCex, self).__init__('exe-cex',
+                                        'Executable Counterexamples',
+                                        allow_extra=True)
+
+    @property
+    def stdout(self):
+        return
+
+    def name_out_file(self, in_files, args=None, work_dir=None):
+        return _remap_file_name(in_files[0], '.exe', work_dir)
+
+    def mk_arg_parser(self, ap):
+        ap = super(SeaExeCex, self).mk_arg_parser(ap)
+        add_tmp_dir_args(ap)
+        add_in_out_args(ap)
+        _add_S_arg(ap)
+        ap.add_argument('--harness', '-harness',
+                        dest='harness',
+                        help='Destination file for the harness',
+                        default=None, metavar='FILE')
+        ap.add_argument('--bit-precise', '-bit-precise',
+                        dest='bv_cex',
+                        help='Generate bit-precise counterexamples',
+                        default=False, action='store_true')
+        ap.add_argument('--bit-mem-precise', '-bit-mem-precise',
+                        dest='bv_part_mem',
+                        help='Generate bit- and memory-precise counterexamples',
+                        default=False, action='store_true')
+        ap.add_argument('--alloc-mem', '-alloc-mem',
+                        default=False, action='store_true',
+                        dest='alloc_mem',
+                        help='Allocate space for uninitialized memory')
+        ap.add_argument('--verify', '-verify',
+                        default=False, action='store_true',
+                        dest='verify',
+                        help='Verify the harness executes __VERIFIER_error')
+        return ap
+
+    def run(self, args, extra):
+        # FIXME: the -o is used both `sea pf` and `sea exe`. Thus,
+        # the output of `sea pf` is overwritten by the output of `sea exe`.
+        try:
+            harness_file = args.harness
+            if harness_file is None:
+                harness_file = 'harness.ll'
+
+            if args.out_file is None:
+                args.out_file = 'harness'
+
+            try:
+                os.remove(harness_file)
+            except OSError:
+                pass
+
+            ## `sea pf`: find counterexample and generate harness
+            c = sea.SeqCmd('', '',
+                           [Clang(), Seapp(), MixedSem(), Seaopt(),
+                            Seahorn(solve=True)])
+            argv = list()
+            argv.extend(['-m64', '-g'])
+            argv.extend(extra)
+            # TODO: we should remove from `extra` the following options:
+            argv.extend(['--cex={0}'.format(harness_file)])
+            if args.bv_cex or args.bv_part_mem:
+                argv.extend(['--bv-cex'])
+            if args.bv_part_mem:
+                argv.extend(['--horn-bv-part-mem'])
+            res = c.run(args,  argv)
+            if res != 0:
+                print('\n\nThe harness was not generated. Aborting ...\n')
+                return res
+
+            if not os.path.isfile(harness_file):  # if program was safe
+                print('\n\nThe harness was not generated. Aborting ...\n')
+                # remove the .smt2 file
+                try:
+                    os.remove(args.out_file)
+                except OSError:
+                    pass
+                # some error code different from 0
+                return 1
+
+            ## `sea exe`: generate executable
+            c = sea.SeqCmd('', '',
+                           [Clang(), Seapp(strip_extern=True, keep_lib_fn=True),
+                            Seapp(internalize=True), WrapMem(), LinkRt()])
+            argv = list()
+            argv.extend(['-m64', '-g'])
+            argv.extend(extra)
+            # TODO: we should remove from `extra` the following options:
+            if args.alloc_mem:
+                argv.extend(['--alloc-mem'])
+            infiles = args.in_files
+            infiles.extend([harness_file])
+            res = c.run(args, argv)
+            if res != 0:
+                print(
+                    '\n\nThe executable counterexample was not generated. Aborting ...\n')
+            else:
+                print('\n\nGenerated executable counterexample {0}'.format(
+                    args.out_file))
+
+            # Optionally verify the harness reaches __VERIFIER_error
+            if res == 0 and args.verify:
+                args.in_files = [args.out_file]
+                c = ExecHarness()
+                c.run(args, [])
+
+            return res
+
+        except Exception as e:
+            raise IOError(str(e))

--- a/py/sea/commands.py
+++ b/py/sea/commands.py
@@ -203,7 +203,7 @@ class LinkRt(sea.LimitedCmd):
 
     def name_out_file (self, in_files, args=None, work_dir=None):
         assert (len (in_files) == 1)
-        return _remap_file (in_files[0], '', work_dir)
+        return _remap_file_name (in_files[0], '', work_dir)
 
     def run (self, args, extra):
 
@@ -744,37 +744,6 @@ class WrapMem(sea.LimitedCmd):
             if args.llvm_asm: argv.append ('-S')
             argv.extend (args.in_files)
             return self.seappCmd.run (args, argv)
-
-class ExecHarness(sea.LimitedCmd):
-    def __init__(self, quiet=False):
-        super(ExecHarness, self).__init__('exec-harness', 'Execute an executable harness to see if it calls __VERIFIER_error',
-                                             allow_extra=True)
-        self.harnessCmd = None
-
-    @property
-    def stdout (self):
-        return self.harnessCmd.stdout
-
-    def mk_arg_parser (self, ap):
-        ap = super (ExecHarness, self).mk_arg_parser (ap)
-        add_in_args (ap)
-        return ap
-
-    def run (self, args, extra):
-        if len(args.in_files) != 1: raise IOError('ExecHarness expects the harness executable as an input')
-        eharness = os.path.abspath(args.in_files[0])
-
-        self.harnessCmd = sea.ExtCmd (eharness)
-        if args.cpu is None: args.cpu = 10
-
-        retval = self.harnessCmd.run (args, [eharness], encoding='utf-8', errors='replace', stdout=subprocess.PIPE)
-
-        if "[sea] __VERIFIER_error was executed" in self.harnessCmd.stdout:
-            print ("__VERIFIER_error was executed")
-        else:
-            print ("__VERIFIER_error was not executed")
-
-        return retval
 
 class CutLoops(sea.LimitedCmd):
     def __init__(self, quiet=False):
@@ -1610,118 +1579,6 @@ class InspectBitcode(sea.LimitedCmd):
 
         return self.seainspectCmd.run (args, argv)
 
-class SeaExeCex(sea.LimitedCmd):
-    def __init__(self, quiet=False):
-        super (SeaExeCex, self).__init__('exe-cex',
-                                         'Executable Counterexamples',
-                                         allow_extra=True)
-    @property
-    def stdout (self):
-        return
-
-    def name_out_file (self, in_files, args=None, work_dir=None):
-        return _remap_file_name (in_files[0], '.exe', work_dir)
-
-    def mk_arg_parser (self, ap):
-        ap = super (SeaExeCex, self).mk_arg_parser (ap)
-        add_tmp_dir_args (ap)
-        add_in_out_args (ap)
-        _add_S_arg (ap)
-        ap.add_argument ('--harness', '-harness',
-                         dest='harness',
-                         help='Destination file for the harness',
-                         default=None, metavar='FILE')
-        ap.add_argument ('--bit-precise','-bit-precise',
-                         dest='bv_cex',
-                         help='Generate bit-precise counterexamples',
-                         default=False, action='store_true')
-        ap.add_argument ('--bit-mem-precise','-bit-mem-precise',
-                         dest='bv_part_mem',
-                         help='Generate bit- and memory-precise counterexamples',
-                         default=False, action='store_true')
-        ap.add_argument ('--alloc-mem', '-alloc-mem',
-                         default=False, action='store_true',
-                         dest='alloc_mem',
-                         help='Allocate space for uninitialized memory')
-        ap.add_argument ('--verify', '-verify',
-                         default=False, action='store_true',
-                         dest='verify',
-                         help='Verify the harness executes __VERIFIER_error')
-        return ap
-
-    def run(self, args, extra):
-        # FIXME: the -o is used both `sea pf` and `sea exe`. Thus,
-        # the output of `sea pf` is overwritten by the output of `sea exe`.
-        try:
-            harness_file = args.harness
-            if harness_file is None:
-                harness_file = 'harness.ll'
-
-            if args.out_file is None:
-                args.out_file = 'harness'
-
-            try:
-                os.remove(harness_file)
-            except OSError:
-                pass
-
-            ## `sea pf`: find counterexample and generate harness
-            c = sea.SeqCmd('','',
-                           [Clang(), Seapp(), MixedSem(), Seaopt(), \
-                            Seahorn(solve=True)])
-            argv = list ()
-            argv.extend(['-m64', '-g'])
-            argv.extend(extra)
-            # TODO: we should remove from `extra` the following options:
-            argv.extend(['--cex={0}'.format(harness_file)])
-            if args.bv_cex or args.bv_part_mem:
-                argv.extend(['--bv-cex'])
-            if args.bv_part_mem:
-                argv.extend(['--horn-bv-part-mem'])
-            res = c.run(args,  argv)
-            if res != 0:
-                print('\n\nThe harness was not generated. Aborting ...\n');
-                return res
-
-            if not os.path.isfile(harness_file): # if program was safe
-                print('\n\nThe harness was not generated. Aborting ...\n');
-                # remove the .smt2 file
-                try:
-                    os.remove(args.out_file)
-                except OSError:
-                    pass
-                # some error code different from 0
-                return 1
-
-
-            ## `sea exe`: generate executable
-            c = sea.SeqCmd('','',
-                           [Clang(), Seapp(strip_extern=True,keep_lib_fn=True), \
-                            Seapp(internalize=True), WrapMem(), LinkRt()])
-            argv = list()
-            argv.extend(['-m64', '-g'])
-            argv.extend(extra)
-            # TODO: we should remove from `extra` the following options:
-            if args.alloc_mem:
-                argv.extend(['--alloc-mem'])
-            infiles = args.in_files
-            infiles.extend([harness_file])
-            res = c.run(args, argv)
-            if res != 0:
-                print('\n\nThe executable counterexample was not generated. Aborting ...\n');
-            else:
-                print ('\n\nGenerated executable counterexample {0}'.format(args.out_file))
-
-            # Optionally verify the harness reaches __VERIFIER_error
-            if res == 0 and args.verify:
-                args.in_files = [args.out_file]
-                c = ExecHarness()
-                c.run(args, [])
-
-            return res
-
-        except Exception as e:
-            raise IOError(str(e))
 
 ## SeaHorn aliases
 FrontEnd = sea.SeqCmd ('fe', 'Front end: alias for clang|pp|ms|opt',

--- a/py/seapy
+++ b/py/seapy
@@ -7,6 +7,7 @@ import os.path
 def main (argv):
     import sea
     import sea.commands
+    import sea.cex
     import sea.yama
 
     cmds = [sea.commands.Bpf,
@@ -42,11 +43,12 @@ def main (argv):
             sea.commands.Inspect,
             sea.commands.SimpleMemoryChecks(),
             sea.commands.Smc,
-            sea.commands.SeaExeCex(),
             sea.commands.RemoveTargetFeatures(),
             sea.commands.Fpf,
             sea.commands.Spf,
             sea.yama.Yama(),
+            sea.cex.CexGen(),
+            sea.cex.SeaExeCex(),
     ]
 
     cmd = sea.AgregateCmd('sea', 'SeaHorn Verification Framework', cmds)

--- a/test/cex/cex_mem.new.c
+++ b/test/cex/cex_mem.new.c
@@ -1,0 +1,35 @@
+// RUN: %solve --horn-bmc-engine=mono --horn-bv2-extra-widemem --horn-bv2-lambdas=false --horn-bmc --horn-bv2=true --keep-shadows=true --cex=/tmp/test_cex_mem.ll %s > /dev/null 2>&1
+// RUN: %cex --run -g %s /tmp/test_cex_mem.ll 2>&1 | OutputCheck %s
+
+
+// CHECK: ^__VERIFIER_error was executed$
+/*
+ Writing and reading primitive field of a nondet pointer
+*/
+#include <stddef.h>
+#include <stdlib.h>
+#include "seahorn/seahorn.h"
+
+struct st {
+    int x;
+    int y;
+    struct st *next;
+};
+
+extern struct st *nd_st(void);
+extern void memhavoc(void *ptr, size_t size);
+
+int main(int argc, char**argv) {
+    struct st *p = malloc(sizeof(struct st));
+    memhavoc(p, sizeof(struct st));
+
+    assume(p > 0);
+    p->y = 43;
+    if (p->x == 42) {
+      if (p->y == 43) {
+        __VERIFIER_error();
+      }
+    }
+    free(p);
+    return 0;
+}

--- a/test/cex/cex_nonlinear_arith.new.c
+++ b/test/cex/cex_nonlinear_arith.new.c
@@ -1,7 +1,10 @@
-// RUN: %sea exe-cex -O0 --verify --bit-precise "%s" 2>&1 | OutputCheck %s
+// RUN: %solve --horn-bmc-engine=mono --horn-bv2-lambdas=false --horn-bmc --horn-bv2=true --cex=/tmp/test_cex_nonlinear_arith.ll %s > /dev/null 2>&1
+// RUN: %cex --run -g %s /tmp/test_cex_nonlinear_arith.ll 2>&1 | OutputCheck %s
+
 // CHECK: ^__VERIFIER_error was executed$
 
 /* 
+   XXX: how to reproduce spurious cex?
    Example where SeaHorn's back-end solver produces an spurious cex
    which is not valid at the bit-level. The reason is that the solver
    does not reason about non-linear multiplication.
@@ -13,8 +16,8 @@ extern int nd_int(void);
 
 int main(int argc, char**argv) {
   int x = nd_int();
-  __VERIFIER_assume (x >= 1);
-  __VERIFIER_assume (x <= 100);
+  assume (x >= 1);
+  assume (x <= 100);
   int y = x * x;
   if (y > x) {
     __VERIFIER_error();

--- a/test/cex/lit.local.cfg
+++ b/test/cex/lit.local.cfg
@@ -3,8 +3,48 @@ import os
 import sys
 import re
 import platform
+import lit.util
+import lit.formats
 
-config.excludes = ['cex_mem.c'
-		  ,'cex_mem_fail.c'
-		  ,'cex_nonlinear_arith.c'
-		  ,'cex_nonlinear_arith.fail.c']
+config.suffixes = ['.c']
+config.excludes = [
+  'cex_mem.c',
+  'cex_nonlinear_arith.c',
+  # need more insight to reproduce these fails
+  'cex_mem_fail.c',
+  'cex_nonlinear_arith.fail.c'
+]
+
+def isexec (fpath):
+    if fpath == None: return False
+    return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
+
+def which (cmd):
+   return lit.util.which(cmd, config.environment['PATH'])
+
+def getSea():
+   return which('sea')
+
+def getArch():
+	return '-m32' if platform.architecture() == '32bit' else '-m64'
+
+cex_bmc_extra_params = lit_config.params.get('cex_bmc_opts',"")
+if len(cex_bmc_extra_params) != 0:
+  print("Passing extra horn bmc cex command line args: {0}".format(
+    cex_bmc_extra_params)
+  )
+
+cex_gen_extra_params = lit_config.params.get('cex_gen_opts', "")
+if len(cex_gen_extra_params) != 0:
+  print("Passing extra cex gen cmd line args: {0}".format(cex_gen_extra_params))
+
+sea_cmd = getSea()
+if not isexec(sea_cmd):
+   lit_config.fatal('Could not find the Sea executable')
+
+machine_arch = getArch()
+lit_config.note('Running cex tests under {}-bit architecture'.format(machine_arch[-2:]))
+cexbmc = [sea_cmd, 'fpf', machine_arch, '--log=cex'] + [cex_bmc_extra_params]
+cexgen = [sea_cmd, 'cex', machine_arch] + [cex_gen_extra_params]
+config.substitutions.append(('%solve', ' '.join(cexbmc)))
+config.substitutions.append(('%cex', ' '.join(cexgen)))

--- a/test/cex/mem_multi.c
+++ b/test/cex/mem_multi.c
@@ -1,0 +1,21 @@
+// RUN: %solve --horn-bmc-engine=mono --horn-bv2-extra-widemem --horn-bv2-lambdas=false --horn-bmc --horn-bv2=true --keep-shadows=true --cex=/tmp/multi.ll %s > /dev/null 2>&1
+// RUN: %cex --run -g %s /tmp/multi.ll 2>&1 | OutputCheck %s
+
+// CHECK: ^__VERIFIER_error was executed$
+
+#include <stddef.h>
+#include "seahorn/seahorn.h"
+extern void memhavoc(void *ptr, size_t size);
+
+int main(void) {
+	int nums[5];
+	memhavoc(nums, sizeof(nums));
+	int nums2[2];
+	memhavoc(nums2, sizeof(nums2));
+	int x = nums[2];
+	int y = nums2[0];
+	if (x > 10) {
+		y = x;
+	}
+	sassert(y == x);
+}

--- a/test/cex/mem_nd_size.c
+++ b/test/cex/mem_nd_size.c
@@ -1,0 +1,30 @@
+// RUN: %solve --horn-bmc-engine=mono --horn-bv2-extra-widemem --horn-bv2-lambdas=false --horn-bmc --horn-bv2=true --keep-shadows=true --cex=/tmp/mem_nd_size.ll %s > /dev/null 2>&1
+// RUN: %cex --run -g %s /tmp/mem_nd_size.ll 2>&1 | OutputCheck %s
+
+// CHECK: ^__VERIFIER_error was executed$
+
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include "seahorn/seahorn.h"
+extern void memhavoc(void *ptr, size_t size);
+extern size_t nd_int(void);
+extern bool nd_bool(void);
+
+int main(void) {
+	size_t len = nd_int();
+	assume(len < 5);
+	int *nums;
+	nums = malloc(len * sizeof(*nums));
+	memhavoc(nums, len * sizeof(*nums));
+	size_t i = nd_int();
+	assume(i < len);
+	int x = nums[i];
+	int y = 0;
+	if (x > 10 && nd_bool()) {
+		y = x + 5;
+	}
+	sassert(y == 0);
+	free(nums);
+}

--- a/test/cex/mem_no_repeat.c
+++ b/test/cex/mem_no_repeat.c
@@ -1,0 +1,22 @@
+// RUN: %solve --horn-bmc-engine=mono --horn-bv2-extra-widemem --horn-bv2-lambdas=false --horn-bmc --horn-bv2=true --keep-shadows=true --cex=/tmp/no_rpt.ll %s > /dev/null 2>&1
+// RUN: %cex --run -g %s /tmp/no_rpt.ll 2>&1 | OutputCheck %s
+
+// CHECK: ^__VERIFIER_error was executed$
+
+#include <stddef.h>
+#include "seahorn/seahorn.h"
+extern void memhavoc(void *ptr, size_t size);
+extern size_t nd_int(void);
+
+int main(void) {
+	int nums[5];
+	memhavoc(nums, sizeof(nums));
+	int x = nums[0];
+	int y = 0;
+	if (nd_int()) {
+		y = x;
+	} else {
+		y = nums[4];
+	}
+	sassert(y == x);
+}


### PR DESCRIPTION
- Cleaned up CexExeGenerator to use `InstVisitor` implementation for collecting nd function values
- added new python command pipeline `CexGen`; given a source (C or IR) and counterexample harness, usage: `sea cex <options> <source> <harness> -o <outfile>`; if -o is not provided, an executable name will be generated in `/tmp/` with default name format: `<target_name>_debug.exe`; I did not add seahorn solve step to the pipeline since right now there are many different ways: `bpf`, `fpf`, `pf`... each with different options, from my personal dev experience I find it more flexible to do seahorn solve step separately
- added back `cex` tests, need insight on `cex_mem_fail.c` and `cex_non_linear_arith.fail.c` about how to reproduce fail in meaningful way.