### PR TITLE
feat(opsem): productionize memory tracking

### DIFF
--- a/include/seahorn/seahorn.h
+++ b/include/seahorn/seahorn.h
@@ -30,7 +30,19 @@ extern void __VERIFIER_assert_if(bool, bool);
  */
 extern bool sea_is_dereferenceable(void *ptr, intptr_t offset);
 extern void sea_assert_if(bool, bool);
-
+/* returns true if memory pointed to by arg has been modified from
+ * 1. allocation OR
+ * 2. reset_modified OR
+ * 3. sea_tracking_on
+ * whichever is the latest event.
+ */
+extern bool sea_is_modified(char *);
+/* tracking is set to on for subsequent program till exit or sea_tracking_off */
+extern void sea_tracking_on();
+/* tracking is set to off for subsequent program till exit or sea_tracking_on */
+extern void sea_tracking_off();
+/* reset modified metadata for memory pointed to by arg */
+extern void sea_reset_modified(char *);
 #ifdef __cplusplus
 }
 #endif

--- a/lib/seahorn/BmcPass.cc
+++ b/lib/seahorn/BmcPass.cc
@@ -291,6 +291,9 @@ public:
     computeDependence(m->getFunction("sea.assert.if"));
     computeDependence(m->getFunction("verifier.assert.not"));
     computeDependence(m->getFunction("verifier.assert"));
+    // add opsem control commands to filter
+    computeDependence(m->getFunction("sea.tracking_on"));
+    computeDependence(m->getFunction("sea.tracking_off"));
 
     // install dependence filter in operational semantics
     auto &filter = dfCoi.getCoi();


### PR DESCRIPTION
1. add memory tracking functions to seahorn.h
2. add sea_tracking_{on,off} to coi