### PR TITLE
Support for predicate synthesis from partial definitions in small step semantics.

### DIFF
--- a/include/seahorn/Analysis/SeaBuiltinsInfo.hh
+++ b/include/seahorn/Analysis/SeaBuiltinsInfo.hh
@@ -16,6 +16,8 @@ enum class SeaBuiltinsOp {
   ASSUME_NOT,         /* verifier.assume.not */
   ASSERT,             /* verifier.assert */
   ASSERT_NOT,         /* verifier.assert.not */
+  SYNTH_ASSUME,       /* sea.synth.assume */
+  SYNTH_ASSERT,       /* sea.synth.assert */
   IS_DEREFERENCEABLE, /* sea.is_dereferenceable */
   ASSERT_IF,          /* sea.assert.if */
   BRANCH_SENTINEL,    /* sea.branch_sentinel */
@@ -38,6 +40,8 @@ class SeaBuiltinsInfo {
   llvm::Function *mkIsDereferenceable(llvm::Module &M);
   llvm::Function *mkAssertIfFn(llvm::Module &M);
   llvm::Function *mkAssertFn(llvm::Module &M, SeaBuiltinsOp);
+  llvm::Function *mkSynthAssume(llvm::Module &M);
+  llvm::Function *mkSynthAssert(llvm::Module &M);
   llvm::Function *mkBranchSentinelFn(llvm::Module &M);
   llvm::Function *mkIsModifiedFn(llvm::Module &M);
   llvm::Function *mkResetModifiedFn(llvm::Module &M);

--- a/include/seahorn/HornifyFunction.hh
+++ b/include/seahorn/HornifyFunction.hh
@@ -37,10 +37,15 @@ protected:
   EZ3 &m_zctx;
   ExprFactory &m_efac;
 
+  llvm::Function *m_synthAssertFn = nullptr;
+
   /// whether encoding is inter-procedural (i.e., with summaries)
   bool m_interproc;
 
   void extractFunctionInfo(const BasicBlock &BB);
+
+  llvm::SmallVector<llvm::Instruction *, 8> getPartialFnsToSynth(Function &F);
+  void expandEdgeFilter(llvm::Instruction &I);
 
 public:
   HornifyFunction(HornifyModule &parent, bool interproc = false)
@@ -55,6 +60,7 @@ public:
 };
 
 class SmallHornifyFunction : public HornifyFunction {
+  void mkBBSynthRules(const LiveSymbols &ls, Function &F, SymStore &store);
 
 public:
   SmallHornifyFunction(HornifyModule &parent, bool interproc = false)

--- a/include/seahorn/HornifyModule.hh
+++ b/include/seahorn/HornifyModule.hh
@@ -14,6 +14,7 @@
 
 #include "seahorn/Analysis/CanFail.hh"
 #include "seahorn/Analysis/CutPointGraph.hh"
+#include "seahorn/Analysis/SeaBuiltinsInfo.hh"
 #include "seahorn/HornClauseDB.hh"
 
 namespace seahorn {
@@ -78,6 +79,10 @@ public:
   LegacyOperationalSemantics &symExec() { return *m_sem; }
 
   CutPointGraph &getCpg(Function &F) { return getAnalysis<CutPointGraph>(F); }
+
+  SeaBuiltinsInfo &getSBI() {
+    return getAnalysis<SeaBuiltinsInfoWrapperPass>().getSBI();
+  }
 };
 } // namespace seahorn
 

--- a/include/seahorn/InitializePasses.hh
+++ b/include/seahorn/InitializePasses.hh
@@ -5,6 +5,7 @@ namespace llvm {
 void initializeSimpleMemoryCheckPass(PassRegistry &);
 void initializeFatBufferBoundsCheckPass(PassRegistry &);
 void initializeSeaBuiltinsInfoWrapperPassPass(PassRegistry &);
+void initializeGeneratePartialFnPassPass(PassRegistry &);
 void initializeLoopPeelerPassPass(PassRegistry &);
 void initializeAddBranchSentinelPassPass(PassRegistry &);
 void initializeEvalBranchSentinelPassPass(PassRegistry &);

--- a/include/seahorn/OperationalSemantics.hh
+++ b/include/seahorn/OperationalSemantics.hh
@@ -172,6 +172,8 @@ struct FunctionInfo {
   llvm::SmallVector<const llvm::GlobalVariable *, 8> globals;
   /// return value. NULL if the function is void or return is not tracked
   const llvm::Value *ret = nullptr;
+  /// Indicates whether the function is an partial function stub.
+  bool isInferable = false;
 
   FunctionInfo() = default;
 };

--- a/include/seahorn/Passes.hh
+++ b/include/seahorn/Passes.hh
@@ -106,6 +106,7 @@ llvm::Pass *createBoogieWriterPass(llvm::raw_ostream *out, bool use_crab);
 
 llvm::ModulePass *createControlDependenceAnalysisPass();
 llvm::ModulePass *createGateAnalysisPass();
+llvm::Pass *createGeneratePartialFnPass();
 llvm::Pass *createCHAPass();
 llvm::ModulePass *createDebugVerifierPass(int instanceID, llvm::StringRef name);
 llvm::Pass *createUnifyAssumesPass();

--- a/include/seahorn/Transforms/Instrumentation/GeneratePartialFnPass.hh
+++ b/include/seahorn/Transforms/Instrumentation/GeneratePartialFnPass.hh
@@ -1,0 +1,22 @@
+#pragma once
+
+/**
+ * Locates external function calls annotated by "partial" and generates
+ * placeholder implementations.
+ */
+
+#include "llvm/IR/Function.h"
+#include "llvm/Pass.h"
+
+using namespace llvm;
+
+namespace seahorn {
+
+// Returns true if GeneratePartialFnPass has marked F as a stub of a partial
+// function.
+bool isInferable(const Function &F);
+
+// Returns true if F has the "partial" annotation.
+bool isPartialFn(const Function &F);
+
+} // namespace seahorn

--- a/include/seahorn/Transforms/Scalar/PromoteVerifierCalls.hh
+++ b/include/seahorn/Transforms/Scalar/PromoteVerifierCalls.hh
@@ -19,6 +19,8 @@ namespace seahorn
     Function *m_assumeFn;
     Function *m_assertFn;
     Function *m_assertNotFn;
+    Function *m_synthAssumeFn;
+    Function *m_synthAssertFn;
     Function *m_errorFn;
     Function *m_failureFn; // to indicate failure. It can only appears in main.
     Function *m_is_deref;

--- a/include/seahorn/seahorn.h
+++ b/include/seahorn/seahorn.h
@@ -50,6 +50,9 @@ extern void sea_reset_modified(char *);
 /* Convenience macros */
 #define assume __VERIFIER_assume
 
+#define PARTIAL_FN                                                             \
+  __attribute__((annotate("partial"))) __attribute__((noinline))
+
 /* See https://github.com/seahorn/seahorn/projects/5 for details */
 #ifdef VACCHECK
 #define sassert(X)                                                             \

--- a/lib/Transforms/Instrumentation/CMakeLists.txt
+++ b/lib/Transforms/Instrumentation/CMakeLists.txt
@@ -12,4 +12,5 @@ add_llvm_library(SeaInstrumentation DISABLE_LLVM_LINK_LLVM_DYLIB
   SimpleMemoryCheck.cc
   FatBufferBoundsCheck.cc
   BranchSentinelPass.cc
+  GeneratePartialFnPass.cc
   )

--- a/lib/Transforms/Instrumentation/GeneratePartialFnPass.cc
+++ b/lib/Transforms/Instrumentation/GeneratePartialFnPass.cc
@@ -1,0 +1,161 @@
+#include "seahorn/Transforms/Instrumentation/GeneratePartialFnPass.hh"
+
+#include "seahorn/Analysis/SeaBuiltinsInfo.hh"
+#include "seahorn/InitializePasses.hh"
+#include "seahorn/Passes.hh"
+#include "seahorn/Support/SeaDebug.h"
+
+#include "llvm_seahorn/IR/LLVMContext.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/IRBuilder.h"
+
+#define PARTIAL_FN_ANNOTATION "partial"
+#define PARTIAL_FN_STUB_PREFIX "sea.synth.inferable."
+
+#define PASS_NAME "generate-partial-fn"
+#define DEBUG_TYPE PASS_NAME
+
+using namespace llvm;
+
+namespace {
+
+// Returns true if I is marked by the "partial" metadata.
+bool hasPartialAnnotation(const llvm::Instruction &I) {
+  if (auto *meta = I.getMetadata(llvm_seahorn::LLVMContext::MD_annotation)) {
+    auto *tuple = cast<MDTuple>(meta);
+    for (auto &N : tuple->operands()) {
+      if (cast<MDString>(N.get())->getString() == PARTIAL_FN_ANNOTATION) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+} // namespace
+
+namespace seahorn {
+
+// Delcared in GeneratePartialFnPass.h
+bool isInferable(const Function &F) {
+  return F.getName().startswith(PARTIAL_FN_STUB_PREFIX);
+}
+
+// Delcared in GeneratePartialFnPass.h
+bool isPartialFn(const Function &F) {
+  // Conservative check: Is the first instruction marked as partial?
+  auto &I = F.getEntryBlock().front();
+  return hasPartialAnnotation(I);
+}
+
+namespace {
+
+// Instruments partial functions. This consists of identifying partial functions
+// (Boolean functions annotated with partial), locating all stubs (external
+// functions called from within the partial function), and instrumenting all
+// stubs as required in VC generations.
+class GeneratePartialFnPass : public llvm::ModulePass {
+private:
+  Function *m_assumeFn = nullptr;
+
+public:
+  static char ID;
+
+  GeneratePartialFnPass() : ModulePass(ID) {}
+
+  virtual void getAnalysisUsage(llvm::AnalysisUsage &AU) const {
+    AU.addRequired<SeaBuiltinsInfoWrapperPass>();
+    AU.setPreservesAll();
+  }
+
+  bool runOnModule(Module &M) {
+    auto &SBI = getAnalysis<SeaBuiltinsInfoWrapperPass>().getSBI();
+    m_assumeFn = SBI.mkSeaBuiltinFn(SeaBuiltinsOp::ASSUME, M);
+
+    bool changed = false;
+    for (auto &F : M) {
+      if (!F.empty()) {
+        changed |= runOnFunction(SBI, F);
+      }
+    }
+    return changed;
+  }
+
+  bool runOnFunction(SeaBuiltinsInfo &SBI, Function &F) {
+    // Checks that this is a partial function, with a Boolean return type.
+    if (!isPartialFn(F))
+      return false;
+
+    if (!F.getReturnType()->isIntegerTy(1)) {
+      DOG(errs() << "Partial function without Bool return type: "
+                 << F.getName().str() << "\n";);
+      return false;
+    }
+
+    // Provides a placeholder implementation to each partial function stub.
+    bool changed = false;
+    for (auto &BB : F) {
+      IRBuilder<> pfnBuilder(&BB);
+
+      for (auto &I : BB) {
+        // Does I call a user defined function.
+        CallBase *CB = dyn_cast<CallBase>(&I);
+        if (!CB || SBI.isSeaBuiltin(*CB))
+          continue;
+
+        // Is the callee defined.
+        Function *CF = CB->getCalledFunction();
+        if (!CF || !CF->isDeclaration())
+          continue;
+
+        // Does the function return an integer?
+        if (!CF->getReturnType() || !CF->getReturnType()->isIntegerTy())
+          continue;
+
+        // Records changes.
+        changed = true;
+        DOG(errs() << "Found external call from partial function "
+                   << F.getName().str() << " to " << CF->getName().str()
+                   << ".\n");
+
+        // Renames the stub so that it can be identified in other passes.
+        CF->setName(PARTIAL_FN_STUB_PREFIX + CF->getName().str());
+
+        // The stub should have a body. The body will force the ModuleHornify
+        // pass to generate a call to the stub. Consequently, arguments passed
+        // to the stub will be live within the partial function that calls it.
+        BasicBlock *block = BasicBlock::Create(CF->getContext(), "entry", CF);
+        IRBuilder<> stubBuilder(block);
+        stubBuilder.CreateRet(ConstantInt::get(CF->getReturnType(), 0));
+
+        // Ensures that the stub is not optimized away by sequential LLVM
+        // passes.
+        CF->addFnAttr(Attribute::NoInline);
+        CF->addFnAttr(Attribute::OptimizeNone);
+
+        // Within the partial function, assume that the call to the stub never
+        // happens. This allows for the body to be synthesized, starting from
+        // the location of the call.
+        pfnBuilder.SetInsertPoint(&I);
+        pfnBuilder.CreateCall(m_assumeFn, pfnBuilder.getFalse());
+      }
+    }
+    return changed;
+  }
+
+  virtual StringRef getPassName() const { return PASS_NAME; }
+};
+
+char GeneratePartialFnPass::ID = 0;
+
+} // namespace
+
+llvm::Pass *createGeneratePartialFnPass() {
+  return new GeneratePartialFnPass();
+}
+
+} // namespace seahorn
+
+using namespace seahorn;
+INITIALIZE_PASS(GeneratePartialFnPass, PASS_NAME,
+                "Marks and instruments partial function stubs.", false, false)

--- a/lib/Transforms/Scalar/PromoteVerifierCalls.cc
+++ b/lib/Transforms/Scalar/PromoteVerifierCalls.cc
@@ -1,5 +1,7 @@
 #include "seahorn/Transforms/Scalar/PromoteVerifierCalls.hh"
+
 #include "seahorn/Analysis/SeaBuiltinsInfo.hh"
+#include "seahorn/Transforms/Instrumentation/GeneratePartialFnPass.hh"
 
 #include "llvm/IR/CallSite.h"
 #include "llvm/IR/InstIterator.h"
@@ -32,6 +34,35 @@ Value *coerceToBool(Value *arg, IRBuilder<> &builder, Instruction &I) {
     arg = builder.CreateICmpNE(arg, ConstantInt::get(arg->getType(), 0));
   return arg;
 }
+
+/// Determines if \p v represents a partial function call. If so, then the
+/// function call is returned.
+Value *extractPartialFnCall(Value *v) {
+  // The partial call may be cast to bool by comparison to 0.
+  if (auto cmp = dyn_cast<ICmpInst>(v)) {
+    auto *lhs = cmp->getOperand(0);
+    auto *rhs = cmp->getOperand(1);
+    v = isa<CallInst>(lhs) ? lhs : rhs;
+  }
+
+  // Strips zext if applicable.
+  if (auto *ze = dyn_cast<ZExtInst>(v))
+    v = ze->getOperand(0);
+
+  // The value must now be a CallInst.
+  auto CI = dyn_cast<CallInst>(v);
+  if (!CI)
+    return nullptr;
+
+  // Ensures that fn is a Boolean function with a "partial" annotation.
+  const Function &F = (*CI->getCalledFunction());
+  if (!F.getReturnType() || !F.getReturnType()->isIntegerTy(1))
+    return nullptr;
+  if (!seahorn::isPartialFn(F))
+    return nullptr;
+  return v;
+}
+
 } // namespace
 namespace seahorn {
 
@@ -50,6 +81,8 @@ bool PromoteVerifierCalls::runOnModule(Module &M) {
   m_errorFn = SBI.mkSeaBuiltinFn(SBIOp::ERROR, M);
   m_is_deref = SBI.mkSeaBuiltinFn(SBIOp::IS_DEREFERENCEABLE, M);
   m_assert_if = SBI.mkSeaBuiltinFn(SBIOp::ASSERT_IF, M);
+  m_synthAssumeFn = SBI.mkSeaBuiltinFn(SBIOp::SYNTH_ASSUME, M);
+  m_synthAssertFn = SBI.mkSeaBuiltinFn(SBIOp::SYNTH_ASSERT, M);
   m_is_modified = SBI.mkSeaBuiltinFn(SBIOp::IS_MODIFIED, M);
   m_reset_modified = SBI.mkSeaBuiltinFn(SBIOp::RESET_MODIFIED, M);
   m_is_read = SBI.mkSeaBuiltinFn(SBIOp::IS_READ, M);
@@ -171,28 +204,55 @@ bool PromoteVerifierCalls::runOnFunction(Function &F) {
                fn->getName().equals("llvm.invariant") ||
                /** my suggested name for pagai invariants */
                fn->getName().equals("pagai.invariant"))) {
-      Function *nfn;
-      if (fn->getName().equals("__VERIFIER_assume"))
-        nfn = m_assumeFn;
-      else if (fn->getName().equals("llvm.invariant"))
-        nfn = m_assumeFn;
-      else if (fn->getName().equals("pagai.invariant"))
-        nfn = m_assumeFn;
-      else if (fn->getName().equals("__VERIFIER_assert"))
-        nfn = m_assertFn;
-      else if (fn->getName().equals("__VERIFIER_assert_not"))
-        nfn = m_assertNotFn;
-      else if (fn->getName().equals("__CPROVER_assume"))
-        nfn = m_assumeFn;
-      else
-        continue;
+      auto arg0 = CS.getArgument(0);
 
-      IRBuilder<> Builder(F.getContext());
-      auto *cond = coerceToBool(CS.getArgument(0), Builder, I);
-      CallInst *ci = Builder.CreateCall(nfn, cond);
-      if (cg)
-        (*cg)[&F]->addCalledFunction(ci, (*cg)[ci->getCalledFunction()]);
+      CallInst *nfnCi = nullptr, *chkCi = nullptr;
+      if (auto partialFn = extractPartialFnCall(arg0)) {
+        // Selects proper synthesis call.
+        Function *nfn;
+        if (fn->getName().equals("__VERIFIER_assume"))
+          nfn = m_synthAssumeFn;
+        else if (fn->getName().equals("__VERIFIER_assert"))
+          nfn = m_synthAssertFn;
+        else
+          assert(0);
 
+        // Generates code.
+        IRBuilder<> Builder(F.getContext());
+        Builder.SetInsertPoint(&I);
+        chkCi = Builder.CreateCall(m_assumeFn, partialFn);
+        nfnCi = Builder.CreateCall(nfn, partialFn);
+      } else {
+        // Selects proper verification call.
+        Function *nfn;
+        if (fn->getName().equals("__VERIFIER_assume"))
+          nfn = m_assumeFn;
+        else if (fn->getName().equals("llvm.invariant"))
+          nfn = m_assumeFn;
+        else if (fn->getName().equals("pagai.invariant"))
+          nfn = m_assumeFn;
+        else if (fn->getName().equals("__VERIFIER_assert"))
+          nfn = m_assertFn;
+        else if (fn->getName().equals("__VERIFIER_assert_not"))
+          nfn = m_assertNotFn;
+        else if (fn->getName().equals("__CPROVER_assume"))
+          nfn = m_assumeFn;
+        else
+          assert(0);
+
+        // Generates code.
+        IRBuilder<> Builder(F.getContext());
+        auto *cond = coerceToBool(arg0, Builder, I);
+        nfnCi = Builder.CreateCall(nfn, cond);
+      }
+
+      // Updates call graph witth added functions.
+      if (cg && nfnCi)
+        (*cg)[&F]->addCalledFunction(nfnCi, (*cg)[nfnCi->getCalledFunction()]);
+      if (cg && chkCi)
+        (*cg)[&F]->addCalledFunction(chkCi, (*cg)[chkCi->getCalledFunction()]);
+
+      // Remove the original instruction.
       toKill.push_back(&I);
     } else if (fn && fn->getName().equals("__VERIFIER_error")) {
       IRBuilder<> Builder(F.getContext());

--- a/lib/seahorn/HornifyModule.cc
+++ b/lib/seahorn/HornifyModule.cc
@@ -437,6 +437,8 @@ bool HornifyModule::runOnFunction(Function &F) {
 void HornifyModule::getAnalysisUsage(llvm::AnalysisUsage &AU) const {
   AU.setPreservesAll();
 
+  AU.addRequired<SeaBuiltinsInfoWrapperPass>();
+
   AU.addRequired<seahorn::CanFail>();
   AU.addRequired<seahorn::NameValues>();
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -200,6 +200,14 @@ add_lit_testsuite(test-inter-mem "Tests for inter-mem encoding"
   DEPENDS seahorn
   )
 
+add_lit_testsuite(test-synth-sm "Regression tests for Small Step Synthesis"
+  -v
+  ${CMAKE_CURRENT_SOURCE_DIR}/synth-sm
+  ARGS
+  --path=${CMAKE_INSTALL_PREFIX}/bin
+  DEPENDS seahorn
+  )
+
 
 if (CMAKE_GENERATOR STREQUAL "Ninja")
   # Depending on install target does not work with make
@@ -226,6 +234,7 @@ if (CMAKE_GENERATOR STREQUAL "Ninja")
   add_dependencies(test-inter-mem install)
   add_dependencies(test-fat-ptr-sym install)
   add_dependencies(test-opsem-extra-widemem install)
+  add_dependencies(test-synth-sm install)
 
 endif()
 install (DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/simple DESTINATION share/seahorn/test)
@@ -252,3 +261,5 @@ install (FILES ${CMAKE_CURRENT_SOURCE_DIR}/lit.cfg DESTINATION share/seahorn/tes
 install (PROGRAMS ${CMAKE_CURRENT_SOURCE_DIR}/dsa/check_graphs.py DESTINATION share/seahorn/test/dsa)
 install (PROGRAMS ${CMAKE_CURRENT_SOURCE_DIR}/tutorial/seatest.py DESTINATION share/seahorn/test/tutorial)
 install (DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/inter-mem DESTINATION share/seahorn/test)
+install (DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/synth-sm DESTINATION share/seahorn/test)
+

--- a/test/synth-sm/01_interpolant_unsat.c
+++ b/test/synth-sm/01_interpolant_unsat.c
@@ -1,0 +1,53 @@
+// RUN: %sea smt %s --step=small -o %t.smt2
+// RUN: %z3 %t.smt2 fp.spacer.order_children=2 2>&1 | OutputCheck %s
+// CHECK: ^unsat$
+
+#include "seahorn/seahorn.h"
+
+extern int nd1();
+extern int nd2();
+extern int nd3();
+extern int nd4();
+extern int nd5();
+extern int nd6();
+
+// Interpolant.
+extern bool infer(int y, int z);
+bool PARTIAL_FN itp(int y, int z) { return infer(y, z); }
+
+// Test.
+int main(void) {
+  // p1 := (w != 0)
+  // p2 := (y = 2 * z + 6)
+  // p3 := (x < 7)
+  // p4 := (y == -4 * z)
+  // p5 := (y != 4)
+  //
+  // A(w, y, z) := p1 && p2
+  // B(x, y, z) := p3 && p4 && p5 
+  //
+  // A is SAT with solution { w := 1, y := 0, z := -3 }. B is also SAT, with
+  // solution { x := 0, y := 0, z := 0 }. However, A && B is UNSAT. First,
+  // resolve p2 with p4 to obtain p6 := z = -1. Next, resolve p6 with p4 to
+  // obtain p7 := y = -4. Finally, p7 conflicts with p5.
+  //
+  // Therefore, there exists an interpolant, ITP(y, z), such that A(w, y, z)
+  // implies ITP(y, z) and ITP(y, z) implies the negation of B(w, y, z).
+  //
+  // Therefore, any solution for itp entails the safety of the program.
+  //
+  // Note: z3's certificate is `true` because a single substitution of `itp` is
+  //       sufficient to prove: `!((x2 < 7) && (y2 == -4 * z2) && (y2 != 4))`.
+
+  int w1 = nd1();
+  int y1 = nd2();
+  int z1 = nd3();
+  assume((w1 != 0) && (y1 == 2 * z1 + 6));
+  __VERIFIER_assert(itp(y1, z1));
+
+  int x2 = nd4();
+  int y2 = nd5();
+  int z2 = nd6();
+  assume(itp(y2, z2));
+  sassert(!((x2 < 7) && (y2 == -4 * z2) && (y2 != 4)));
+}

--- a/test/synth-sm/02_interpolant_sat.c
+++ b/test/synth-sm/02_interpolant_sat.c
@@ -1,0 +1,38 @@
+// RUN: %sea smt %s --step=small -o %t.smt2
+// RUN: %z3 %t.smt2 fp.spacer.order_children=2 2>&1 | OutputCheck %s
+// CHECK: ^sat$
+
+#include "seahorn/seahorn.h"
+
+extern int nd1();
+extern int nd2();
+extern int nd3();
+extern int nd4();
+extern int nd5();
+extern int nd6();
+
+// Interpolant.
+extern bool infer(int y, int z);
+bool PARTIAL_FN itp(int y, int z) { return infer(y, z); }
+
+// Test.
+int main(void) {
+  // See 01_interpolant_unsat.c.
+  // 
+  // Recall that the original program was safe because (1) A && B entailed
+  // y = 4 and (2) B entails y != 4. In this program, B no longer entails
+  // y != 4. As a result, A && B are SAT, and an interpolant no longer exists.
+  // The program is unsafe.
+
+  int w1 = nd1();
+  int y1 = nd2();
+  int z1 = nd3();
+  assume((w1 != 0) && (y1 = 2 * z1 + 6));
+  __VERIFIER_assert(itp(y1, z1));
+
+  int x2 = nd4();
+  int y2 = nd5();
+  int z2 = nd6();
+  assume(itp(y2, z2));
+  sassert(!((x2 < 7) && (y2 == -4 * z2)));
+}

--- a/test/synth-sm/03_loop_unsat.c
+++ b/test/synth-sm/03_loop_unsat.c
@@ -1,0 +1,53 @@
+// RUN: %sea smt %s --step=small -o %t.smt2
+// RUN: %z3 %t.smt2 fp.spacer.order_children=2 2>&1 | OutputCheck %s
+// CHECK: ^unsat$
+
+#include "seahorn/seahorn.h"
+
+extern int nd1();
+extern int nd2();
+extern int nd3();
+extern int nd4();
+
+// Loop invariant.
+extern bool infer(int x, int y, int n);
+bool PARTIAL_FN inv(int x, int y, int n) { return infer(x, y, n); }
+
+// Test.
+int main(void) {
+  // Problem:
+  //   int x = 0;
+  //   int y = 0;
+  //   int n = *;
+  //   assume(n > 0);
+  //
+  //   while (x < n) {
+  //     x += 1; y += 1;
+  //   }
+  //
+  //   sassert(y == n);
+  // The program is safe because (x <= n && x == y) is an invariant of the loop.
+  // The loop invariant is over all of (x, y, n), so a solution exists.
+
+  int x1 = 0;
+  int y1 = 0;
+  int n1 = nd1();
+  assume(n1 > 0);
+
+  // Pre => Inv
+  __VERIFIER_assert(inv(x1, y1, n1));
+
+  // Inv && cond && Tr => Inv'
+  int x2 = nd2();
+  int y2 = nd3();
+  int n2 = nd4();
+  assume(inv(x2, y2, n2));
+  if (x2 < n2) {
+    x2 += 1; y2 += 1;
+    __VERIFIER_assert(inv(x2, y2, n2));
+    assume(0);
+  }
+
+  // Inv && !cond => Post
+  sassert(y2 == n2);
+}

--- a/test/synth-sm/04_loop_sat.c
+++ b/test/synth-sm/04_loop_sat.c
@@ -1,0 +1,42 @@
+// RUN: %sea smt %s --step=small -o %t.smt2
+// RUN: %z3 %t.smt2 fp.spacer.order_children=2 2>&1 | OutputCheck %s
+// CHECK: ^sat$
+
+#include "seahorn/seahorn.h"
+
+extern int nd1();
+extern int nd2();
+extern int nd3();
+extern int nd4();
+
+// Loop invariant.
+extern bool infer(int x, int n);
+bool PARTIAL_FN inv(int x, int n) { return infer(x, n); }
+
+// Test.
+int main(void) {
+  // See 03_loop.unsat.c.
+  //
+  // The inductive invariant is now restricted to x and n. It is impossible to
+  // say that x == y. Therefore, there is no solution that satisfies the
+  // property. Hence, the problem is SAT.
+
+  int x1 = 0;
+  int y1 = 0;
+  int n1 = nd1();
+  assume(n1 > 0);
+
+  __VERIFIER_assert(inv(x1, n1));
+
+  int x2 = nd2();
+  int y2 = nd3();
+  int n2 = nd4();
+  assume(inv(x2, n2));
+  if (x2 < n2) {
+    x2 += 1; y2 += 1;
+    __VERIFIER_assert(inv(x2, n2));
+    assume(0);
+  }
+
+  sassert(y2 == n2);
+}

--- a/test/synth-sm/05_object_unsat.c
+++ b/test/synth-sm/05_object_unsat.c
@@ -1,0 +1,81 @@
+// RUN: %sea smt %s --step=small -o %t.smt2
+// RUN: %z3 %t.smt2 fp.spacer.order_children=2 2>&1 | OutputCheck %s
+// CHECK: ^unsat$
+
+#include "seahorn/seahorn.h"
+
+extern int nd1();
+extern int nd2();
+extern int nd3();
+extern int nd4();
+extern int nd5();
+extern int nd6();
+extern int nd7();
+extern int nd8();
+extern int nd9();
+
+// Object invariant.
+extern bool infer(int count, int max);
+bool PARTIAL_FN inv(int count, int max) { return infer(count, max); }
+
+// Object methods.
+void incr(int *count, int *max) {
+  if (*count < *max) ++(*count);
+}
+
+void decr(int *count, int *max) {
+  if (*count > 0) --(*count);
+}
+
+void set(int *count, int *max, int nMax) {
+  assume(nMax > 0);
+  *count = 0;
+  *max = nMax;
+}
+
+int check(int *count, int *max) {
+  return (*count >= *max);
+}
+
+// Test.
+int main(void) {
+  // Program:
+  //   class Counter {
+  //     int count;
+  //     int max;
+  //
+  //     Counter(int nMax): count(0), max(nMax) { assume(max > 0); }
+  //
+  //     void incr() { if (count < max) ++count; }
+  //     void decr() { if (count > 0) --count; }
+  //     void set(int nMax) { assume(nMax > 0); count = 0; max = nMax; }
+  //     void check() { return count >= max; }
+  //   };
+  // Property: check() => (count == max)
+  //
+  // An object invariant is implied by the constructor, and invariant under any
+  // method of the object. If an object invariant implies a property, then the
+  // property must hold.
+
+  // constructor => inv
+  int count1 = 0;
+  int max1 = nd1();
+  assume(max1 > 0);
+  __VERIFIER_assert(inv(count1, max1));
+
+  // inv && op => inv'
+  int count2 = nd2();
+  int max2 = nd3();
+  assume(inv(count2, max2));
+  if (nd4()) incr(&count2, &max2);
+  else if (nd5()) decr(&count2, &max2);
+  else if (nd6()) set(&count2, &max2, nd7());
+  else check(&count2, &max2);
+  __VERIFIER_assert(inv(count2, max2));
+
+  // inv => safe
+  int count3 = nd8();
+  int max3 = nd9();
+  assume(inv(count3, max3));
+  if (check(&count3, &max3)) sassert(count3 == max3);
+}

--- a/test/synth-sm/06_object_sat.c
+++ b/test/synth-sm/06_object_sat.c
@@ -1,0 +1,68 @@
+// RUN: %sea smt %s --step=small -o %t.smt2
+// RUN: %z3 %t.smt2 fp.spacer.order_children=2 2>&1 | OutputCheck %s
+// CHECK: ^sat$
+
+#include "seahorn/seahorn.h"
+
+extern int nd1();
+extern int nd2();
+extern int nd3();
+extern int nd4();
+extern int nd5();
+extern int nd6();
+extern int nd7();
+extern int nd8();
+extern int nd9();
+
+// Object invariant.
+extern bool infer(int count, int max);
+bool PARTIAL_FN inv(int count, int max) { return infer(count, max); }
+
+// Object methods.
+void incr(int *count, int *max) {
+  if (*count < *max) ++(*count);
+}
+
+void decr(int *count, int *max) {
+  if (*count > 0) --(*count);
+}
+
+void set(int *count, int *max, int nMax) {
+  assume(nMax > 0);
+  *count = 0;
+  *max = nMax;
+}
+
+int check(int *count, int *max) {
+  return (*count >= *max);
+}
+
+// Test.
+int main(void) {
+  // See 05_object_unsat.c.
+  //
+  // The specification is now count < max, which is not true of the program.
+  // Hence, the program is SAT.
+
+  // constructor => inv
+  int count1 = 0;
+  int max1 = nd1();
+  assume(max1 > 0);
+  __VERIFIER_assert(inv(count1, max1));
+
+  // inv && op => inv'
+  int count2 = nd2();
+  int max2 = nd3();
+  assume(inv(count2, max2));
+  if (nd4()) incr(&count2, &max2);
+  else if (nd5()) decr(&count2, &max2);
+  else if (nd6()) set(&count2, &max2, nd7());
+  else check(&count2, &max2);
+  __VERIFIER_assert(inv(count2, max2));
+
+  // inv => safe
+  int count3 = nd8();
+  int max3 = nd9();
+  assume(inv(count3, max3));
+  sassert(count3 < max3);
+}

--- a/test/synth-sm/07_mem_unsat.c
+++ b/test/synth-sm/07_mem_unsat.c
@@ -1,0 +1,69 @@
+// RUN: %sea smt %s --step=small -o %t.smt2
+// RUN: %z3 %t.smt2 fp.spacer.order_children=2 2>&1 | OutputCheck %s
+// CHECK: ^unsat$
+
+#include "seahorn/seahorn.h"
+
+extern int nd1();
+extern int nd2();
+extern int nd3();
+extern int nd4();
+extern int nd5();
+
+// Compositional invariant.
+extern bool infer(int owner, int sum, int i, int v);
+bool PARTIAL_FN inv(int owner, int sum, int i, int v) {
+  if (v == 0) return 1;
+  return infer(owner, sum, i, v);
+}
+
+// Test.
+int main(void) {
+  // Assumption: init => forall i: m[i] = 0
+  // Program:
+  //   mapping(int => int) m;
+  //   int owner;
+  //   int sum = 0;
+  //   
+  //   void body(int i) {
+  //     if (i == owner) {
+  //       v += 1; sum += 1;
+  //     }
+  //   }
+  // Property: If a reactive system implements body, then it is always the case
+  //           that v[i] <= sum.
+  //
+  // A (sound but incomplete) solution to the above problem is to find a
+  // compositional invariant Inv such that:
+  // 1. Init => Inv
+  // 2. Inv(i) && Tr(i) => Inv'(i)
+  // 3. Inv(i) && i != j && Tr(i) && Inv(j) => Inv'(i)
+  // In this case, such an invariant does exist and the program must be UNSAT.
+
+  int owner = nd1();
+  int sum = 0;
+
+  while (1) {
+    int i = nd2();
+
+    // START_TX[
+    int j = nd3();
+    int v = nd4();
+    int v_j = nd5();
+    assume(i != j);
+    assume(inv(owner, sum, i, v));
+    assume(inv(owner, sum, j, v_j));
+    // ]END
+
+    if (i != owner) {
+      v += 1;
+      sum += 1;
+    }
+    sassert(v <= sum);
+
+    // END_TX[
+    __VERIFIER_assert(inv(owner, sum, i, v));
+    __VERIFIER_assert(inv(owner, sum, j, v_j));
+    // ]END
+  }
+}

--- a/test/synth-sm/08_mem_sat.c
+++ b/test/synth-sm/08_mem_sat.c
@@ -1,0 +1,56 @@
+// RUN: %sea smt %s --step=small -o %t.smt2
+// RUN: %z3 %t.smt2 fp.spacer.order_children=2 2>&1 | OutputCheck %s
+// CHECK: ^sat$
+
+#include "seahorn/seahorn.h"
+
+extern int nd1();
+extern int nd2();
+extern int nd3();
+extern int nd4();
+extern int nd5();
+
+// Compositional invariant.
+extern bool infer(int owner, int sum, int i, int v);
+bool PARTIAL_FN inv(int owner, int sum, int i, int v) {
+  if (v == 0) return 1;
+  return infer(owner, sum, i, v);
+}
+
+// Test.
+int main(void) {
+  // See 08_mem_unsat.c.
+  //
+  // Property: If a reactive system implements body, then it is always the case
+  //           that v[i] <= sum.
+  //
+  // This property does not hold. As PCMC is sound, a compositional invariant
+  // does not exist. Therefore, the program is SAT.
+
+  int owner = nd1();
+  int sum = 0;
+
+  while (1) {
+    int i = nd2();
+
+    // START_TX[
+    int j = nd3();
+    int v = nd4();
+    int v_j = nd5();
+    assume(i != j);
+    assume(inv(owner, sum, i, v));
+    assume(inv(owner, sum, j, v_j));
+    // ]END
+
+    if (i != owner) {
+      v += 1;
+      sum += 1;
+    }
+    sassert(v == sum);
+
+    // END_TX[
+    __VERIFIER_assert(inv(owner, sum, i, v));
+    __VERIFIER_assert(inv(owner, sum, j, v_j));
+    // ]END
+  }
+}

--- a/test/synth-sm/09_partitioned_unsat.c
+++ b/test/synth-sm/09_partitioned_unsat.c
@@ -1,0 +1,44 @@
+// RUN: %sea smt %s --step=small -o %t.smt2
+// RUN: %z3 %t.smt2 fp.spacer.order_children=2 2>&1 | OutputCheck %s
+// CHECK: ^unsat$
+
+#include "seahorn/seahorn.h"
+
+extern int nd1();
+extern int nd2();
+extern int nd3();
+extern int nd4();
+extern int nd5();
+extern int nd6();
+
+// Loop invariant.
+extern bool infer(int a, int b);
+bool PARTIAL_FN inv1(int x, int y) { return infer(x, y); }
+bool PARTIAL_FN inv2(int x, int n) { return infer(x, n); }
+
+// Test.
+int main(void) {
+  // See 03_loop.unsat.c.
+
+  int x1 = 0;
+  int y1 = 0;
+  int n1 = nd1();
+  assume(n1 > 0);
+
+  if (nd2()) __VERIFIER_assert(inv1(x1, y1));
+  else __VERIFIER_assert(inv2(x1, n1));
+
+  int x2 = nd3();
+  int y2 = nd4();
+  int n2 = nd5();
+  assume(inv1(x2, y2));
+  assume(inv2(x2, n2));
+  if (x2 < n2) {
+    x2 += 1; y2 += 1;
+    if (nd6()) __VERIFIER_assert(inv1(x2, y2));
+    else __VERIFIER_assert(inv2(x2, n2));
+    assume(0);
+  }
+
+  sassert(y2 == n2);
+}

--- a/test/synth-sm/10_partitioned_sat.c
+++ b/test/synth-sm/10_partitioned_sat.c
@@ -1,0 +1,44 @@
+// RUN: %sea smt %s --step=small -o %t.smt2
+// RUN: %z3 %t.smt2 fp.spacer.order_children=2 2>&1 | OutputCheck %s
+// CHECK: ^sat$
+
+#include "seahorn/seahorn.h"
+
+extern int nd1();
+extern int nd2();
+extern int nd3();
+extern int nd4();
+extern int nd5();
+extern int nd6();
+
+// Loop invariant.
+extern bool infer(int a, int b);
+bool PARTIAL_FN inv1(int x, int n) { return infer(x, n); }
+bool PARTIAL_FN inv2(int y, int n) { return infer(y, n); }
+
+// Test.
+int main(void) {
+  // See 03_loop.unsat.c.
+
+  int x1 = 0;
+  int y1 = 0;
+  int n1 = nd1();
+  assume(n1 > 0);
+
+  if (nd2()) __VERIFIER_assert(inv1(x1, n1));
+  else __VERIFIER_assert(inv2(y1, n1));
+
+  int x2 = nd2();
+  int y2 = nd3();
+  int n2 = nd4();
+  assume(inv1(x2, n2));
+  assume(inv2(y2, n2));
+  if (x2 < n2) {
+    x2 += 1; y2 += 1;
+    if (nd6()) __VERIFIER_assert(inv1(x2, n2));
+    else __VERIFIER_assert(inv2(y2, n2));
+    assume(0);
+  }
+
+  sassert(y2 == n2);
+}

--- a/test/synth-sm/11_split_unsat.c
+++ b/test/synth-sm/11_split_unsat.c
@@ -1,0 +1,58 @@
+// RUN: %sea smt %s --step=small -o %t.smt2
+// RUN: %z3 %t.smt2 fp.spacer.order_children=2 2>&1 | OutputCheck %s
+// CHECK: ^unsat$
+
+#include "seahorn/seahorn.h"
+
+extern int nd1();
+extern int nd2();
+extern int nd3();
+extern int nd4();
+extern int nd5();
+
+// Compositional invariant.
+extern bool infer(int sum, int v);
+bool PARTIAL_FN inv1(int sum, int v) {
+  if (v == 0) return 1;
+  return infer(sum, v);
+}
+bool PARTIAL_FN inv2(int sum, int v) {
+  if (v == 0) return 1;
+  return infer(sum, v);
+}
+
+// Test.
+int main(void) {
+  // see 07_mem_unsat.c.
+
+  int owner = nd1();
+  int sum = 0;
+
+  while (1) {
+    int i = nd2();
+
+    // START_TX[
+    int j = nd3();
+    int v = nd4();
+    int v_j = nd5();
+    assume(i != j);
+    if (i == owner) assume(inv1(sum, v));
+    else assume(inv2(sum, v));
+    if (j == owner) assume(inv1(sum, v_j));
+    else assume(inv2(sum, v_j));
+    // ]END
+
+    if (i != owner) {
+      v += 1;
+      sum += 1;
+    }
+    sassert(v <= sum);
+
+    // END_TX[
+    if (i == owner) __VERIFIER_assert(inv1(sum, v));
+    else __VERIFIER_assert(inv2(sum, v));
+    if (j == owner) __VERIFIER_assert(inv1(sum, v_j));
+    else __VERIFIER_assert(inv2(sum, v_j));
+    // ]END
+  }
+}

--- a/test/synth-sm/12_split_sat.c
+++ b/test/synth-sm/12_split_sat.c
@@ -1,0 +1,58 @@
+// RUN: %sea smt %s --step=small -o %t.smt2
+// RUN: %z3 %t.smt2 fp.spacer.order_children=2 2>&1 | OutputCheck %s
+// CHECK: ^sat$
+
+#include "seahorn/seahorn.h"
+
+extern int nd1();
+extern int nd2();
+extern int nd3();
+extern int nd4();
+extern int nd5();
+
+// Compositional invariant.
+extern bool infer(int sum, int v);
+bool PARTIAL_FN inv1(int sum, int v) {
+  if (v == 0) return 1;
+  return infer(sum, v);
+}
+bool PARTIAL_FN inv2(int sum, int v) {
+  if (v == 0) return 1;
+  return infer(sum, v);
+}
+
+// Test.
+int main(void) {
+  // see 08_mem_sat.c.
+
+  int owner = nd1();
+  int sum = 0;
+
+  while (1) {
+    int i = nd2();
+
+    // START_TX[
+    int j = nd3();
+    int v = nd4();
+    int v_j = nd5();
+    assume(i != j);
+    if (i == owner) assume(inv1(sum, v));
+    else assume(inv2(sum, v));
+    if (j == owner) assume(inv1(sum, v_j));
+    else assume(inv2(sum, v_j));
+    // ]END
+
+    if (i != owner) {
+      v += 1;
+      sum += 1;
+    }
+    sassert(v == sum);
+
+    // END_TX[
+    if (i == owner) __VERIFIER_assert(inv1(sum, v));
+    else __VERIFIER_assert(inv2(sum, v));
+    if (j == owner) __VERIFIER_assert(inv1(sum, v_j));
+    else __VERIFIER_assert(inv2(sum, v_j));
+    // ]END
+  }
+}

--- a/test/synth-sm/lit.cfg
+++ b/test/synth-sm/lit.cfg
@@ -1,0 +1,68 @@
+# -*- Python -*-
+
+import os
+import sys
+import re
+import platform
+import lit.util
+import lit.formats
+
+config.name = 'Seahorn'
+
+config.test_format = lit.formats.ShTest(execute_external=False)
+config.suffixes = ['.c', '.cpp']
+config.excludes = [ # These are no tests
+                    'list1_check.c'
+                  ]
+config.test_source_root = os.path.dirname(__file__)
+config.test_exec_root = lit_config.params.get('test_dir', '.')
+config.useProgressBar= True
+config.showOutput= True
+config.timeout=30
+config.max_time=30
+
+repositoryRoot = os.path.dirname (os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+def addEnv(name):
+   if name in os.environ:
+      config.environment[name] = os.environ[name]
+
+def isexec (fpath):
+    if fpath == None: return False
+    return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
+
+def which (cmd):
+   return lit.util.which(cmd, config.environment['PATH'])
+def getSea ():
+   seahorn = None
+   if 'SEAHORN' in os.environ:
+      seahorn = os.environ ['SEAHORN']
+   if seahorn is None or not isexec(seahorn):
+      seahorn = which('sea')
+   return seahorn
+def getZ3 ():
+   z3_cmd = None
+   if 'Z3' in os.environ:
+      z3_cmd = os.environ ['Z3']
+   if z3_cmd is None or not isexec(z3_cmd):
+      z3_cmd = which('z3')
+   return z3_cmd
+
+addEnv('HOME')
+addEnv('PWD')
+addEnv('C_INCLUDE_PATH')
+
+lit_config.note('Repository root is {}'.format(repositoryRoot))
+
+sea_cmd = getSea()
+z3_cmd = getZ3()
+if not isexec(sea_cmd):
+   lit_config.fatal('Could not find the Seahorn executable')
+if not isexec(z3_cmd):
+   lit_config.fatal('Cound not find the Z3 executable')
+
+config.substitutions.append(('%sea', sea_cmd))
+config.substitutions.append(('%z3', z3_cmd))
+
+## seahorn options here
+config.substitutions.append(('%dsa', "--dsa=sea-cs"))

--- a/tools/seahorn/CMakeLists.txt
+++ b/tools/seahorn/CMakeLists.txt
@@ -8,6 +8,7 @@ set (USED_LIBS
   ${SEA_DSA_LIBS}
   SeaSupport
   ${LLVM_SEAHORN_LIBS}
+  SeaLlvmIpo
   ${GMP_LIB}
   ${RT_LIB}
   )

--- a/tools/seapp/CMakeLists.txt
+++ b/tools/seapp/CMakeLists.txt
@@ -8,6 +8,7 @@ set (USED_LIBS
   SeaSupport
   ${LLVM_SEAHORN_LIBS}
   ${Boost_SYSTEM_LIBRARY}
+  SeaLlvmIpo
   ${GMP_LIB}
   ${RT_LIB})
 

--- a/tools/seapp/seapp.cc
+++ b/tools/seapp/seapp.cc
@@ -8,6 +8,9 @@
 ///
 // SeaPP-- LLVM bitcode Pre-Processor for Verification
 ///
+
+#include "llvm_seahorn/InitializePasses.h"
+#include "llvm_seahorn/Transforms/IPO.h"
 #include "llvm/Bitcode/BitcodeWriter.h"
 #include "llvm/Bitcode/BitcodeWriterPass.h"
 #include "llvm/IR/LLVMContext.h"
@@ -375,6 +378,7 @@ int main(int argc, char **argv) {
   llvm::initializeDsaLibFuncInfoPass(Registry);
 
   llvm::initializeCompleteCallGraphPass(Registry);
+  llvm::initializeAnnotation2MetadataLegacyPass(Registry);
 
   // add an appropriate DataLayout instance for the module
   const llvm::DataLayout *dl = &module->getDataLayout();
@@ -385,6 +389,7 @@ int main(int argc, char **argv) {
 
   assert(dl && "Could not find Data Layout for the module");
 
+  pm_wrapper.add(llvm_seahorn::createAnnotation2MetadataLegacyPass());
   pm_wrapper.add(seahorn::createSeaBuiltinsWrapperPass());
 
   if (RenameNondet)


### PR DESCRIPTION
This PR allows Seahorn to synthesize predicates from partial definitions using small step semantics.

- A function `f` that is marked with a `partial` annotation is treated as a partial function definition. If `f` returns 1 on an input, the input is included in the base case. If `f` calls to an external function, then the call is treated as `assume(0);`.
- New intrinsics, `sea.synth.assume` and `sea.synth.assert` are added to provide specifications to a partial function `f`. These intrinsics are used in place of `verifier.assume` and `verifier.assert` when the argument is a partial function. 
- If `sea.synth.assume` appears in a program, then the predicate is assumed to be true.
- If `sea.synth.assert` appears in a program, then the predicate must be true. In terms of the CHC encoding, this means that the predicate appears on the rhs of a rule.

The test cases demonstrate use case for the feature.