### PR TITLE
fix(local): do not drop ref of BBs with uses

### DIFF
--- a/lib/Analysis/CanReadUndef.cc
+++ b/lib/Analysis/CanReadUndef.cc
@@ -10,6 +10,9 @@
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/CommandLine.h"
 
+#include "seahorn/Support/SeaDebug.h"
+#include "seahorn/Support/SeaLog.hh"
+
 using namespace llvm;
 
 static llvm::cl::opt<bool>
@@ -108,6 +111,11 @@ namespace seahorn {
           
           // -- the normal case
           for (unsigned i = 0; i < u.getNumOperands (); i++) {
+            if (u.getOperand(i) == NULL) {
+              LOG("read-undef",
+                  WARN << "User of " << b.getName() << " is mal-formed!\n";);
+              continue;
+            }
             if (isa <UndefValue> (u.getOperand (i))) {
               m_undef_num++;
 	      if (hasDebugLoc(dyn_cast<Instruction>(&u))) {

--- a/lib/Transforms/Utils/Local.cc
+++ b/lib/Transforms/Utils/Local.cc
@@ -74,7 +74,10 @@ void reduceToRegion(Function &F, DenseSet<const BasicBlock *> &region,
   }
 
   for (auto BB : dead) {
-    BB->dropAllReferences();
+    if (BB->hasNUses(0)) {
+      // only drop if has no uses
+      BB->dropAllReferences();
+    }
   }
 
   for (auto *bb : dead) {


### PR DESCRIPTION
In `Local.cc:reduceToRegion`, it was possible to remove all references on a "dead" basic block that has greater than 0 uses (`BB->hasNUses(0) == false`); however, we do not completely delete these Basic Blocks in the following for loop (using `eraseFromParent`); this behaviour would create malformed IR basic blocks and cause crashes in passes such as `CanReadUndef` and `llvm::VerifierPass`.