### PR TITLE
fix(alias): replace all uses of the alias with the correct function

### DIFF
--- a/lib/Transforms/Utils/DevirtFunctions.cc
+++ b/lib/Transforms/Utils/DevirtFunctions.cc
@@ -24,7 +24,7 @@ static bool isIndirectCall(CallSite &CS) {
   if (!v)
     return false;
 
-  v = v->stripPointerCasts();
+  v = v->stripPointerCastsAndAliases();
   return !isa<Function>(v);
 }
 


### PR DESCRIPTION
Use stripPointerCastsAndAliases to check indirect calls.
If the global alias is used in a call, replace all uses with the correct function call.
Revise the new function name ended with `.addr`.