### PR TITLE
feat(seahorn): small step synthesis does not rely on opsem order

### DIFF
--- a/include/seahorn/LegacyOperationalSemantics.hh
+++ b/include/seahorn/LegacyOperationalSemantics.hh
@@ -1,8 +1,8 @@
 #pragma once
 
+#include "seahorn/Expr/Expr.hh"
 #include "seahorn/OperationalSemantics.hh"
 #include "seahorn/SymStore.hh"
-#include "seahorn/Expr/Expr.hh"
 #include "llvm/IR/InstVisitor.h"
 
 namespace seahorn {
@@ -54,6 +54,11 @@ public:
     execBr(ctx.values(), src, dst, ctx.side(), ctx.getPathCond());
   }
 
+  void execRange(const llvm::BasicBlock::iterator begin,
+                 const llvm::BasicBlock::iterator end, OpSemContext &ctx) {
+    execRange(ctx.values(), begin, end, ctx.side(), ctx.getPathCond());
+  }
+
   /// Deprecated old interface
   virtual void exec(SymStore &s, const BasicBlock &bb, ExprVector &side,
                     Expr act) = 0;
@@ -66,6 +71,12 @@ public:
 
   virtual void execBr(SymStore &s, const BasicBlock &src, const BasicBlock &dst,
                       ExprVector &side, Expr act) = 0;
+
+  virtual void execRange(SymStore &s, const llvm::BasicBlock::iterator begin,
+                         const llvm::BasicBlock::iterator end, ExprVector &side,
+                         Expr act) {
+    assert(false);
+  }
 };
 
 /// \brief Evaluate (read) all arguments of \p fi in store \p s

--- a/include/seahorn/OperationalSemantics.hh
+++ b/include/seahorn/OperationalSemantics.hh
@@ -206,11 +206,10 @@ public:
   ExprFactory &getExprFactory() const { return m_efac; }
   ExprFactory &efac() const { return m_efac; }
 
-  void resetFilter() {m_filter.clear();}
-  bool isInFilter(const llvm::Value &v) const {return m_filter.count(&v);}
-  void addToFilter(const llvm::Value& v) {m_filter.insert(&v);}
-  template <typename Iterator>
-  void addToFilter(Iterator begin, Iterator end) {
+  void resetFilter() { m_filter.clear(); }
+  bool isInFilter(const llvm::Value &v) const { return m_filter.count(&v); }
+  void addToFilter(const llvm::Value &v) { m_filter.insert(&v); }
+  template <typename Iterator> void addToFilter(Iterator begin, Iterator end) {
     m_filter.insert(begin, end);
   }
 
@@ -240,6 +239,14 @@ public:
   virtual void execBr(const llvm::BasicBlock &src, const llvm::BasicBlock &dst,
                       OpSemContext &ctx) = 0;
 
+  /// \brief Executes the instructions (except for PHINode) from \p begin, up to
+  /// \p end assuming that \p begin preceeds \p end in some block.
+  virtual void execRange(const llvm::BasicBlock::iterator begin,
+                         const llvm::BasicBlock::iterator end,
+                         OpSemContext &ctx) {
+    assert(false);
+  }
+
   /// \brief Returns a symbolic register correspond to llvm::Value \p v
   ///
   /// Creates a new register if one does not exists
@@ -262,7 +269,6 @@ public:
   virtual bool isTracked(const llvm::Value &v) const {
     return m_filter.empty() || m_filter.count(&v);
   }
-
 
   /// \brief Returns a symbolic value of \p v in the given store \p s
   /// \p v is either a constant or has a corresponding symbolic

--- a/include/seahorn/UfoOpSem.hh
+++ b/include/seahorn/UfoOpSem.hh
@@ -76,6 +76,10 @@ public:
   void execBr(SymStore &s, const BasicBlock &src, const BasicBlock &dst,
               ExprVector &side, Expr act) override;
 
+  void execRange(SymStore &s, const llvm::BasicBlock::iterator begin,
+                 const llvm::BasicBlock::iterator end, ExprVector &side,
+                 Expr act) override;
+
   Expr symb(const Value &v) override;
   const Value &conc(Expr v) const override;
   bool isTracked(const Value &v) const override;

--- a/lib/seahorn/UfoOpSem.cc
+++ b/lib/seahorn/UfoOpSem.cc
@@ -1206,6 +1206,17 @@ void UfoOpSem::execBr(SymStore &s, const BasicBlock &src, const BasicBlock &dst,
   }
 }
 
+void UfoOpSem::execRange(SymStore &s, const llvm::BasicBlock::iterator begin,
+                         const llvm::BasicBlock::iterator end, ExprVector &side,
+                         Expr act) {
+  OpSemVisitor v(s, *this, side);
+  v.setActiveLit(act);
+  for (const auto &I : llvm::make_range(begin, end)) {
+    v.visit(const_cast<Instruction &>(I));
+  }
+  v.resetActiveLit();
+}
+
 // internal function only for debugging (avoids duplication of code)
 static void printCS(const CallSiteInfo &csi, const FunctionInfo &fi) {
   errs() << "Call instruction: " << *csi.m_cs.getInstruction() << "\n";


### PR DESCRIPTION
Small step synthesis relies on the order of instructions in `side`. However, opsem does not place guarantees on the order of terms in `side`. To fix this, I have:
1. exposed a new interface (`execRange`) through `OperationalSemantics` to assemble individual instructions,
2. used `execRange` within synthesis to assemble the rhs of each synthesis rule.

Note: clang-format required that I fix `LegacyOperationalSemantics.hh` and `OperationalSemantics.hh`.