### PR TITLE
Fixed bug in KleeInternalize.

### DIFF
--- a/lib/Transforms/Instrumentation/KleeInternalize.cc
+++ b/lib/Transforms/Instrumentation/KleeInternalize.cc
@@ -12,11 +12,11 @@ terms.
 #include "llvm/IR/Module.h"
 #include "llvm/Pass.h"
 
+#include "seahorn/Support/SeaDebug.h"
 #include "llvm/Analysis/CallGraph.h"
 #include "llvm/Analysis/TargetLibraryInfo.h"
-#include "llvm/Support/raw_ostream.h"
 #include "llvm/Support/CommandLine.h"
-#include "seahorn/Support/SeaDebug.h"
+#include "llvm/Support/raw_ostream.h"
 
 #include <fstream>
 #include <set>

--- a/lib/Transforms/Instrumentation/KleeInternalize.cc
+++ b/lib/Transforms/Instrumentation/KleeInternalize.cc
@@ -189,6 +189,8 @@ public:
     m_externalNames.insert("seahorn.fail");
     m_externalNames.insert("verifier.error");
 
+    m_externalNames.insert("__SEA_assume");
+
     m_externalNames.insert("__VERIFIER_assume");
     m_externalNames.insert("__VERIFIER_error");
 


### PR DESCRIPTION
The new `__SEA_assume` primitive is not exempt for `KleeInternalize`. This breaks executable counter-examples.