### PR TITLE
fix(snyth): synthesis assertions are preserved

### DIFF
--- a/include/seahorn/seahorn.h
+++ b/include/seahorn/seahorn.h
@@ -55,14 +55,18 @@ extern void sea_reset_modified(char *);
 /* Convenience macros */
 #define assume __SEA_assume
 
+#ifdef VACCHECK
+/* See https://github.com/seahorn/seahorn/projects/5 for details */
+#define sassert(X)                                                             \
+  (void)((__VERIFIER_assert(X), (X)) || (__VERIFIER_error(), 0))
+#elif defined(SEA_SYNTH)
+/* See test/synth/ for use cases */
 #define PARTIAL_FN                                                             \
   __attribute__((annotate("partial"))) __attribute__((noinline))
-
-/* See https://github.com/seahorn/seahorn/projects/5 for details */
-#ifdef VACCHECK
 #define sassert(X)                                                             \
   (void)((__VERIFIER_assert(X), (X)) || (__VERIFIER_error(), 0))
 #else
+/* Default semantics of sassert */
 #define sassert(X) (void)((X) || (__VERIFIER_error(), 0))
 #endif
 

--- a/lib/Transforms/Scalar/PromoteVerifierCalls.cc
+++ b/lib/Transforms/Scalar/PromoteVerifierCalls.cc
@@ -217,18 +217,24 @@ bool PromoteVerifierCalls::runOnFunction(Function &F) {
       if (auto partialFn = extractPartialFnCall(arg0)) {
         // Selects proper synthesis call.
         Function *nfn;
+        bool insert_assume;
         if (fn->getName().equals("__VERIFIER_assume") ||
-            fn->getName().equals("__SEA_assume"))
+            fn->getName().equals("__SEA_assume")) {
           nfn = m_synthAssumeFn;
-        else if (fn->getName().equals("__VERIFIER_assert"))
+          insert_assume = true;
+        } else if (fn->getName().equals("__VERIFIER_assert")) {
           nfn = m_synthAssertFn;
-        else
+          insert_assume = false;
+        } else {
           assert(0);
+        }
 
         // Generates code.
         IRBuilder<> Builder(F.getContext());
         Builder.SetInsertPoint(&I);
-        chkCi = Builder.CreateCall(m_assumeFn, partialFn);
+        if (insert_assume) {
+          chkCi = Builder.CreateCall(m_assumeFn, partialFn);
+        }
         nfnCi = Builder.CreateCall(nfn, partialFn);
       } else {
         // Selects proper verification call.

--- a/test/synth/01_interpolant_unsat.c
+++ b/test/synth/01_interpolant_unsat.c
@@ -12,6 +12,7 @@
 //
 // CHECK: ^unsat$
 
+#define SEA_SYNTH
 #include "seahorn/seahorn.h"
 
 extern int nd1();
@@ -53,7 +54,7 @@ int main(void) {
   int y1 = nd2();
   int z1 = nd3();
   assume((w1 != 0) && (y1 == 2 * z1 + 6));
-  __VERIFIER_assert(itp(y1, z1));
+  sassert(itp(y1, z1));
 
   int x2 = nd4();
   int y2 = nd5();

--- a/test/synth/02_interpolant_sat.c
+++ b/test/synth/02_interpolant_sat.c
@@ -12,6 +12,7 @@
 //
 // CHECK: ^sat$
 
+#define SEA_SYNTH
 #include "seahorn/seahorn.h"
 
 extern int nd1();
@@ -38,7 +39,7 @@ int main(void) {
   int y1 = nd2();
   int z1 = nd3();
   assume((w1 != 0) && (y1 = 2 * z1 + 6));
-  __VERIFIER_assert(itp(y1, z1));
+  sassert(itp(y1, z1));
 
   int x2 = nd4();
   int y2 = nd5();

--- a/test/synth/03_loop_unsat.c
+++ b/test/synth/03_loop_unsat.c
@@ -12,6 +12,7 @@
 //
 // CHECK: ^unsat$
 
+#define SEA_SYNTH
 #include "seahorn/seahorn.h"
 
 extern int nd1();
@@ -45,7 +46,7 @@ int main(void) {
   assume(n1 > 0);
 
   // Pre => Inv
-  __VERIFIER_assert(inv(x1, y1, n1));
+  sassert(inv(x1, y1, n1));
 
   // Inv && cond && Tr => Inv'
   int x2 = nd2();
@@ -54,7 +55,7 @@ int main(void) {
   assume(inv(x2, y2, n2));
   if (x2 < n2) {
     x2 += 1; y2 += 1;
-    __VERIFIER_assert(inv(x2, y2, n2));
+    sassert(inv(x2, y2, n2));
     assume(0);
   }
 

--- a/test/synth/05_object_unsat.c
+++ b/test/synth/05_object_unsat.c
@@ -12,6 +12,7 @@
 //
 // CHECK: ^unsat$
 
+#define SEA_SYNTH
 #include "seahorn/seahorn.h"
 
 extern int nd1();
@@ -71,7 +72,7 @@ int main(void) {
   int count1 = 0;
   int max1 = nd1();
   assume(max1 > 0);
-  __VERIFIER_assert(inv(count1, max1));
+  sassert(inv(count1, max1));
 
   // inv && op => inv'
   int count2 = nd2();
@@ -81,7 +82,7 @@ int main(void) {
   else if (nd5()) decr(&count2, &max2);
   else if (nd6()) set(&count2, &max2, nd7());
   else check(&count2, &max2);
-  __VERIFIER_assert(inv(count2, max2));
+  sassert(inv(count2, max2));
 
   // inv => safe
   int count3 = nd8();

--- a/test/synth/06_object_sat.c
+++ b/test/synth/06_object_sat.c
@@ -12,6 +12,7 @@
 //
 // CHECK: ^sat$
 
+#define SEA_SYNTH
 #include "seahorn/seahorn.h"
 
 extern int nd1();
@@ -58,7 +59,7 @@ int main(void) {
   int count1 = 0;
   int max1 = nd1();
   assume(max1 > 0);
-  __VERIFIER_assert(inv(count1, max1));
+  sassert(inv(count1, max1));
 
   // inv && op => inv'
   int count2 = nd2();
@@ -68,7 +69,7 @@ int main(void) {
   else if (nd5()) decr(&count2, &max2);
   else if (nd6()) set(&count2, &max2, nd7());
   else check(&count2, &max2);
-  __VERIFIER_assert(inv(count2, max2));
+  sassert(inv(count2, max2));
 
   // inv => safe
   int count3 = nd8();

--- a/test/synth/07_mem_unsat.c
+++ b/test/synth/07_mem_unsat.c
@@ -12,6 +12,7 @@
 //
 // CHECK: ^unsat$
 
+#define SEA_SYNTH
 #include "seahorn/seahorn.h"
 
 extern int nd1();
@@ -72,8 +73,8 @@ int main(void) {
     sassert(v <= sum);
 
     // END_TX[
-    __VERIFIER_assert(inv(owner, sum, i, v));
-    __VERIFIER_assert(inv(owner, sum, j, v_j));
+    sassert(inv(owner, sum, i, v));
+    sassert(inv(owner, sum, j, v_j));
     // ]END
   }
 }

--- a/test/synth/08_mem_sat.c
+++ b/test/synth/08_mem_sat.c
@@ -12,6 +12,7 @@
 //
 // CHECK: ^sat$
 
+#define SEA_SYNTH
 #include "seahorn/seahorn.h"
 
 extern int nd1();
@@ -59,8 +60,8 @@ int main(void) {
     sassert(v == sum);
 
     // END_TX[
-    __VERIFIER_assert(inv(owner, sum, i, v));
-    __VERIFIER_assert(inv(owner, sum, j, v_j));
+    sassert(inv(owner, sum, i, v));
+    sassert(inv(owner, sum, j, v_j));
     // ]END
   }
 }

--- a/test/synth/09_partitioned_unsat.c
+++ b/test/synth/09_partitioned_unsat.c
@@ -1,8 +1,4 @@
-// RUN: %sea smt %s --step=small -o %t.sm.smt2
-// RUN: %z3 %t.sm.smt2 fp.spacer.order_children=2 2>&1 | OutputCheck %s
-//
-// RUN: %sea smt %s --step=small --inline -o %t.sm.inline.smt2
-// RUN: %z3 %t.sm.inline.smt2 fp.spacer.order_children=2 2>&1 | OutputCheck %s
+// This test struggles on small step.
 //
 // RUN: %sea smt %s --step=large -o %t.lg.smt2
 // RUN: %z3 %t.lg.smt2 fp.spacer.order_children=2 2>&1 | OutputCheck %s
@@ -12,6 +8,7 @@
 //
 // CHECK: ^unsat$
 
+#define SEA_SYNTH
 #include "seahorn/seahorn.h"
 
 extern int nd1();
@@ -35,8 +32,8 @@ int main(void) {
   int n1 = nd1();
   assume(n1 > 0);
 
-  if (nd2()) __VERIFIER_assert(inv1(x1, y1));
-  else __VERIFIER_assert(inv2(x1, n1));
+  sassert(inv1(x1, y1));
+  sassert(inv2(x1, n1));
 
   int x2 = nd3();
   int y2 = nd4();
@@ -45,8 +42,8 @@ int main(void) {
   assume(inv2(x2, n2));
   if (x2 < n2) {
     x2 += 1; y2 += 1;
-    if (nd6()) __VERIFIER_assert(inv1(x2, y2));
-    else __VERIFIER_assert(inv2(x2, n2));
+    sassert(inv1(x2, y2));
+    sassert(inv2(x2, n2));
     assume(0);
   }
 

--- a/test/synth/10_partitioned_sat.c
+++ b/test/synth/10_partitioned_sat.c
@@ -12,14 +12,13 @@
 //
 // CHECK: ^sat$
 
+#define SEA_SYNTH
 #include "seahorn/seahorn.h"
 
 extern int nd1();
 extern int nd2();
 extern int nd3();
 extern int nd4();
-extern int nd5();
-extern int nd6();
 
 // Loop invariant.
 extern bool infer(int a, int b);
@@ -35,8 +34,8 @@ int main(void) {
   int n1 = nd1();
   assume(n1 > 0);
 
-  if (nd2()) __VERIFIER_assert(inv1(x1, n1));
-  else __VERIFIER_assert(inv2(y1, n1));
+  sassert(inv1(x1, n1));
+  sassert(inv2(y1, n1));
 
   int x2 = nd2();
   int y2 = nd3();
@@ -45,8 +44,8 @@ int main(void) {
   assume(inv2(y2, n2));
   if (x2 < n2) {
     x2 += 1; y2 += 1;
-    if (nd6()) __VERIFIER_assert(inv1(x2, n2));
-    else __VERIFIER_assert(inv2(y2, n2));
+    sassert(inv1(x2, n2));
+    sassert(inv2(y2, n2));
     assume(0);
   }
 

--- a/test/synth/11_split_unsat.c
+++ b/test/synth/11_split_unsat.c
@@ -12,6 +12,7 @@
 //
 // CHECK: ^unsat$
 
+#define SEA_SYNTH
 #include "seahorn/seahorn.h"
 
 extern int nd1();
@@ -59,10 +60,10 @@ int main(void) {
     sassert(v <= sum);
 
     // END_TX[
-    if (i == owner) __VERIFIER_assert(inv1(sum, v));
-    else __VERIFIER_assert(inv2(sum, v));
-    if (j == owner) __VERIFIER_assert(inv1(sum, v_j));
-    else __VERIFIER_assert(inv2(sum, v_j));
+    if (i == owner) sassert(inv1(sum, v));
+    else sassert(inv2(sum, v));
+    if (j == owner) sassert(inv1(sum, v_j));
+    else sassert(inv2(sum, v_j));
     // ]END
   }
 }

--- a/test/synth/12_split_sat.c
+++ b/test/synth/12_split_sat.c
@@ -12,6 +12,7 @@
 //
 // CHECK: ^sat$
 
+#define SEA_SYNTH
 #include "seahorn/seahorn.h"
 
 extern int nd1();
@@ -59,10 +60,10 @@ int main(void) {
     sassert(v == sum);
 
     // END_TX[
-    if (i == owner) __VERIFIER_assert(inv1(sum, v));
-    else __VERIFIER_assert(inv2(sum, v));
-    if (j == owner) __VERIFIER_assert(inv1(sum, v_j));
-    else __VERIFIER_assert(inv2(sum, v_j));
+    if (i == owner) sassert(inv1(sum, v));
+    else sassert(inv2(sum, v));
+    if (j == owner) sassert(inv1(sum, v_j));
+    else sassert(inv2(sum, v_j));
     // ]END
   }
 }

--- a/test/synth/13_philosophers_unsat.c
+++ b/test/synth/13_philosophers_unsat.c
@@ -6,6 +6,7 @@
 //
 // CHECK: ^unsat$
 
+#define SEA_SYNTH
 #include "seahorn/seahorn.h"
 
 extern int nd1();
@@ -117,8 +118,8 @@ int main(void)
     assume(inv(fork_1, representative, fork_2));
     assume(inv(fork_2, interference, fork_1));
     tr(&fork_1, &representative, &fork_2);
-    __VERIFIER_assert(inv(fork_1, representative, fork_2));
-    __VERIFIER_assert(inv(fork_2, interference, fork_1));
+    sassert(inv(fork_1, representative, fork_2));
+    sassert(inv(fork_2, interference, fork_1));
 
     // Checks property.
     int left_fork = nd6();

--- a/test/synth/14_philosophers_sat.c
+++ b/test/synth/14_philosophers_sat.c
@@ -6,6 +6,7 @@
 //
 // CHECK: ^sat$
 
+#define SEA_SYNTH
 #include "seahorn/seahorn.h"
 
 extern int nd1();
@@ -116,8 +117,8 @@ int main(void)
     assume(inv(fork_1, representative, fork_2));
     assume(inv(fork_2, interference, fork_1));
     tr(&fork_1, &representative, &fork_2);
-    __VERIFIER_assert(inv(fork_1, representative, fork_2));
-    __VERIFIER_assert(inv(fork_2, interference, fork_1));
+    sassert(inv(fork_1, representative, fork_2));
+    sassert(inv(fork_2, interference, fork_1));
 
     // Checks property.
     int left_fork = nd6();

--- a/test/synth/15_jayhorn_unsat.c
+++ b/test/synth/15_jayhorn_unsat.c
@@ -6,6 +6,7 @@
 //
 // CHECK: ^unsat$
 
+#define SEA_SYNTH
 #include "seahorn/seahorn.h"
 
 #define ALLOC_L1 0
@@ -46,7 +47,7 @@ struct Node
 
 void push(struct Node *n)
 {
-    __VERIFIER_assert(inv(n->id_addr, n->id_alloc, n->data, n->next_addr, n->next_alloc));
+    sassert(inv(n->id_addr, n->id_alloc, n->data, n->next_addr, n->next_alloc));
 }
 
 void pull(struct Node *n)

--- a/test/synth/16_jayhorn_sat.c
+++ b/test/synth/16_jayhorn_sat.c
@@ -6,6 +6,7 @@
 //
 // CHECK: ^sat$
 
+#define SEA_SYNTH
 #include "seahorn/seahorn.h"
 
 #define ALLOC_L1 0
@@ -46,7 +47,7 @@ struct Node
 
 void push(struct Node *n)
 {
-    __VERIFIER_assert(inv(n->id_addr, n->id_alloc, n->data, n->next_addr, n->next_alloc));
+    sassert(inv(n->id_addr, n->id_alloc, n->data, n->next_addr, n->next_alloc));
 }
 
 void pull(struct Node *n)

--- a/test/synth/17_jayhorn_sat.c
+++ b/test/synth/17_jayhorn_sat.c
@@ -6,6 +6,7 @@
 //
 // CHECK: ^sat$
 
+#define SEA_SYNTH
 #include "seahorn/seahorn.h"
 
 #define ALLOC_L1 0
@@ -46,7 +47,7 @@ struct Node
 
 void push(struct Node *n)
 {
-    __VERIFIER_assert(inv(n->id_addr, n->id_alloc, n->data, n->next_addr, n->next_alloc));
+    sassert(inv(n->id_addr, n->id_alloc, n->data, n->next_addr, n->next_alloc));
 }
 
 void pull(struct Node *n)

--- a/test/synth/18_jayhorn_sat.c
+++ b/test/synth/18_jayhorn_sat.c
@@ -6,6 +6,7 @@
 //
 // CHECK: ^sat$
 
+#define SEA_SYNTH
 #include "seahorn/seahorn.h"
 
 #define ALLOC_L1 0
@@ -46,7 +47,7 @@ struct Node
 
 void push(struct Node *n)
 {
-    __VERIFIER_assert(inv(n->id_addr, n->id_alloc, n->data, n->next_addr, n->next_alloc));
+    sassert(inv(n->id_addr, n->id_alloc, n->data, n->next_addr, n->next_alloc));
 }
 
 void pull(struct Node *n)

--- a/test/synth/19_paths_unsat.c
+++ b/test/synth/19_paths_unsat.c
@@ -1,0 +1,50 @@
+// RUN: %sea smt %s --step=small -o %t.sm.smt2
+// RUN: %z3 %t.sm.smt2 fp.spacer.order_children=2 2>&1 | OutputCheck %s
+//
+// RUN: %sea smt %s --step=small --inline -o %t.sm.inline.smt2
+// RUN: %z3 %t.sm.inline.smt2 fp.spacer.order_children=2 2>&1 | OutputCheck %s
+//
+// RUN: %sea smt %s --step=large -o %t.lg.smt2
+// RUN: %z3 %t.lg.smt2 fp.spacer.order_children=2 2>&1 | OutputCheck %s
+//
+// RUN: %sea smt %s --step=large --inline -o %t.lg.inline.smt2
+// RUN: %z3 %t.lg.inline.smt2 fp.spacer.order_children=2 2>&1 | OutputCheck %s
+//
+// CHECK: ^unsat$
+
+#define SEA_SYNTH
+#include "seahorn/seahorn.h"
+
+extern int nd1();
+extern int nd2();
+extern int nd3();
+
+extern bool infer(int x);
+bool PARTIAL_FN inv(int x)
+{
+    if (x == 5) return true;
+    return infer(x);
+}
+
+// This program has two distinct paths.
+// Along the first path, a synthesis assertion is made.
+// Along the second path, a safety assertion is made.
+// A solution to the first path is an invariant such that (x >= 5) => inv(x).
+// The second path if safe if and only if inv(x) => (x > 2).
+// Consequently, the program is unsafe.
+int main(void)
+{
+    if (nd1())
+    {
+        int x = nd2();
+        assume(inv(x));
+	    x = x + 1;
+	    sassert(inv(x));
+    }
+    else
+    {
+        int x = nd3();
+	    assume(inv(x));
+	    sassert(x > 2);
+    }
+}

--- a/test/synth/20_paths_sat.c
+++ b/test/synth/20_paths_sat.c
@@ -18,36 +18,33 @@
 extern int nd1();
 extern int nd2();
 extern int nd3();
-extern int nd4();
 
-// Loop invariant.
-extern bool infer(int x, int n);
-bool PARTIAL_FN inv(int x, int n) { return infer(x, n); }
+extern bool infer(int x);
+bool PARTIAL_FN inv(int x)
+{
+    if (x == 0) return true;
+    return infer(x);
+}
 
-// Test.
-int main(void) {
-  // See 03_loop.unsat.c.
-  //
-  // The inductive invariant is now restricted to x and n. It is impossible to
-  // say that x == y. Therefore, there is no solution that satisfies the
-  // property. Hence, the problem is SAT.
-
-  int x1 = 0;
-  int y1 = 0;
-  int n1 = nd1();
-  assume(n1 > 0);
-
-  sassert(inv(x1, n1));
-
-  int x2 = nd2();
-  int y2 = nd3();
-  int n2 = nd4();
-  assume(inv(x2, n2));
-  if (x2 < n2) {
-    x2 += 1; y2 += 1;
-    sassert(inv(x2, n2));
-    assume(0);
-  }
-
-  sassert(y2 == n2);
+// This program has two distinct paths.
+// Along the first path, a synthesis assertion is made.
+// Along the second path, a safety assertion is made.
+// A solution to the first path is an invariant such that (x >= 0) => inv(x).
+// The second path if safe if and only if inv(x) => (x < 5).
+// Consequently, the program is unsafe.
+int main(void)
+{
+    if (nd1())
+    {
+        int x = nd2();
+        assume(inv(x));
+	    x = x + 1;
+	    sassert(inv(x));
+    }
+    else
+    {
+        int x = nd3();
+	    assume(inv(x));
+	    sassert(x < 5);
+    }
 }


### PR DESCRIPTION
Previously, synthesis assertions were encoded using `__VERIFIER_assert(x)`, and did not generate calls to `__VERIFIER_error()`. If the assertion did not appear on a path to `__VERIFIER_error()`, then the assertion could be optimized away. This commit resolves the issue by extending `sassert(x)` for synthesis (similar to `VACCHECK`).

The synthesis version of `sassert` is enabled by defining `SEA_SYNTH`. The `PARTIAL_FN` macro is now guarded by `SEA_SYNTH`. By guarding `PARTIAL_FN`, it is ensured that should an end-user forget to define `SEA_SYNTH`, then compilation will fail.

This change also impacts the promotion of synthesis calls in `PromoteVerifierCalls.cc`. Before this change, PromoteVerifierCalls would assume the partial function after each synthesis call. This assumption is now generated automatically by `sassert(x)`. Following this change, PromoteVerifierCalls only generates assumptions for sea.synth.assume.