### PR TITLE
test(synth): sufficient class invariant inference from VMCAI 2014

### DIFF
--- a/test/synth/21_true_unsat.c
+++ b/test/synth/21_true_unsat.c
@@ -1,0 +1,57 @@
+// RUN: %sea smt %s --step=small -o %t.sm.smt2
+// RUN: %z3 %t.sm.smt2 fp.spacer.order_children=2 2>&1 | OutputCheck %s
+//
+// RUN: %sea smt %s --step=small --inline -o %t.sm.inline.smt2
+// RUN: %z3 %t.sm.inline.smt2 fp.spacer.order_children=2 2>&1 | OutputCheck %s
+//
+// RUN: %sea smt %s --step=large -o %t.lg.smt2
+// RUN: %z3 %t.lg.smt2 fp.spacer.order_children=2 2>&1 | OutputCheck %s
+//
+// RUN: %sea smt %s --step=large --inline -o %t.lg.inline.smt2
+// RUN: %z3 %t.lg.inline.smt2 fp.spacer.order_children=2 2>&1 | OutputCheck %s
+//
+// CHECK: ^sat$
+
+#define SEA_SYNTH
+#include "seahorn/seahorn.h"
+
+extern int nd1();
+extern int nd2();
+extern int nd3();
+
+extern bool infer(int k);
+bool PARTIAL_FN inv(int k) { return infer(k); }
+
+// When the loop in this program terminates, k_i = k_0 - n.
+// Since k_0 > n, then k_i > 0.
+// Therefore, the synthesis assertion is reached and inv(k) must be set to true.
+// Consequently, the program is unsafe, and the proof relies on the loop invariant.
+//
+// This test is meant to ensure that a solver handles true invariants.
+int main(void)
+{
+  int n = nd1();
+  assume(n > 0);
+  int k = nd2();
+  assume(k > n);
+  int j = 0;
+
+  // After i iterations, i = j <= n, and k_i = k_0 - i >= k_0 - n > 0.
+  while (j < n)
+  {
+    j = j + 1;
+    k = k - 1;
+  }
+
+  // At this point k_i = k_0 - n > 0.
+  if (k > 0)
+  {
+    k = nd3();
+    sassert(inv(k));
+  }
+
+  // inv must be set to true, so this is unsafe.
+  assume(inv(k));
+  sassert(false);
+  return 0;
+}

--- a/test/synth/22_false_unsat.c
+++ b/test/synth/22_false_unsat.c
@@ -1,0 +1,56 @@
+// RUN: %sea smt %s --step=small -o %t.sm.smt2
+// RUN: %z3 %t.sm.smt2 fp.spacer.order_children=2 2>&1 | OutputCheck %s
+//
+// RUN: %sea smt %s --step=small --inline -o %t.sm.inline.smt2
+// RUN: %z3 %t.sm.inline.smt2 fp.spacer.order_children=2 2>&1 | OutputCheck %s
+//
+// RUN: %sea smt %s --step=large -o %t.lg.smt2
+// RUN: %z3 %t.lg.smt2 fp.spacer.order_children=2 2>&1 | OutputCheck %s
+//
+// RUN: %sea smt %s --step=large --inline -o %t.lg.inline.smt2
+// RUN: %z3 %t.lg.inline.smt2 fp.spacer.order_children=2 2>&1 | OutputCheck %s
+//
+// CHECK: ^unsat$
+
+#define SEA_SYNTH
+#include "seahorn/seahorn.h"
+
+extern int nd1();
+extern int nd2();
+
+extern bool infer(int k);
+bool PARTIAL_FN inv(int k) { return infer(k); }
+
+// When the loop in this program terminates, k_i = k_0 - n.
+// Since k_0 > n, then k_i > 0.
+// Therefore, the synthesis assertion is never reached and inv(k) can be set to false.
+// Consequently, the program is safe, and correctness relies on the loop invariant.
+//
+// This test is meant to ensure that a solver handles false invariants.
+int main(void)
+{
+  int n = nd1();
+  assume(n > 0);
+  int k = nd2();
+  assume(k > n);
+  int j = 0;
+
+  // After i iterations, i = j <= n, and k_i = k_0 - i >= k_0 - n > 0.
+  while (j < n)
+  {
+    j = j + 1;
+    k = k - 1;
+  }
+
+  // At this point k_i = k_0 - n > 0.
+  if (k < 0)
+  {
+    k = nd3();
+    sassert(inv(k));
+  }
+
+  // inv can be set to false so this is safe.
+  assume(inv(k));
+  sassert(false);
+  return 0;
+}

--- a/test/synth/23_vmcai2004_ex1_unsat.c
+++ b/test/synth/23_vmcai2004_ex1_unsat.c
@@ -1,0 +1,241 @@
+// RUN: %sea smt %s --step=small --inline -o %t.sm.inline.smt2
+// RUN: %z3 %t.sm.inline.smt2 fp.spacer.order_children=2 2>&1 | OutputCheck %s
+//
+// RUN: %sea smt %s --step=large --inline -o %t.lg.inline.smt2
+// RUN: %z3 %t.lg.inline.smt2 fp.spacer.order_children=2 2>&1 | OutputCheck %s
+//
+// CHECK: ^unsat$
+
+// This set of tests is inspired by "Automatic Inference of Class Invariants" by Francesco Logozzo in VMCAI 2014.
+// This test case encodes the Stack class given by Fig. 1.
+
+#define SEA_SYNTH
+#include "seahorn/seahorn.h"
+
+// In this example, exceptions are encoded as implicit arguments passed between throwing methods.
+// Since only the exception type matters in this example, each exception is encoded by a unique integer.
+// Exception handling is instrumented into the call site (for example, line A to line B).
+#define EXCEPTION__NONE 0
+#define EXCEPTION__OUT_OF_BOUNDS 1
+#define EXCEPTION__NEGATIVE_SIZE 2
+#define EXCEPTION__STACK 3
+
+extern int nd1(void);
+extern int nd2(void);
+extern int nd3(void);
+extern int nd4(void);
+extern int nd5(void);
+extern int nd6(void);
+extern int nd7(void);
+extern int nd8(void);
+
+extern bool infer(int size, int pos, int stack_size);
+bool PARTIAL_FN inv(int size, int pos, int stack_size)
+{
+    return infer(size, pos, stack_size);
+}
+
+//
+// Library methods assumed by the example in Fig 1.
+//
+
+int Math_Max(int a, int b)
+{
+  if (a < b) return b;
+  else return a;
+}
+
+//
+// Mock implementation of Object[].
+//
+
+struct MockObjectArray
+{
+  int size;
+};
+
+void New_MockObjectArray(struct MockObjectArray *array, int *exception, int size)
+{
+  if (size > 0)
+  {
+    array->size = size;
+  }
+  else
+  {
+    array->size = 0;
+    *exception = EXCEPTION__NEGATIVE_SIZE;
+  }
+}
+
+int MockObjectArray_read(struct MockObjectArray *array, int *exception, int i)
+{
+  if (array->size > i)
+  {
+    return nd1();
+  }
+  else
+  {
+    *exception = EXCEPTION__OUT_OF_BOUNDS;
+    return 0;
+  }
+}
+
+void MockObjectArray_write(struct MockObjectArray *array, int *exception, int i, int o)
+{
+  if (array->size > i)
+  {
+    (void) o;
+    return;
+  }
+  else
+  {
+    *exception = EXCEPTION__OUT_OF_BOUNDS;
+  }
+}
+
+//
+// Encoding of Stack from Fig 1.
+//
+
+struct Stack
+{
+  int size;
+  int pos;
+  struct MockObjectArray stack;
+};
+
+void New_Stack(struct Stack *stack, int *exception, int size)
+{
+  stack->size = Math_Max(size, 1);
+  stack->pos = 0;
+  New_MockObjectArray(&stack->stack, exception, stack->size);
+  /* CHECK FOR EXCEPTIONS */ if (exception != EXCEPTION__NONE) return;
+}
+
+bool Stack_isEmpty(struct Stack *stack)
+{
+  return (stack->pos <= 0);
+}
+
+bool Stack_isFull(struct Stack *stack)
+{
+  return (stack->pos >= stack->size);
+}
+
+int Stack_top(struct Stack *stack, int *exception)
+{
+  if (!Stack_isEmpty(stack))
+  {
+    int tmp = MockObjectArray_read(&stack->stack, exception, stack->pos - 1); // Line A.
+    /* CHECK FOR EXCEPTIONS */ if (exception != EXCEPTION__NONE) return 0;
+    return tmp; // Line B.
+  }
+  else
+  {
+    *exception = EXCEPTION__STACK;
+    return 0;
+  }
+}
+
+void Stack_push(struct Stack *stack, int *exception, int o)
+{
+  if (!Stack_isFull(stack))
+  {
+    MockObjectArray_write(&stack->stack, exception, stack->pos, o);
+    /* CHECK FOR EXCEPTIONS */ if (exception != EXCEPTION__NONE) return;
+    stack->pos = stack->pos + 1;
+  }
+  else
+  {
+    *exception = EXCEPTION__STACK;
+  }
+}
+
+void Stack_pop(struct Stack *stack, int *exception)
+{
+  if (!Stack_isEmpty(stack))
+  {
+    stack->pos = stack->pos - 1;
+  }
+  else
+  {
+    *exception = EXCEPTION__STACK;
+  }
+}
+
+//
+// Harness.
+//
+
+void Assume_Struct(struct Stack *stack)
+{
+  stack->size = nd2();
+  stack->pos = nd3();
+  stack->stack.size = nd4();
+  assume(inv(stack->size, stack->pos, stack->stack.size));
+}
+
+void Assert_Struct(struct Stack *stack)
+{
+  sassert(inv(stack->size, stack->pos, stack->stack.size));
+}
+
+int ApplyOperation(struct Stack *stack, int op)
+{
+  int exception = EXCEPTION__NONE;
+  switch (op)
+  {
+  case 0:
+    Stack_isEmpty(stack);
+    break;
+  case 1:
+    Stack_isFull(stack);
+    break;
+  case 2:
+    Stack_top(stack, &exception);
+    break;
+  case 3:
+    Stack_push(stack, &exception, nd6());
+    break;
+  default:
+    Stack_pop(stack, &exception);
+    break;
+  }
+  return exception;
+}
+
+int SelectOperation(struct Stack *stack)
+{
+  return ApplyOperation(stack, nd5());
+}
+
+int main(void)
+{
+  // This harness verifies the property given in the paper.
+  // That is, no call to stack returns the OutOfBounds exception.
+
+  int rule = nd7();
+  if (rule == 0)
+  {
+    // Base case.
+    struct Stack s;
+    int exception = EXCEPTION__NONE;
+    New_Stack(&s, &exception, nd8());
+    Assert_Struct(&s);
+  }
+  else if (rule == 1)
+  {
+    // Inductive case.
+    struct Stack s;
+    Assume_Struct(&s);
+    SelectOperation(&s);
+    Assert_Struct(&s);
+  }
+  else
+  {
+    // Safety condition.
+    struct Stack s;
+    Assume_Struct(&s);
+    sassert(SelectOperation(&s) != EXCEPTION__OUT_OF_BOUNDS);
+  }
+}

--- a/test/synth/24_vmcai2004_ex1_unsat.c
+++ b/test/synth/24_vmcai2004_ex1_unsat.c
@@ -1,0 +1,241 @@
+// RUN: %sea smt %s --step=small --inline -o %t.sm.inline.smt2
+// RUN: %z3 %t.sm.inline.smt2 fp.spacer.order_children=2 2>&1 | OutputCheck %s
+//
+// RUN: %sea smt %s --step=large --inline -o %t.lg.inline.smt2
+// RUN: %z3 %t.lg.inline.smt2 fp.spacer.order_children=2 2>&1 | OutputCheck %s
+//
+// CHECK: ^unsat$
+
+// This set of tests is inspired by "Automatic Inference of Class Invariants" by Francesco Logozzo in VMCAI 2014.
+// This test case encodes the Stack class given by Fig. 1.
+
+#define SEA_SYNTH
+#include "seahorn/seahorn.h"
+
+// In this example, exceptions are encoded as implicit arguments passed between throwing methods.
+// Since only the exception type matters in this example, each exception is encoded by a unique integer.
+// Exception handling is instrumented into the call site (for example, line A to line B).
+#define EXCEPTION__NONE 0
+#define EXCEPTION__OUT_OF_BOUNDS 1
+#define EXCEPTION__NEGATIVE_SIZE 2
+#define EXCEPTION__STACK 3
+
+extern int nd1(void);
+extern int nd2(void);
+extern int nd3(void);
+extern int nd4(void);
+extern int nd5(void);
+extern int nd6(void);
+extern int nd7(void);
+extern int nd8(void);
+
+extern bool infer(int size, int pos, int stack_size);
+bool PARTIAL_FN inv(int size, int pos, int stack_size)
+{
+    return infer(size, pos, stack_size);
+}
+
+//
+// Library methods assumed by the example in Fig 1.
+//
+
+int Math_Max(int a, int b)
+{
+  if (a < b) return b;
+  else return a;
+}
+
+//
+// Mock implementation of Object[].
+//
+
+struct MockObjectArray
+{
+  int size;
+};
+
+void New_MockObjectArray(struct MockObjectArray *array, int *exception, int size)
+{
+  if (size > 0)
+  {
+    array->size = size;
+  }
+  else
+  {
+    array->size = 0;
+    *exception = EXCEPTION__NEGATIVE_SIZE;
+  }
+}
+
+int MockObjectArray_read(struct MockObjectArray *array, int *exception, int i)
+{
+  if (array->size > i)
+  {
+    return nd1();
+  }
+  else
+  {
+    *exception = EXCEPTION__OUT_OF_BOUNDS;
+    return 0;
+  }
+}
+
+void MockObjectArray_write(struct MockObjectArray *array, int *exception, int i, int o)
+{
+  if (array->size > i)
+  {
+    (void) o;
+    return;
+  }
+  else
+  {
+    *exception = EXCEPTION__OUT_OF_BOUNDS;
+  }
+}
+
+//
+// Encoding of Stack from Fig 1.
+//
+
+struct Stack
+{
+  int size;
+  int pos;
+  struct MockObjectArray stack;
+};
+
+void New_Stack(struct Stack *stack, int *exception, int size)
+{
+  stack->size = Math_Max(size, 1);
+  stack->pos = 0;
+  New_MockObjectArray(&stack->stack, exception, stack->size);
+  /* CHECK FOR EXCEPTIONS */ if (exception != EXCEPTION__NONE) return;
+}
+
+bool Stack_isEmpty(struct Stack *stack)
+{
+  return (stack->pos <= 0);
+}
+
+bool Stack_isFull(struct Stack *stack)
+{
+  return (stack->pos >= stack->size);
+}
+
+int Stack_top(struct Stack *stack, int *exception)
+{
+  if (!Stack_isEmpty(stack))
+  {
+    int tmp = MockObjectArray_read(&stack->stack, exception, stack->pos - 1); // Line A.
+    /* CHECK FOR EXCEPTIONS */ if (exception != EXCEPTION__NONE) return 0;
+    return tmp; // Line B.
+  }
+  else
+  {
+    *exception = EXCEPTION__STACK;
+    return 0;
+  }
+}
+
+void Stack_push(struct Stack *stack, int *exception, int o)
+{
+  if (!Stack_isFull(stack))
+  {
+    MockObjectArray_write(&stack->stack, exception, stack->pos, o);
+    /* CHECK FOR EXCEPTIONS */ if (exception != EXCEPTION__NONE) return;
+    stack->pos = stack->pos + 1;
+  }
+  else
+  {
+    *exception = EXCEPTION__STACK;
+  }
+}
+
+void Stack_pop(struct Stack *stack, int *exception)
+{
+  if (!Stack_isEmpty(stack))
+  {
+    stack->pos = stack->pos - 1;
+  }
+  else
+  {
+    *exception = EXCEPTION__STACK;
+  }
+}
+
+//
+// Harness.
+//
+
+void Assume_Struct(struct Stack *stack)
+{
+  stack->size = nd2();
+  stack->pos = nd3();
+  stack->stack.size = nd4();
+  assume(inv(stack->size, stack->pos, stack->stack.size));
+}
+
+void Assert_Struct(struct Stack *stack)
+{
+  sassert(inv(stack->size, stack->pos, stack->stack.size));
+}
+
+int ApplyOperation(struct Stack *stack, int op)
+{
+  int exception = EXCEPTION__NONE;
+  switch (op)
+  {
+  case 0:
+    Stack_isEmpty(stack);
+    break;
+  case 1:
+    Stack_isFull(stack);
+    break;
+  case 2:
+    Stack_top(stack, &exception);
+    break;
+  case 3:
+    Stack_push(stack, &exception, nd6());
+    break;
+  default:
+    Stack_pop(stack, &exception);
+    break;
+  }
+  return exception;
+}
+
+int SelectOperation(struct Stack *stack)
+{
+  return ApplyOperation(stack, nd5());
+}
+
+int main(void)
+{
+  // This harness verifies the invariant given in the paper.
+
+  int rule = nd7();
+  if (rule == 0)
+  {
+    // Base case.
+    struct Stack s;
+    int exception = EXCEPTION__NONE;
+    New_Stack(&s, &exception, nd8());
+    Assert_Struct(&s);
+  }
+  else if (rule == 1)
+  {
+    // Inductive case.
+    struct Stack s;
+    Assume_Struct(&s);
+    SelectOperation(&s);
+    Assert_Struct(&s);
+  }
+  else
+  {
+    // Safety condition.
+    struct Stack s;
+    Assume_Struct(&s);
+    sassert(0 <= s.pos && s.pos < s.size);
+    sassert(s.size == s.stack.size);
+  }
+}

--- a/test/synth/25_vmcai2004_ex1_sat.c
+++ b/test/synth/25_vmcai2004_ex1_sat.c
@@ -1,0 +1,242 @@
+// RUN: %sea smt %s --step=small --inline -o %t.sm.inline.smt2
+// RUN: %z3 %t.sm.inline.smt2 fp.spacer.order_children=2 2>&1 | OutputCheck %s
+//
+// RUN: %sea smt %s --step=large --inline -o %t.lg.inline.smt2
+// RUN: %z3 %t.lg.inline.smt2 fp.spacer.order_children=2 2>&1 | OutputCheck %s
+//
+// CHECK: ^unsat$
+
+// This set of tests is inspired by "Automatic Inference of Class Invariants" by Francesco Logozzo in VMCAI 2014.
+// This test case encodes the Stack class given by Fig. 1.
+
+#define SEA_SYNTH
+#include "seahorn/seahorn.h"
+
+// In this example, exceptions are encoded as implicit arguments passed between throwing methods.
+// Since only the exception type matters in this example, each exception is encoded by a unique integer.
+// Exception handling is instrumented into the call site (for example, line A to line B).
+#define EXCEPTION__NONE 0
+#define EXCEPTION__OUT_OF_BOUNDS 1
+#define EXCEPTION__NEGATIVE_SIZE 2
+#define EXCEPTION__STACK 3
+
+extern int nd1(void);
+extern int nd2(void);
+extern int nd3(void);
+extern int nd4(void);
+extern int nd5(void);
+extern int nd6(void);
+extern int nd7(void);
+extern int nd8(void);
+
+extern bool infer(int size, int pos, int stack_size);
+bool PARTIAL_FN inv(int size, int pos, int stack_size)
+{
+    return infer(size, pos, stack_size);
+}
+
+//
+// Library methods assumed by the example in Fig 1.
+//
+
+int Math_Max(int a, int b)
+{
+  if (a < b) return b;
+  else return a;
+}
+
+//
+// Mock implementation of Object[].
+//
+
+struct MockObjectArray
+{
+  int size;
+};
+
+void New_MockObjectArray(struct MockObjectArray *array, int *exception, int size)
+{
+  if (size > 0)
+  {
+    array->size = size;
+  }
+  else
+  {
+    array->size = 0;
+    *exception = EXCEPTION__NEGATIVE_SIZE;
+  }
+}
+
+int MockObjectArray_read(struct MockObjectArray *array, int *exception, int i)
+{
+  if (array->size > i)
+  {
+    return nd1();
+  }
+  else
+  {
+    *exception = EXCEPTION__OUT_OF_BOUNDS;
+    return 0;
+  }
+}
+
+void MockObjectArray_write(struct MockObjectArray *array, int *exception, int i, int o)
+{
+  if (array->size > i)
+  {
+    (void) o;
+    return;
+  }
+  else
+  {
+    *exception = EXCEPTION__OUT_OF_BOUNDS;
+  }
+}
+
+//
+// Encoding of Stack from Fig 1.
+//
+
+struct Stack
+{
+  int size;
+  int pos;
+  struct MockObjectArray stack;
+};
+
+void New_Stack(struct Stack *stack, int *exception, int size)
+{
+  stack->size = Math_Max(size, 1);
+  stack->pos = 0;
+  New_MockObjectArray(&stack->stack, exception, stack->size);
+  /* CHECK FOR EXCEPTIONS */ if (exception != EXCEPTION__NONE) return;
+}
+
+bool Stack_isEmpty(struct Stack *stack)
+{
+  return (stack->pos <= 0);
+}
+
+bool Stack_isFull(struct Stack *stack)
+{
+  return (stack->pos >= stack->size);
+}
+
+int Stack_top(struct Stack *stack, int *exception)
+{
+  if (!Stack_isEmpty(stack))
+  {
+    int tmp = MockObjectArray_read(&stack->stack, exception, stack->pos - 1); // Line A.
+    /* CHECK FOR EXCEPTIONS */ if (exception != EXCEPTION__NONE) return 0;
+    return tmp; // Line B.
+  }
+  else
+  {
+    *exception = EXCEPTION__STACK;
+    return 0;
+  }
+}
+
+void Stack_push(struct Stack *stack, int *exception, int o)
+{
+  if (!Stack_isFull(stack))
+  {
+    MockObjectArray_write(&stack->stack, exception, stack->pos, o);
+    /* CHECK FOR EXCEPTIONS */ if (exception != EXCEPTION__NONE) return;
+    stack->pos = stack->pos + 1;
+  }
+  else
+  {
+    *exception = EXCEPTION__STACK;
+  }
+}
+
+void Stack_pop(struct Stack *stack, int *exception)
+{
+  if (!Stack_isEmpty(stack))
+  {
+    stack->pos = stack->pos - 1;
+  }
+  else
+  {
+    *exception = EXCEPTION__STACK;
+  }
+}
+
+//
+// Harness.
+//
+
+void Assume_Struct(struct Stack *stack)
+{
+  stack->size = nd2();
+  stack->pos = nd3();
+  stack->stack.size = nd4();
+  assume(inv(stack->size, stack->pos, stack->stack.size));
+}
+
+void Assert_Struct(struct Stack *stack)
+{
+  sassert(inv(stack->size, stack->pos, stack->stack.size));
+}
+
+int ApplyOperation(struct Stack *stack, int op)
+{
+  int exception = EXCEPTION__NONE;
+  switch (op)
+  {
+  case 0:
+    Stack_isEmpty(stack);
+    break;
+  case 1:
+    Stack_isFull(stack);
+    break;
+  case 2:
+    Stack_top(stack, &exception);
+    break;
+  case 3:
+    Stack_push(stack, &exception, nd6());
+    break;
+  default:
+    Stack_pop(stack, &exception);
+    break;
+  }
+  return exception;
+}
+
+int SelectOperation(struct Stack *stack)
+{
+  return ApplyOperation(stack, nd5());
+}
+
+int main(void)
+{
+  // This harness claims that push never returns a StackError exception.
+  // The claim is false, since push raises StackError whenever stack->pos == stack->size.
+  // Furthermore, stack->pos == stack->size after calling push stack->size times.
+
+  int rule = nd7();
+  if (rule == 0)
+  {
+    // Base case.
+    struct Stack s;
+    int exception = EXCEPTION__NONE;
+    New_Stack(&s, &exception, nd8());
+    Assert_Struct(&s);
+  }
+  else if (rule == 1)
+  {
+    // Inductive case.
+    struct Stack s;
+    Assume_Struct(&s);
+    SelectOperation(&s);
+    Assert_Struct(&s);
+  }
+  else
+  {
+    // Safety condition.
+    struct Stack s;
+    Assume_Struct(&s);
+    sassert(ApplyOperation(&s, 3) != EXCEPTION__STACK);
+  }
+}

--- a/test/synth/26_vmcai2004_ex1_sat.c
+++ b/test/synth/26_vmcai2004_ex1_sat.c
@@ -1,0 +1,241 @@
+// RUN: %sea smt %s --step=small --inline -o %t.sm.inline.smt2
+// RUN: %z3 %t.sm.inline.smt2 fp.spacer.order_children=2 2>&1 | OutputCheck %s
+//
+// RUN: %sea smt %s --step=large --inline -o %t.lg.inline.smt2
+// RUN: %z3 %t.lg.inline.smt2 fp.spacer.order_children=2 2>&1 | OutputCheck %s
+//
+// CHECK: ^unsat$
+
+// This set of tests is inspired by "Automatic Inference of Class Invariants" by Francesco Logozzo in VMCAI 2014.
+// This test case encodes the Stack class given by Fig. 1.
+
+#define SEA_SYNTH
+#include "seahorn/seahorn.h"
+
+// In this example, exceptions are encoded as implicit arguments passed between throwing methods.
+// Since only the exception type matters in this example, each exception is encoded by a unique integer.
+// Exception handling is instrumented into the call site (for example, line A to line B).
+#define EXCEPTION__NONE 0
+#define EXCEPTION__OUT_OF_BOUNDS 1
+#define EXCEPTION__NEGATIVE_SIZE 2
+#define EXCEPTION__STACK 3
+
+extern int nd1(void);
+extern int nd2(void);
+extern int nd3(void);
+extern int nd4(void);
+extern int nd5(void);
+extern int nd6(void);
+extern int nd7(void);
+extern int nd8(void);
+
+extern bool infer(int size, int pos, int stack_size);
+bool PARTIAL_FN inv(int size, int pos, int stack_size)
+{
+    return infer(size, pos, stack_size);
+}
+
+//
+// Library methods assumed by the example in Fig 1.
+//
+
+int Math_Max(int a, int b)
+{
+  if (a < b) return b;
+  else return a;
+}
+
+//
+// Mock implementation of Object[].
+//
+
+struct MockObjectArray
+{
+  int size;
+};
+
+void New_MockObjectArray(struct MockObjectArray *array, int *exception, int size)
+{
+  if (size > 0)
+  {
+    array->size = size;
+  }
+  else
+  {
+    array->size = 0;
+    *exception = EXCEPTION__NEGATIVE_SIZE;
+  }
+}
+
+int MockObjectArray_read(struct MockObjectArray *array, int *exception, int i)
+{
+  if (array->size > i)
+  {
+    return nd1();
+  }
+  else
+  {
+    *exception = EXCEPTION__OUT_OF_BOUNDS;
+    return 0;
+  }
+}
+
+void MockObjectArray_write(struct MockObjectArray *array, int *exception, int i, int o)
+{
+  if (array->size > i)
+  {
+    (void) o;
+    return;
+  }
+  else
+  {
+    *exception = EXCEPTION__OUT_OF_BOUNDS;
+  }
+}
+
+//
+// Encoding of Stack from Fig 1.
+//
+
+struct Stack
+{
+  int size;
+  int pos;
+  struct MockObjectArray stack;
+};
+
+void New_Stack(struct Stack *stack, int *exception, int size)
+{
+  stack->size = Math_Max(size, 1);
+  stack->pos = 0;
+  New_MockObjectArray(&stack->stack, exception, stack->size);
+  /* CHECK FOR EXCEPTIONS */ if (exception != EXCEPTION__NONE) return;
+}
+
+bool Stack_isEmpty(struct Stack *stack)
+{
+  return (stack->pos <= 0);
+}
+
+bool Stack_isFull(struct Stack *stack)
+{
+  return (stack->pos >= stack->size);
+}
+
+int Stack_top(struct Stack *stack, int *exception)
+{
+  if (!Stack_isEmpty(stack))
+  {
+    int tmp = MockObjectArray_read(&stack->stack, exception, stack->pos - 1); // Line A.
+    /* CHECK FOR EXCEPTIONS */ if (exception != EXCEPTION__NONE) return 0;
+    return tmp; // Line B.
+  }
+  else
+  {
+    *exception = EXCEPTION__STACK;
+    return 0;
+  }
+}
+
+void Stack_push(struct Stack *stack, int *exception, int o)
+{
+  if (!Stack_isFull(stack))
+  {
+    MockObjectArray_write(&stack->stack, exception, stack->pos, o);
+    /* CHECK FOR EXCEPTIONS */ if (exception != EXCEPTION__NONE) return;
+    stack->pos = stack->pos + 1;
+  }
+  else
+  {
+    *exception = EXCEPTION__STACK;
+  }
+}
+
+void Stack_pop(struct Stack *stack, int *exception)
+{
+  if (!Stack_isEmpty(stack))
+  {
+    stack->pos = stack->pos - 1;
+  }
+  else
+  {
+    *exception = EXCEPTION__STACK;
+  }
+}
+
+//
+// Harness.
+//
+
+void Assume_Struct(struct Stack *stack)
+{
+  stack->size = nd2();
+  stack->pos = nd3();
+  stack->stack.size = nd4();
+  assume(inv(stack->size, stack->pos, stack->stack.size));
+}
+
+void Assert_Struct(struct Stack *stack)
+{
+  sassert(inv(stack->size, stack->pos, stack->stack.size));
+}
+
+int ApplyOperation(struct Stack *stack, int op)
+{
+  int exception = EXCEPTION__NONE;
+  switch (op)
+  {
+  case 0:
+    Stack_isEmpty(stack);
+    break;
+  case 1:
+    Stack_isFull(stack);
+    break;
+  case 2:
+    Stack_top(stack, &exception);
+    break;
+  case 3:
+    Stack_push(stack, &exception, nd6());
+    break;
+  default:
+    Stack_pop(stack, &exception);
+    break;
+  }
+  return exception;
+}
+
+int SelectOperation(struct Stack *stack)
+{
+  return ApplyOperation(stack, nd5());
+}
+
+int main(void)
+{
+  // This harness claims that stack.pos is never stack.size.
+  // This claim is violated by calling push at least stack.size times.
+
+  int rule = nd7();
+  if (rule == 0)
+  {
+    // Base case.
+    struct Stack s;
+    int exception = EXCEPTION__NONE;
+    New_Stack(&s, &exception, nd8());
+    Assert_Struct(&s);
+  }
+  else if (rule == 1)
+  {
+    // Inductive case.
+    struct Stack s;
+    Assume_Struct(&s);
+    SelectOperation(&s);
+    Assert_Struct(&s);
+  }
+  else
+  {
+    // Safety condition.
+    struct Stack s;
+    Assume_Struct(&s);
+    sassert(s.pos != s.size);
+  }
+}

--- a/test/synth/27_vmcai_2004_ex2_unsat.c
+++ b/test/synth/27_vmcai_2004_ex2_unsat.c
@@ -1,0 +1,297 @@
+// RUN: %sea smt %s --step=small --inline -o %t.sm.inline.smt2
+// RUN: %z3 %t.sm.inline.smt2 fp.spacer.order_children=2 2>&1 | OutputCheck %s
+//
+// RUN: %sea smt %s --step=large --inline -o %t.lg.inline.smt2
+// RUN: %z3 %t.lg.inline.smt2 fp.spacer.order_children=2 2>&1 | OutputCheck %s
+//
+// CHECK: ^unsat$
+
+// This set of tests is inspired by "Automatic Inference of Class Invariants" by Francesco Logozzo in VMCAI 2014.
+// This test case encodes the StackWithUndo class given by Fig. 2.
+
+#define SEA_SYNTH
+#include "seahorn/seahorn.h"
+
+// In this example, exceptions are encoded as implicit arguments passed between throwing methods.
+// Since only the exception type matters in this example, each exception is encoded by a unique integer.
+// Exception handling is instrumented into the call site (for example, line A to line B).
+#define EXCEPTION__NONE 0
+#define EXCEPTION__OUT_OF_BOUNDS 1
+#define EXCEPTION__NEGATIVE_SIZE 2
+#define EXCEPTION__STACK 3
+
+extern int nd1(void);
+extern int nd2(void);
+extern int nd3(void);
+extern int nd4(void);
+extern int nd5(void);
+extern int nd6(void);
+extern int nd7(void);
+extern int nd8(void);
+extern int nd9(void);
+extern int nd10(void);
+
+extern bool infer(int size, int pos, int stack_size, int undoObject, int undoType);
+bool PARTIAL_FN inv(int size, int pos, int stack_size, int undoObject, int undoType)
+{
+    return infer(size, pos, stack_size, undoObject, undoType);
+}
+
+//
+// Library methods assumed by the example in Fig 1.
+//
+
+int Math_Max(int a, int b)
+{
+  if (a < b) return b;
+  else return a;
+}
+
+//
+// Mock implementation of Object[].
+//
+
+struct MockObjectArray
+{
+  int size;
+};
+
+void New_MockObjectArray(struct MockObjectArray *array, int *exception, int size)
+{
+  if (size > 0)
+  {
+    array->size = size;
+  }
+  else
+  {
+    array->size = 0;
+    *exception = EXCEPTION__NEGATIVE_SIZE;
+  }
+}
+
+int MockObjectArray_read(struct MockObjectArray *array, int *exception, int i)
+{
+  if (array->size > i)
+  {
+    return nd1();
+  }
+  else
+  {
+    *exception = EXCEPTION__OUT_OF_BOUNDS;
+    return 0;
+  }
+}
+
+void MockObjectArray_write(struct MockObjectArray *array, int *exception, int i, int o)
+{
+  if (array->size > i)
+  {
+    (void) o;
+    return;
+  }
+  else
+  {
+    *exception = EXCEPTION__OUT_OF_BOUNDS;
+  }
+}
+
+//
+// Encoding of Stack from Fig 2.
+//
+
+struct StackWithUndo
+{
+  // Stack.
+  int size;
+  int pos;
+  struct MockObjectArray stack;
+  // StackWithUndo.
+  int undoObject;
+  int undoType;
+};
+
+void New_Stack(struct StackWithUndo *stack, int *exception, int size)
+{
+  stack->size = Math_Max(size, 1);
+  stack->pos = 0;
+  New_MockObjectArray(&stack->stack, exception, stack->size);
+  /* CHECK FOR EXCEPTIONS */ if (exception != EXCEPTION__NONE) return;
+}
+
+void New_StackWithUndo(struct StackWithUndo *stack, int *exception, int size)
+{
+  stack->undoObject = 0;
+  stack->undoType = 0;
+  New_Stack(stack, exception, size);
+  /* CHECK FOR EXCEPTIONS */ if (exception != EXCEPTION__NONE) return;
+}
+
+bool Stack_isEmpty(struct StackWithUndo *stack)
+{
+  return (stack->pos <= 0);
+}
+
+bool Stack_isFull(struct StackWithUndo *stack)
+{
+  return (stack->pos >= stack->size);
+}
+
+int Stack_top(struct StackWithUndo *stack, int *exception)
+{
+  if (!Stack_isEmpty(stack))
+  {
+    int tmp = MockObjectArray_read(&stack->stack, exception, stack->pos - 1); // Line A.
+    /* CHECK FOR EXCEPTIONS */ if (exception != EXCEPTION__NONE) return 0;
+    return tmp; // Line B.
+  }
+  else
+  {
+    *exception = EXCEPTION__STACK;
+    return 0;
+  }
+}
+
+void Stack_push(struct StackWithUndo *stack, int *exception, int o)
+{
+  if (!Stack_isFull(stack))
+  {
+    MockObjectArray_write(&stack->stack, exception, stack->pos, o);
+    /* CHECK FOR EXCEPTIONS */ if (exception != EXCEPTION__NONE) return;
+    stack->pos = stack->pos + 1;
+  }
+  else
+  {
+    *exception = EXCEPTION__STACK;
+  }
+}
+
+void StackWithUndo_push(struct StackWithUndo *stack, int *exception, int o)
+{
+  Stack_push(stack, exception, o);
+  /* CHECK FOR EXCEPTIONS */ if (exception != EXCEPTION__NONE) return;
+  stack->undoType = 1;
+}
+
+void Stack_pop(struct StackWithUndo *stack, int *exception)
+{
+  if (!Stack_isEmpty(stack))
+  {
+    stack->pos = stack->pos - 1;
+  }
+  else
+  {
+    *exception = EXCEPTION__STACK;
+  }
+}
+
+void StackWithUndo_pop(struct StackWithUndo *stack, int *exception)
+{
+  int tmp = stack->undoObject;
+  if (!Stack_isEmpty(stack))
+  {
+    int tmp = MockObjectArray_read(&stack->stack, exception, stack->pos - 1);
+    /* CHECK FOR EXCEPTIONS */ if (exception != EXCEPTION__NONE) return;
+  }
+  Stack_pop(stack, exception);
+  /* CHECK FOR EXCEPTIONS */ if (exception != EXCEPTION__NONE) return;
+  stack->undoType = -1;
+  stack->undoObject = tmp;
+}
+
+void StackWithUndo_undo(struct StackWithUndo *stack, int *exception)
+{
+  if (stack->undoType == -1)
+  {
+    Stack_push(stack, exception, stack->undoObject);
+    /* CHECK FOR EXCEPTIONS */ if (exception != EXCEPTION__NONE) return;
+    stack->undoType = 0;
+  }
+  else if (stack->undoType == 1)
+  {
+    Stack_pop(stack, exception);
+    /* CHECK FOR EXCEPTIONS */ if (exception != EXCEPTION__NONE) return;
+    stack->undoType = 0;
+  }
+}
+
+//
+// Harness.
+//
+
+void Assume_Struct(struct StackWithUndo *stack)
+{
+  stack->size = nd2();
+  stack->pos = nd3();
+  stack->stack.size = nd4();
+  stack->undoObject = nd5();
+  stack->undoType = nd6();
+  assume(inv(stack->size, stack->pos, stack->stack.size, stack->undoObject, stack->undoType));
+}
+
+void Assert_Struct(struct StackWithUndo *stack)
+{
+  sassert(inv(stack->size, stack->pos, stack->stack.size, stack->undoObject, stack->undoType));
+}
+
+int ApplyOperation(struct StackWithUndo *stack, int op)
+{
+  int exception = EXCEPTION__NONE;
+  switch (op)
+  {
+  case 0:
+    Stack_isEmpty(stack);
+    break;
+  case 1:
+    Stack_isFull(stack);
+    break;
+  case 2:
+    Stack_top(stack, &exception);
+    break;
+  case 3:
+    StackWithUndo_push(stack, &exception, nd7());
+    break;
+  case 4:
+    StackWithUndo_pop(stack, &exception);
+    break;
+  default:
+    StackWithUndo_undo(stack, &exception);
+  }
+  return exception;
+}
+
+int SelectOperation(struct StackWithUndo *stack)
+{
+  return ApplyOperation(stack, nd8());
+}
+
+int main(void)
+{
+  // This harness claims that push never returns a StackError exception.
+  // The claim is false, since push raises StackError whenever stack->pos == stack->size.
+  // Furthermore, stack->pos == stack->size after calling push stack->size times.
+
+  int rule = nd9();
+  if (rule == 0)
+  {
+    // Base case.
+    struct StackWithUndo s;
+    int exception = EXCEPTION__NONE;
+    New_StackWithUndo(&s, &exception, nd10());
+    Assert_Struct(&s);
+  }
+  else if (rule == 1)
+  {
+    // Inductive case.
+    struct StackWithUndo s;
+    Assume_Struct(&s);
+    SelectOperation(&s);
+    Assert_Struct(&s);
+  }
+  else
+  {
+    // Safety condition.
+    struct StackWithUndo s;
+    Assume_Struct(&s);
+    sassert(ApplyOperation(&s, 3) != EXCEPTION__STACK);
+  }
+}

--- a/test/synth/28_vmcai2004_ex2_unsat.c
+++ b/test/synth/28_vmcai2004_ex2_unsat.c
@@ -1,0 +1,301 @@
+// RUN: %sea smt %s --step=small --inline -o %t.sm.inline.smt2
+// RUN: %z3 %t.sm.inline.smt2 fp.spacer.order_children=2 2>&1 | OutputCheck %s
+//
+// RUN: %sea smt %s --step=large --inline -o %t.lg.inline.smt2
+// RUN: %z3 %t.lg.inline.smt2 fp.spacer.order_children=2 2>&1 | OutputCheck %s
+//
+// CHECK: ^unsat$
+
+// This set of tests is inspired by "Automatic Inference of Class Invariants" by Francesco Logozzo in VMCAI 2014.
+// This test case encodes the StackWithUndo class given by Fig. 2.
+
+#define SEA_SYNTH
+#include "seahorn/seahorn.h"
+
+// In this example, exceptions are encoded as implicit arguments passed between throwing methods.
+// Since only the exception type matters in this example, each exception is encoded by a unique integer.
+// Exception handling is instrumented into the call site (for example, line A to line B).
+#define EXCEPTION__NONE 0
+#define EXCEPTION__OUT_OF_BOUNDS 1
+#define EXCEPTION__NEGATIVE_SIZE 2
+#define EXCEPTION__STACK 3
+
+extern int nd1(void);
+extern int nd2(void);
+extern int nd3(void);
+extern int nd4(void);
+extern int nd5(void);
+extern int nd6(void);
+extern int nd7(void);
+extern int nd8(void);
+extern int nd9(void);
+extern int nd10(void);
+
+extern bool infer(int size, int pos, int stack_size, int undoObject, int undoType);
+bool PARTIAL_FN inv(int size, int pos, int stack_size, int undoObject, int undoType)
+{
+    return infer(size, pos, stack_size, undoObject, undoType);
+}
+
+//
+// Library methods assumed by the example in Fig 1.
+//
+
+int Math_Max(int a, int b)
+{
+  if (a < b) return b;
+  else return a;
+}
+
+//
+// Mock implementation of Object[].
+//
+
+struct MockObjectArray
+{
+  int size;
+};
+
+void New_MockObjectArray(struct MockObjectArray *array, int *exception, int size)
+{
+  if (size > 0)
+  {
+    array->size = size;
+  }
+  else
+  {
+    array->size = 0;
+    *exception = EXCEPTION__NEGATIVE_SIZE;
+  }
+}
+
+int MockObjectArray_read(struct MockObjectArray *array, int *exception, int i)
+{
+  if (array->size > i)
+  {
+    return nd1();
+  }
+  else
+  {
+    *exception = EXCEPTION__OUT_OF_BOUNDS;
+    return 0;
+  }
+}
+
+void MockObjectArray_write(struct MockObjectArray *array, int *exception, int i, int o)
+{
+  if (array->size > i)
+  {
+    (void) o;
+    return;
+  }
+  else
+  {
+    *exception = EXCEPTION__OUT_OF_BOUNDS;
+  }
+}
+
+//
+// Encoding of Stack from Fig 2.
+//
+
+struct StackWithUndo
+{
+  // Stack.
+  int size;
+  int pos;
+  struct MockObjectArray stack;
+  // StackWithUndo.
+  int undoObject;
+  int undoType;
+};
+
+void New_Stack(struct StackWithUndo *stack, int *exception, int size)
+{
+  stack->size = Math_Max(size, 1);
+  stack->pos = 0;
+  New_MockObjectArray(&stack->stack, exception, stack->size);
+  /* CHECK FOR EXCEPTIONS */ if (exception != EXCEPTION__NONE) return;
+}
+
+void New_StackWithUndo(struct StackWithUndo *stack, int *exception, int size)
+{
+  stack->undoObject = 0;
+  stack->undoType = 0;
+  New_Stack(stack, exception, size);
+  /* CHECK FOR EXCEPTIONS */ if (exception != EXCEPTION__NONE) return;
+}
+
+bool Stack_isEmpty(struct StackWithUndo *stack)
+{
+  return (stack->pos <= 0);
+}
+
+bool Stack_isFull(struct StackWithUndo *stack)
+{
+  return (stack->pos >= stack->size);
+}
+
+int Stack_top(struct StackWithUndo *stack, int *exception)
+{
+  if (!Stack_isEmpty(stack))
+  {
+    int tmp = MockObjectArray_read(&stack->stack, exception, stack->pos - 1); // Line A.
+    /* CHECK FOR EXCEPTIONS */ if (exception != EXCEPTION__NONE) return 0;
+    return tmp; // Line B.
+  }
+  else
+  {
+    *exception = EXCEPTION__STACK;
+    return 0;
+  }
+}
+
+void Stack_push(struct StackWithUndo *stack, int *exception, int o)
+{
+  if (!Stack_isFull(stack))
+  {
+    MockObjectArray_write(&stack->stack, exception, stack->pos, o);
+    /* CHECK FOR EXCEPTIONS */ if (exception != EXCEPTION__NONE) return;
+    stack->pos = stack->pos + 1;
+  }
+  else
+  {
+    *exception = EXCEPTION__STACK;
+  }
+}
+
+void StackWithUndo_push(struct StackWithUndo *stack, int *exception, int o)
+{
+  Stack_push(stack, exception, o);
+  /* CHECK FOR EXCEPTIONS */ if (exception != EXCEPTION__NONE) return;
+  stack->undoType = 1;
+}
+
+void Stack_pop(struct StackWithUndo *stack, int *exception)
+{
+  if (!Stack_isEmpty(stack))
+  {
+    stack->pos = stack->pos - 1;
+  }
+  else
+  {
+    *exception = EXCEPTION__STACK;
+  }
+}
+
+void StackWithUndo_pop(struct StackWithUndo *stack, int *exception)
+{
+  int tmp = stack->undoObject;
+  if (!Stack_isEmpty(stack))
+  {
+    int tmp = MockObjectArray_read(&stack->stack, exception, stack->pos - 1);
+    /* CHECK FOR EXCEPTIONS */ if (exception != EXCEPTION__NONE) return;
+  }
+  Stack_pop(stack, exception);
+  /* CHECK FOR EXCEPTIONS */ if (exception != EXCEPTION__NONE) return;
+  stack->undoType = -1;
+  stack->undoObject = tmp;
+}
+
+void StackWithUndo_undo(struct StackWithUndo *stack, int *exception)
+{
+  if (stack->undoType == -1)
+  {
+    Stack_push(stack, exception, stack->undoObject);
+    /* CHECK FOR EXCEPTIONS */ if (exception != EXCEPTION__NONE) return;
+    stack->undoType = 0;
+  }
+  else if (stack->undoType == 1)
+  {
+    Stack_pop(stack, exception);
+    /* CHECK FOR EXCEPTIONS */ if (exception != EXCEPTION__NONE) return;
+    stack->undoType = 0;
+  }
+}
+
+//
+// Harness.
+//
+
+void Assume_Struct(struct StackWithUndo *stack)
+{
+  stack->size = nd2();
+  stack->pos = nd3();
+  stack->stack.size = nd4();
+  stack->undoObject = nd5();
+  stack->undoType = nd6();
+  assume(inv(stack->size, stack->pos, stack->stack.size, stack->undoObject, stack->undoType));
+}
+
+void Assert_Struct(struct StackWithUndo *stack)
+{
+  sassert(inv(stack->size, stack->pos, stack->stack.size, stack->undoObject, stack->undoType));
+}
+
+int ApplyOperation(struct StackWithUndo *stack, int op)
+{
+  int exception = EXCEPTION__NONE;
+  switch (op)
+  {
+  case 0:
+    Stack_isEmpty(stack);
+    break;
+  case 1:
+    Stack_isFull(stack);
+    break;
+  case 2:
+    Stack_top(stack, &exception);
+    break;
+  case 3:
+    StackWithUndo_push(stack, &exception, nd7());
+    break;
+  case 4:
+    StackWithUndo_pop(stack, &exception);
+    break;
+  default:
+    StackWithUndo_undo(stack, &exception);
+  }
+  return exception;
+}
+
+int SelectOperation(struct StackWithUndo *stack)
+{
+  return ApplyOperation(stack, nd8());
+}
+
+int main(void)
+{
+  // This harness verifies the invariant given in the paper.
+
+  int rule = nd9();
+  if (rule == 0)
+  {
+    // Base case.
+    struct StackWithUndo s;
+    int exception = EXCEPTION__NONE;
+    New_StackWithUndo(&s, &exception, nd10());
+    Assert_Struct(&s);
+  }
+  else if (rule == 1)
+  {
+    // Inductive case.
+    struct StackWithUndo s;
+    Assume_Struct(&s);
+    SelectOperation(&s);
+    Assert_Struct(&s);
+  }
+  else
+  {
+    // Safety condition.
+    struct StackWithUndo s;
+    Assume_Struct(&s);
+    // Inherited invariant (Stack).
+    sassert(0 <= s.pos && s.pos < s.size);
+    sassert(s.size == s.stack.size);
+    // Refinement (StackWithUndo).
+    sassert(-1 <= s.undoType && s.undoType <= 1);
+    sassert(s.undoType != 1 || 0 < s.pos);
+    //sassert(s.undoType != -1 || s.pos < s.size);
+  }
+}

--- a/test/synth/29_vmcai_2004_ex2_sat.c
+++ b/test/synth/29_vmcai_2004_ex2_sat.c
@@ -1,0 +1,300 @@
+// RUN: %sea smt %s --step=small --inline -o %t.sm.inline.smt2
+// RUN: %z3 %t.sm.inline.smt2 fp.spacer.order_children=2 2>&1 | OutputCheck %s
+//
+// RUN: %sea smt %s --step=large --inline -o %t.lg.inline.smt2
+// RUN: %z3 %t.lg.inline.smt2 fp.spacer.order_children=2 2>&1 | OutputCheck %s
+//
+// CHECK: ^unsat$
+
+// This set of tests is inspired by "Automatic Inference of Class Invariants" by Francesco Logozzo in VMCAI 2014.
+// This test case encodes the StackWithUndo class given by Fig. 2.
+
+#define SEA_SYNTH
+#include "seahorn/seahorn.h"
+
+// In this example, exceptions are encoded as implicit arguments passed between throwing methods.
+// Since only the exception type matters in this example, each exception is encoded by a unique integer.
+// Exception handling is instrumented into the call site (for example, line A to line B).
+#define EXCEPTION__NONE 0
+#define EXCEPTION__OUT_OF_BOUNDS 1
+#define EXCEPTION__NEGATIVE_SIZE 2
+#define EXCEPTION__STACK 3
+
+extern int nd1(void);
+extern int nd2(void);
+extern int nd3(void);
+extern int nd4(void);
+extern int nd5(void);
+extern int nd6(void);
+extern int nd7(void);
+extern int nd8(void);
+extern int nd9(void);
+extern int nd10(void);
+
+extern bool infer(int size, int pos, int stack_size, int undoObject, int undoType);
+bool PARTIAL_FN inv(int size, int pos, int stack_size, int undoObject, int undoType)
+{
+    return infer(size, pos, stack_size, undoObject, undoType);
+}
+
+//
+// Library methods assumed by the example in Fig 1.
+//
+
+int Math_Max(int a, int b)
+{
+  if (a < b) return b;
+  else return a;
+}
+
+//
+// Mock implementation of Object[].
+//
+
+struct MockObjectArray
+{
+  int size;
+};
+
+void New_MockObjectArray(struct MockObjectArray *array, int *exception, int size)
+{
+  if (size > 0)
+  {
+    array->size = size;
+  }
+  else
+  {
+    array->size = 0;
+    *exception = EXCEPTION__NEGATIVE_SIZE;
+  }
+}
+
+int MockObjectArray_read(struct MockObjectArray *array, int *exception, int i)
+{
+  if (array->size > i)
+  {
+    return nd1();
+  }
+  else
+  {
+    *exception = EXCEPTION__OUT_OF_BOUNDS;
+    return 0;
+  }
+}
+
+void MockObjectArray_write(struct MockObjectArray *array, int *exception, int i, int o)
+{
+  if (array->size > i)
+  {
+    (void) o;
+    return;
+  }
+  else
+  {
+    *exception = EXCEPTION__OUT_OF_BOUNDS;
+  }
+}
+
+//
+// Encoding of Stack from Fig 2.
+//
+
+struct StackWithUndo
+{
+  // Stack.
+  int size;
+  int pos;
+  struct MockObjectArray stack;
+  // StackWithUndo.
+  int undoObject;
+  int undoType;
+};
+
+void New_Stack(struct StackWithUndo *stack, int *exception, int size)
+{
+  stack->size = Math_Max(size, 1);
+  stack->pos = 0;
+  New_MockObjectArray(&stack->stack, exception, stack->size);
+  /* CHECK FOR EXCEPTIONS */ if (exception != EXCEPTION__NONE) return;
+}
+
+void New_StackWithUndo(struct StackWithUndo *stack, int *exception, int size)
+{
+  stack->undoObject = 0;
+  stack->undoType = 0;
+  New_Stack(stack, exception, size);
+  /* CHECK FOR EXCEPTIONS */ if (exception != EXCEPTION__NONE) return;
+}
+
+bool Stack_isEmpty(struct StackWithUndo *stack)
+{
+  return (stack->pos <= 0);
+}
+
+bool Stack_isFull(struct StackWithUndo *stack)
+{
+  return (stack->pos >= stack->size);
+}
+
+int Stack_top(struct StackWithUndo *stack, int *exception)
+{
+  if (!Stack_isEmpty(stack))
+  {
+    int tmp = MockObjectArray_read(&stack->stack, exception, stack->pos - 1); // Line A.
+    /* CHECK FOR EXCEPTIONS */ if (exception != EXCEPTION__NONE) return 0;
+    return tmp; // Line B.
+  }
+  else
+  {
+    *exception = EXCEPTION__STACK;
+    return 0;
+  }
+}
+
+void Stack_push(struct StackWithUndo *stack, int *exception, int o)
+{
+  if (!Stack_isFull(stack))
+  {
+    MockObjectArray_write(&stack->stack, exception, stack->pos, o);
+    /* CHECK FOR EXCEPTIONS */ if (exception != EXCEPTION__NONE) return;
+    stack->pos = stack->pos + 1;
+  }
+  else
+  {
+    *exception = EXCEPTION__STACK;
+  }
+}
+
+void StackWithUndo_push(struct StackWithUndo *stack, int *exception, int o)
+{
+  Stack_push(stack, exception, o);
+  /* CHECK FOR EXCEPTIONS */ if (exception != EXCEPTION__NONE) return;
+  stack->undoType = 1;
+}
+
+void Stack_pop(struct StackWithUndo *stack, int *exception)
+{
+  if (!Stack_isEmpty(stack))
+  {
+    stack->pos = stack->pos - 1;
+  }
+  else
+  {
+    *exception = EXCEPTION__STACK;
+  }
+}
+
+void StackWithUndo_pop(struct StackWithUndo *stack, int *exception)
+{
+  int tmp = stack->undoObject;
+  if (!Stack_isEmpty(stack))
+  {
+    int tmp = MockObjectArray_read(&stack->stack, exception, stack->pos - 1);
+    /* CHECK FOR EXCEPTIONS */ if (exception != EXCEPTION__NONE) return;
+  }
+  Stack_pop(stack, exception);
+  /* CHECK FOR EXCEPTIONS */ if (exception != EXCEPTION__NONE) return;
+  stack->undoType = -1;
+  stack->undoObject = tmp;
+}
+
+void StackWithUndo_undo(struct StackWithUndo *stack, int *exception)
+{
+  if (stack->undoType == -1)
+  {
+    Stack_push(stack, exception, stack->undoObject);
+    /* CHECK FOR EXCEPTIONS */ if (exception != EXCEPTION__NONE) return;
+    stack->undoType = 0;
+  }
+  else if (stack->undoType == 1)
+  {
+    Stack_pop(stack, exception);
+    /* CHECK FOR EXCEPTIONS */ if (exception != EXCEPTION__NONE) return;
+    stack->undoType = 0;
+  }
+}
+
+//
+// Harness.
+//
+
+void Assume_Struct(struct StackWithUndo *stack)
+{
+  stack->size = nd2();
+  stack->pos = nd3();
+  stack->stack.size = nd4();
+  stack->undoObject = nd5();
+  stack->undoType = nd6();
+  assume(inv(stack->size, stack->pos, stack->stack.size, stack->undoObject, stack->undoType));
+}
+
+void Assert_Struct(struct StackWithUndo *stack)
+{
+  sassert(inv(stack->size, stack->pos, stack->stack.size, stack->undoObject, stack->undoType));
+}
+
+int ApplyOperation(struct StackWithUndo *stack, int op)
+{
+  int exception = EXCEPTION__NONE;
+  switch (op)
+  {
+  case 0:
+    Stack_isEmpty(stack);
+    break;
+  case 1:
+    Stack_isFull(stack);
+    break;
+  case 2:
+    Stack_top(stack, &exception);
+    break;
+  case 3:
+    StackWithUndo_push(stack, &exception, nd7());
+    break;
+  case 4:
+    StackWithUndo_pop(stack, &exception);
+    break;
+  default:
+    StackWithUndo_undo(stack, &exception);
+  }
+  return exception;
+}
+
+int SelectOperation(struct StackWithUndo *stack)
+{
+  return ApplyOperation(stack, nd8());
+}
+
+int main(void)
+{
+  // This harness claims stack.undoType cannot change from -1 to 1.
+  // This is false, as after push is called, stack.undoType is changed to -1.
+  // If pop is then called, stack.undoType will change from -1 to 1.
+
+  int rule = nd9();
+  if (rule == 0)
+  {
+    // Base case.
+    struct StackWithUndo s;
+    int exception = EXCEPTION__NONE;
+    New_StackWithUndo(&s, &exception, nd10());
+    Assert_Struct(&s);
+  }
+  else if (rule == 1)
+  {
+    // Inductive case.
+    struct StackWithUndo s;
+    Assume_Struct(&s);
+    SelectOperation(&s);
+    Assert_Struct(&s);
+  }
+  else
+  {
+    // Safety condition.
+    struct StackWithUndo s;
+    Assume_Struct(&s);
+    int oldType = s.undoType;
+    SelectOperation(&s);
+    int newType = s.undoType;
+    sassert(oldType != -1 || newType != 1);
+  }
+}


### PR DESCRIPTION
This commit also includes two tests that were previously missing:
- A safe program for which the only adequate invariant is "true"
- A safe program for which the only adequate invariant is "false"