### PR TITLE
fix(boost): resolve ambiguous under boost namepsace

### DIFF
--- a/include/seahorn/HornClauseDBBgl.hh
+++ b/include/seahorn/HornClauseDBBgl.hh
@@ -101,9 +101,10 @@ namespace boost
   inline std::pair<out_eit,out_eit> out_edges (expr::Expr e, const seahorn::HornClauseDBCallGraph &callgraph)
   {
     auto const &callees = callgraph.callees(e);
-    return std::make_pair
-        (make_transform_iterator (callees.begin(), seahorn::bgl::MkOutEdgePair (e)),
-         make_transform_iterator (callees.end(), seahorn::bgl::MkOutEdgePair (e)));
+    return std::make_pair(iterators::make_transform_iterator(
+                              callees.begin(), seahorn::bgl::MkOutEdgePair(e)),
+                          iterators::make_transform_iterator(
+                              callees.end(), seahorn::bgl::MkOutEdgePair(e)));
   }
   
   inline size_t out_degree (expr::Expr e, const seahorn::HornClauseDBCallGraph &callgraph)
@@ -112,9 +113,10 @@ namespace boost
   inline std::pair<in_eit, in_eit> in_edges (expr::Expr e, const seahorn::HornClauseDBCallGraph &callgraph)
   {
     auto const &callers = callgraph.callers(e);
-    return std::make_pair
-        (make_transform_iterator (callers.begin(), seahorn::bgl::MkInEdgePair (e)),
-         make_transform_iterator (callers.end(), seahorn::bgl::MkInEdgePair (e)));
+    return std::make_pair(iterators::make_transform_iterator(
+                              callers.begin(), seahorn::bgl::MkInEdgePair(e)),
+                          iterators::make_transform_iterator(
+                              callers.end(), seahorn::bgl::MkInEdgePair(e)));
   }
   
   inline size_t in_degree (expr::Expr e, const seahorn::HornClauseDBCallGraph &callgraph)

--- a/lib/seahorn/FiniteMapTransf.cc
+++ b/lib/seahorn/FiniteMapTransf.cc
@@ -10,6 +10,7 @@ using namespace expr;
 using namespace expr::op;
 
 namespace seahorn {
+namespace op_variant = expr::op::variant;
 // ----------------------------------------------------------------------
 //  FiniteMapArgsVisitor
 // ----------------------------------------------------------------------
@@ -18,7 +19,8 @@ namespace seahorn {
 // also used in FinteMapBodyVisitor
 static Expr mkVarGet(Expr mapConst, Expr k, Expr vTy) {
   assert(bind::isFiniteMapConst(mapConst));
-  return bind::mkConst(variant::variant(0, finite_map::get(mapConst, k)), vTy);
+  return bind::mkConst(op_variant::variant(0, finite_map::get(mapConst, k)),
+                       vTy);
 }
 
 // \brief rewrites a map into separate scalar variables. New variables are added
@@ -67,7 +69,8 @@ static Expr mkFappArgsCore(Expr fapp, Expr newFdecl, ExprVector &extraUnifs,
       if (bind::isFiniteMapConst(arg)) {
         map_var_name = arg;
       } else {
-        map_var_name = bind::mkConst(variant::variant(arg_count, fname), argTy);
+        map_var_name =
+            bind::mkConst(op_variant::variant(arg_count, fname), argTy);
         // if there is no name, we create a variant with the name of the
         // function, make new variable (same as normalization)
       }

--- a/lib/seahorn/FlatHornifyFunction.cc
+++ b/lib/seahorn/FlatHornifyFunction.cc
@@ -7,6 +7,7 @@
 #include "seahorn/Support/SeaDebug.h"
 
 namespace seahorn {
+namespace op_variant = expr::op::variant;
 
 void FlatSmallHornifyFunction::runOnFunction(Function &F) {
 
@@ -52,7 +53,7 @@ void FlatSmallHornifyFunction::runOnFunction(Function &F) {
     Expr name = mkTerm<const Function *>(&F, m_efac);
     // avoid clash with the names of summaries
     if (m_interproc)
-      name = variant::prime(name);
+      name = op_variant::prime(name);
 
     step = bind::fdecl(name, sorts);
     m_db.registerRelation(step);
@@ -259,7 +260,7 @@ void FlatLargeHornifyFunction::runOnFunction(Function &F) {
     Expr name = mkTerm<const Function *>(&F, m_efac);
     // avoid clash with the names of summaries
     if (m_interproc)
-      name = variant::prime(name);
+      name = op_variant::prime(name);
 
     step = bind::fdecl(name, sorts);
     m_db.registerRelation(step);


### PR DESCRIPTION
Fix ambiguity caused by using the namespace `expr::op::variant`.