### PR TITLE
refactor(opsem): refactor mem mgr to allow object mem

### DIFF
--- a/lib/seahorn/BvOpSem2.cc
+++ b/lib/seahorn/BvOpSem2.cc
@@ -1781,6 +1781,7 @@ public:
 
   Expr executeSelectInst(Expr cond, Expr op0, Expr op1, Type *ty,
                          Bv2OpSemContext &ctx) {
+    // TODO: move this logic to mem manager
     if (ty->isVectorTy()) {
       llvm_unreachable(nullptr);
     }
@@ -2711,6 +2712,10 @@ boost::tribool Bv2OpSemContext::solve() { return m_z3_solver->solve(); }
 Expr Bv2OpSemContext::ptrToAddr(Expr p) { return mem().ptrToAddr(p); }
 
 Expr Bv2OpSemContext::getRawMem(Expr p) { return mem().getRawMem(p); }
+
+Expr Bv2OpSemContext::joinMemories(Expr mem1, Expr mem2) {
+  return m_memManager->joinMemories(mem1, mem2);
+}
 
 } // namespace details
 

--- a/lib/seahorn/BvOpSem2Context.hh
+++ b/lib/seahorn/BvOpSem2Context.hh
@@ -39,6 +39,11 @@ auto widemem_tag_of =
   return {};
 };
 
+auto objectmem_tag_of =
+    [](auto t) -> hana::type<typename decltype(t)::type::ObjectMemTag> {
+  return {};
+};
+
 // This empty class is used as a 'tag' to mark containing classes as enabling
 // features
 // feature: tracking.
@@ -47,6 +52,9 @@ struct Tracking_tag {};
 struct FatMem_tag {};
 // feature: Wide Memory.
 struct WideMem_tag {};
+
+// feature: Object Memory.
+struct ObjectMem_tag {};
 
 auto has_tracking = [](auto t) {
   return hana::sfinae(tracking_tag_of)(t) ==
@@ -60,6 +68,11 @@ auto has_fatmem = [](auto t) {
 auto has_widemem = [](auto t) {
   return hana::sfinae(widemem_tag_of)(t) ==
          hana::just(hana::type<WideMem_tag>{});
+};
+
+auto has_objectmem = [](auto t) {
+  return hana::sfinae(objectmem_tag_of)(t) ==
+         hana::just(hana::type<ObjectMem_tag>{});
 };
 
 } // namespace MemoryFeatures
@@ -260,6 +273,9 @@ public:
   /// symbolic pointer \ptr. Memory register being read from must be set via
   /// \f setMemReadRegister
   Expr loadValueFromMem(Expr ptr, const llvm::Type &ty, uint32_t align);
+
+  /// \brief join two memories according to semantics of memory manager
+  Expr joinMemories(Expr mem1, Expr mem2);
 
   /// \brief Store a value \val to symbolic memory at address \p ptr
   ///
@@ -657,6 +673,8 @@ public:
 
   virtual MemValTy storeValueToMem(Expr _val, PtrTy ptr, MemValTy memIn,
                                    const llvm::Type &ty, uint32_t align) = 0;
+
+  virtual MemValTy joinMemories(Expr mem1, Expr mem2) = 0;
 
   /// \brief Executes symbolic memset with a concrete length
   virtual MemValTy MemSet(PtrTy ptr, Expr _val, unsigned len, MemValTy mem,

--- a/lib/seahorn/BvOpSem2MemManagerMixin.hh
+++ b/lib/seahorn/BvOpSem2MemManagerMixin.hh
@@ -199,6 +199,18 @@ public:
     return toMemValTy(std::move(res));
   }
 
+  MemValTy joinMemories(MemValTy mem1, MemValTy mem2) {
+    // TODO: remove this since every memory mgr will impl
+    // join mem
+    return hana::eval_if(
+        MemoryFeatures::has_objectmem(hana::type<BaseT>{}),
+        [&](auto _) { return _(base()).joinMemories(mem1, mem2); },
+        [&] {
+          LOG("opsem", WARN << "joinMemories() not implemented!\n");
+          return Expr();
+        });
+  }
+
   MemValTy MemSet(PtrTy ptr, Expr _val, unsigned len, MemValTy mem,
                   uint32_t align) override {
     auto res = base().MemSet(BasePtrTy(std::move(ptr)), _val, len,

--- a/lib/seahorn/BvOpSem2RawMemMgr.hh
+++ b/lib/seahorn/BvOpSem2RawMemMgr.hh
@@ -120,6 +120,7 @@ public:
   using TrackingTag = int;
   using FatMemTag = int;
   using WideMemTag = int;
+  using ObjectMemTag = int;
 
   /// \brief A null pointer expression (cache)
   PtrTy m_nullPtr;


### PR DESCRIPTION
Templatize TrackingMemMgr and ExtraWideMemMgr so that they can take in any mem mgr, not just raw mem mgr

ObjectMemMgr (to be added) will be a sibling to RawMemMgr