### PR TITLE
feat(opsem): integrate crab to lower sea-is-deref

### DIFF
--- a/lib/seahorn/PathBmc.cc
+++ b/lib/seahorn/PathBmc.cc
@@ -137,7 +137,10 @@ static llvm::cl::opt<clam::CrabDomain::Type, true, clam::CrabDomainParser>
                  clEnumValN(clam::CrabDomain::TERMS_ZONES, "rtz",
                             "Reduced product of term-dis-int and zones"),
                  clEnumValN(clam::CrabDomain::WRAPPED_INTERVALS, "w-int",
-                            "Wrapped interval domain")),
+                            "Wrapped interval domain"),
+                 clEnumValN(clam::CrabDomain::OCT, "oct", "Octagon domain"),
+                 clEnumValN(clam::CrabDomain::PK, "pk",
+                            "Convex Polyhedra and Linear Equalities domains")),
              llvm::cl::location(seahorn::CrabDom),
              llvm::cl::init(clam::CrabDomain::ZONES_SPLIT_DBM));
 

--- a/test/crab/crab_is_deref_1.c
+++ b/test/crab/crab_is_deref_1.c
@@ -1,0 +1,73 @@
+// RUN: %sea -O3 fpf --inline --horn-bv2-crab-lower-is-deref --horn-bmc-crab-dom=pk --dsa=sea-cs-t --bmc=opsem --horn-vcgen-use-ite --horn-vcgen-only-dataflow=false --horn-bmc-coi=false --horn-stats=true --sea-opsem-allocator=static "%s" 2>&1 | OutputCheck %s
+// CHECK: ^unsat$
+// CHECK: ^BRUNCH_STAT crab.isderef.solve 3
+
+#include <seahorn/seahorn.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+extern int nd_int(void);
+
+size_t size_t_nd(void) {
+    int res = nd_int();
+    assume(res > 0);
+    return res;
+}
+
+extern void memhavoc(void *, size_t);
+
+struct aws_byte_cursor {
+    /* do not reorder this, this struct lines up nicely with windows buffer structures--saving us allocations */
+    size_t len;
+    uint8_t *ptr;
+};
+
+struct aws_byte_buf {
+    /* do not reorder this, this struct lines up nicely with windows buffer structures--saving us allocations.*/
+    size_t len;
+    uint8_t *buffer;
+    size_t capacity;
+    struct aws_allocator *allocator;
+};
+
+extern void *ext_memcpy (void *dest, const void *src, size_t len);
+
+void *mymemcpy(void *dst, const void *src, size_t len) {
+    sassert(sea_is_dereferenceable(dst, len));
+    sassert(sea_is_dereferenceable(src, len));
+    return ext_memcpy(dst, src, len);
+}
+
+void initialize_byte_buf(struct aws_byte_buf *const buf) {
+    size_t len = size_t_nd();
+    size_t cap = size_t_nd();
+    assume(len <= cap);
+    assume(cap <= 512);
+
+    buf->len = len;
+    buf->capacity = cap;
+    buf->buffer = malloc(cap * sizeof(*(buf->buffer)));
+}
+
+void init_cursor_from_buf(struct aws_byte_buf *const buf, struct aws_byte_cursor *cur) {
+    cur->len = buf->len;
+    cur->ptr = malloc(sizeof(uint8_t) * cur->len);
+}
+
+int main(void) {
+    struct aws_byte_buf buf;
+    initialize_byte_buf(&buf);
+    if (buf.capacity == 0) return 0;
+    struct aws_byte_cursor cur;
+    init_cursor_from_buf(&buf, &cur);
+
+    sassert(sea_is_dereferenceable(buf.buffer, buf.len));
+    if (buf.capacity - buf.len < cur.len) return -1;
+    if (cur.len > 0)
+        mymemcpy(buf.buffer + buf.len, cur.ptr, cur.len);
+    return 0;
+}
+

--- a/test/crab/crab_is_deref_2.c
+++ b/test/crab/crab_is_deref_2.c
@@ -1,0 +1,31 @@
+// RUN: %sea -O3 fpf --inline --horn-bv2-crab-lower-is-deref --horn-bmc-crab-dom=pk --dsa=sea-cs-t --bmc=opsem --horn-vcgen-use-ite --horn-vcgen-only-dataflow=false --horn-bmc-coi=false --horn-stats=true --sea-opsem-allocator=static "%s" 2>&1 | OutputCheck %s
+// CHECK: ^unsat$
+// CHECK: ^BRUNCH_STAT crab.isderef.solve 6
+
+#include <seahorn/seahorn.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+extern int nd_int(void);
+extern bool nd_bool(void);
+extern void memhavoc(void *, size_t);
+
+// Domain: oct
+int main() {
+    int len = nd_int();
+    assume(len > 0);
+    int max_len = 1024;
+    assume(len < max_len);
+    uint8_t *ptr = malloc(len);
+    sassert(sea_is_dereferenceable(ptr, len));
+    while (len > 0) {
+        uint8_t *p2 = ptr + (len - 1);
+        sassert(sea_is_dereferenceable(p2, sizeof(uint8_t)));
+        uint8_t tmp = *p2;
+        -- len;
+    }
+   return 0;
+}


### PR DESCRIPTION
Use crab to infer the results of  `sea.is_dereferenceable`.