### PR TITLE
fix(CI): use new codecov upload action and dev10

### DIFF
--- a/.github/workflows/seahorn-coverage.yml
+++ b/.github/workflows/seahorn-coverage.yml
@@ -20,10 +20,11 @@ jobs:
       - name: Collect coverage report
         run:  docker run -v $(pwd):/host seahorn/seahorn-builder:bionic-llvm10 /bin/bash -c "/seahorn/scripts/coverage/docker-run-lcov.sh && mv /seahorn/all.info /host"
       - name: Upload coverage report
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./all.info
+          files: ./all.info
           name: codecov-seahorn
+          override_branch: dev10
           fail_ci_if_error: true
           verbose: true


### PR DESCRIPTION
Since `master` branch has been stale for some time, number of repeated coverage uploads based on `master` seem to have exceeded the limit from codecov.io ([150](https://community.codecov.com/t/ci-failure-due-to-too-many-uploads-to-this-commit/2587/7) from semi-official source);
This commit will base future coverage uploads off `dev10` since most developments have migrated there; also bumping `codecov-action` to v2 since [v1 is going deprecated soon](https://about.codecov.io/blog/introducing-codecovs-new-uploader/).