### PR TITLE
fix(inter-mem): force not inlining in tests

### DIFF
--- a/test/inter-mem/0_bounded_mem_unknown.c
+++ b/test/inter-mem/0_bounded_mem_unknown.c
@@ -18,18 +18,22 @@ typedef struct Struct {
   int y;
 } Struct;
 
+__attribute__((noinline))
 void modify_x(Struct *s, int v) {
   s->x = v;
 }
 
+__attribute__((noinline))
 void modify_y(Struct *s, int v) {
   s->y = v;
 }
 
+__attribute__((noinline))
 int read_x(Struct *s) {
   return s->x;
 }
 
+__attribute__((noinline))
 int read_y(Struct *s) {
   return s->y;
 }

--- a/test/inter-mem/1_bounded_mem_unsat.c
+++ b/test/inter-mem/1_bounded_mem_unsat.c
@@ -15,18 +15,22 @@ typedef struct Struct {
   int y;
 } Struct;
 
+__attribute__((noinline))
 void modify_x(Struct *s, int v) {
   s->x = v;
 }
 
+__attribute__((noinline))
 void modify_y(Struct *s, int v) {
   s->y = v;
 }
 
+__attribute__((noinline))
 int read_x(Struct *s) {
   return s->x;
 }
 
+__attribute__((noinline))
 int read_y(Struct *s) {
   return s->y;
 }

--- a/test/inter-mem/2_unbounded_mem_unknown.c
+++ b/test/inter-mem/2_unbounded_mem_unknown.c
@@ -26,16 +26,7 @@ typedef struct List {
   LElem * e;
 } List;
 
-List * new_list() {
-  List * l = (List *) malloc(sizeof(List));
-
-  l->cap=MAX_LIST;
-  l->sz=0;
-  l->e=NULL;
-
-  return l;
-}
-
+__attribute__((noinline))
 void init_list(List * l) {
   l->cap=MAX_LIST;
   l->sz=0;
@@ -43,6 +34,7 @@ void init_list(List * l) {
 }
 
 //bounded memory written and read
+__attribute__((noinline))
 int push_elem(List * l, int data) {
 
   if(l->sz < l->cap){

--- a/test/inter-mem/3_unbounded_mem_unsat.c
+++ b/test/inter-mem/3_unbounded_mem_unsat.c
@@ -23,16 +23,7 @@ typedef struct List {
   LElem * e;
 } List;
 
-List * new_list() {
-  List * l = (List *) malloc(sizeof(List));
-
-  l->cap=MAX_LIST;
-  l->sz=0;
-  l->e=NULL;
-
-  return l;
-}
-
+__attribute__((noinline))
 void init_list(List * l) {
   l->cap=MAX_LIST;
   l->sz=0;
@@ -40,6 +31,7 @@ void init_list(List * l) {
 }
 
 //bounded memory written and read
+__attribute__((noinline))
 int push_elem(List * l, int data) {
 
   if(l->sz < l->cap){
@@ -63,7 +55,7 @@ int main() {
   init_list(&l2);
 
   sea_dsa_alias(&l1,&l2); // comment this line to converge
-  assume(&l1 + sizeof(List) + 100 < &l2);
+  assume(&l1 + sizeof(List) < &l2);
 
   push_elem(&l2, 42);
 

--- a/test/inter-mem/4_two_structs_unknown.c
+++ b/test/inter-mem/4_two_structs_unknown.c
@@ -31,30 +31,37 @@ typedef struct Struct1 {
   Struct2 * t;
 } Struct1;
 
+__attribute__((noinline))
 void modify_x(Struct1 *s, int v) {
   s->x = v;
 }
 
+__attribute__((noinline))
 void modify_y(Struct1 *s, int v) {
   s->y = v;
 }
 
+__attribute__((noinline))
 int read_x(Struct1 *s) {
   return s->x;
 }
 
+__attribute__((noinline))
 int read_y(Struct1 *s) {
   return s->y;
 }
 
+__attribute__((noinline))
 int read_t_s(Struct1 *s) {
   return s->t->s;
 }
 
+__attribute__((noinline))
 void modify_r(Struct2 *s, int v) {
   s->r = v;
 }
 
+__attribute__((noinline))
 void modify_t_r(Struct1 *s, int v) {
   modify_r(s->t,v);
 }

--- a/test/inter-mem/5_two_structs_unsat.c
+++ b/test/inter-mem/5_two_structs_unsat.c
@@ -31,30 +31,37 @@ typedef struct Struct1 {
   Struct2 * t;
 } Struct1;
 
+__attribute__((noinline))
 void modify_x(Struct1 *s, int v) {
   s->x = v;
 }
 
+__attribute__((noinline))
 void modify_y(Struct1 *s, int v) {
   s->y = v;
 }
 
+__attribute__((noinline))
 int read_x(Struct1 *s) {
   return s->x;
 }
 
+__attribute__((noinline))
 int read_y(Struct1 *s) {
   return s->y;
 }
 
+__attribute__((noinline))
 int read_t_s(Struct1 *s) {
   return s->t->s;
 }
 
+__attribute__((noinline))
 void modify_r(Struct2 *s, int v) {
   s->r = v;
 }
 
+__attribute__((noinline))
 void modify_t_r(Struct1 *s, int v) {
   modify_r(s->t,v);
 }

--- a/test/inter-mem/6_offset_collapsed_unknown.c
+++ b/test/inter-mem/6_offset_collapsed_unknown.c
@@ -27,6 +27,7 @@ typedef struct {
   int data[MAX_LIST];
 } List;
 
+__attribute__((noinline))
 void init_list(List * l) {
 
   l->sz=l->data;
@@ -34,6 +35,7 @@ void init_list(List * l) {
 }
 
 //bounded memory written and read
+__attribute__((noinline))
 int push_elem(List * l, int data) {
 
   if(l->sz < l->cap){

--- a/test/inter-mem/7_offset_collapsed_unsat.c
+++ b/test/inter-mem/7_offset_collapsed_unsat.c
@@ -26,6 +26,7 @@ typedef struct {
   int data[MAX_LIST];
 } List;
 
+__attribute__((noinline))
 void init_list(List * l) {
 
   l->sz=l->data;
@@ -33,6 +34,7 @@ void init_list(List * l) {
 }
 
 //bounded memory written and read
+__attribute__((noinline))
 int push_elem(List * l, int data) {
 
   if(l->sz < l->cap){


### PR DESCRIPTION
functions are inlined with the -O0 option so nothing was being tested