### PR TITLE
fix(cex): handle invalid memmap when build memhavoc

### DIFF
--- a/include/seahorn/Expr/ExprMemMap.hh
+++ b/include/seahorn/Expr/ExprMemMap.hh
@@ -168,6 +168,8 @@ public:
   const_mc_iterator cbegin() const { return m_cells.cbegin(); }
 
   const_mc_iterator cend() const { return m_cells.cend(); }
+
+  Expr getRawExpr() const { return m_expr; }
 };
 } // namespace exprMemMap
 } // namespace expr


### PR DESCRIPTION
- when synthesizing `memhavoc`, return all 0 constant array if `ExprMemMap` cannot parse a valid mem map.
- explicitly checks if mem map content width is not less than `llvm::IntegerType::MIN_INT_BITS`; `is_valid` field should have been enough but just adding these as sanity checks.
- fixes #424 , tested using `debug` build against vcc `byte_buf_write_from_whole_string`