### PR TITLE
fix(opsem): init fresh ptr name in widememmgrs

### DIFF
--- a/lib/seahorn/BvOpSem2Allocators.cc
+++ b/lib/seahorn/BvOpSem2Allocators.cc
@@ -210,6 +210,8 @@ public:
     Expr inRange = m_ctx.alu().doUle(
         bytes, m_ctx.alu().ui(m_maxSymbAllocSz, width), width);
     m_ctx.addScopedRely(inRange);
+    LOG("opsem", errs() << "Adding allocation interval: " << addrIvl.first
+                        << " to " << addrIvl.second << "\n";);
     return addrIvl;
   }
 };

--- a/lib/seahorn/BvOpSem2ExtraWideMemMgr.cc
+++ b/lib/seahorn/BvOpSem2ExtraWideMemMgr.cc
@@ -447,7 +447,7 @@ typename ExtraWideMemManager<T>::PtrTy ExtraWideMemManager<T>::nullPtr() const {
 }
 template <class T>
 typename ExtraWideMemManager<T>::PtrTy ExtraWideMemManager<T>::freshPtr() {
-  Expr name = op::variant::variant(m_id++, m_freshPtrName);
+  Expr name = m_main.freshPtr();
   return mkAlignedPtr(name, m_alignment);
 }
 template <class T>

--- a/lib/seahorn/BvOpSem2WideMemMgr.cc
+++ b/lib/seahorn/BvOpSem2WideMemMgr.cc
@@ -317,7 +317,7 @@ Expr WideMemManager::coerce(Expr sort, Expr val) {
   return m_main.coerce(sort, val);
 }
 WideMemManager::PtrTy WideMemManager::freshPtr() {
-  Expr name = op::variant::variant(m_id++, m_freshPtrName);
+  Expr name = m_main.freshPtr();
   return mkAlignedPtr(name, m_alignment);
 }
 WideMemManager::MemSortTy

--- a/test/opsem2/widemem/sym_alloc.c
+++ b/test/opsem2/widemem/sym_alloc.c
@@ -1,0 +1,33 @@
+//; RUN: %sea "%s" --horn-bv2-extra-widemem --horn-opsem-max-symb-alloc=0 2>&1 | OutputCheck %s
+//; RUN: %sea "%s" --horn-bv2-widemem --horn-opsem-max-symb-alloc=0 2>&1 | OutputCheck %s
+// CHECK: ^sat$
+
+/**
+ * This test should normally be unsat except that we don't give any symbolic memory (--horn-opsem-max-symb-alloc=0) so
+ * seahorn nondeterministically chooses two fresh pointers.
+ *
+ * This test SHOULD NOT crash.
+ */
+
+#include <seahorn/seahorn.h>
+#include <stdlib.h>
+
+extern uint8_t nd_char();
+extern bool nd_bool();
+
+int main() {
+  size_t szBytes1 = nd_char();
+  size_t szBytes2 = nd_char();
+
+  assume(szBytes1 < 100);
+  assume(szBytes1 < 100);
+  uint32_t *p = malloc(szBytes1 * sizeof(uint8_t));
+  uint32_t *q = malloc(szBytes2 * sizeof(uint8_t));
+  *p = 1;
+  *q = 2;
+  int diff = p - q;
+  sassert(diff < -4 || diff > 4);
+  sassert(*p != *q);
+}
+
+


### PR DESCRIPTION
Added test to replicate failure and validate fix

Why was this failure not detected?

Because we never set the symbolic memory threshold very low thus escaping the need to use fresh pointers and exercise faulty code path