### PR TITLE
fix(ci): force use latest dev10 commit

### DIFF
--- a/.github/workflows/seahorn-coverage.yml
+++ b/.github/workflows/seahorn-coverage.yml
@@ -4,6 +4,12 @@ name: Coverage
 on:
   schedule:
     - cron: 0 0 * * *  # run every day at UTC 00:00
+  workflow_dispatch:
+    inputs:
+      Triggerer:
+        description: 'Triggered by:'
+        required: true
+        default: ''
 
 jobs:
   coverage:
@@ -15,6 +21,9 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: dev10  # only checkout dev10
+      - name: Set dev10 commit SHA
+        run: | # set dev10 last commit SHA
+          echo "COMMIT_SHA=$(git log -1 --format='%H')" >> $GITHUB_ENV
       - name: Build seahorn builder
         run: docker build . --file docker/seahorn-builder.Dockerfile --tag seahorn/seahorn-builder:bionic-llvm10 --build-arg BUILD_TYPE=$BUILD_TYPE
       - name: Collect coverage report
@@ -26,5 +35,6 @@ jobs:
           files: ./all.info
           name: codecov-seahorn
           override_branch: dev10
+          override_commit: ${{ env.COMMIT_SHA }}
           fail_ci_if_error: true
           verbose: true


### PR DESCRIPTION
Problem: Codecov uploader was still using the latest commit SHA of `master` for each coverage upload, so the limit on uploads per commit was exceeded again. 
Solution: Force codecov uploader to use latest commit SHA of `dev10` instead. See this [successful run](https://github.com/danblitzhou/seahorn/runs/5413144820?check_suite_focus=true) and [code cov report showing latest commit to dev10 from 3 days ago](https://codecov.io/gh/danblitzhou/seahorn/commit/edf8d5700170640b63422140fee173acb674d4f0/).