### PR TITLE
refactor(opsem): decouple sub mem mgr tuple from trackingmemmgr

### DIFF
--- a/lib/seahorn/BvOpSem2TrackingRawMemMgr.cc
+++ b/lib/seahorn/BvOpSem2TrackingRawMemMgr.cc
@@ -8,25 +8,35 @@ const unsigned int TrackingRawMemManager::g_MetadataByteWidth =
     TrackingRawMemManager::g_MetadataBitWidth / 8;
 const unsigned int TrackingRawMemManager::g_num_slots = 4;
 
+TrackingMemoryTuple::TrackingMemoryTuple(Bv2OpSem &sem, Bv2OpSemContext &ctx,
+                                         unsigned ptrSz, unsigned wordSz,
+                                         bool useLambdas)
+    : m_main(sem, ctx, ptrSz, wordSz, useLambdas),
+      m_w_metadata(sem, ctx, ptrSz, TrackingRawMemManager::g_MetadataByteWidth,
+                   useLambdas, true),
+      m_r_metadata(sem, ctx, ptrSz, TrackingRawMemManager::g_MetadataByteWidth,
+                   useLambdas, true),
+      m_a_metadata(sem, ctx, ptrSz, TrackingRawMemManager::g_MetadataByteWidth,
+                   useLambdas, true) {}
+
+TrackingMemoryTuple::TrackingMemoryTuple(Bv2OpSem &sem, Bv2OpSemContext &ctx,
+                                         unsigned ptrSz, unsigned wordSz,
+                                         bool useLambdas, bool ignoreAlignment)
+    : m_main(sem, ctx, ptrSz, wordSz, useLambdas, ignoreAlignment),
+      m_w_metadata(sem, ctx, ptrSz, TrackingRawMemManager::g_MetadataByteWidth,
+                   useLambdas, true),
+      m_r_metadata(sem, ctx, ptrSz, TrackingRawMemManager::g_MetadataByteWidth,
+                   useLambdas, true),
+      m_a_metadata(sem, ctx, ptrSz, TrackingRawMemManager::g_MetadataByteWidth,
+                   useLambdas, true) {}
+
 TrackingRawMemManager::TrackingRawMemManager(Bv2OpSem &sem,
                                              Bv2OpSemContext &ctx,
                                              unsigned ptrSz, unsigned wordSz,
                                              bool useLambdas)
     : MemManagerCore(sem, ctx, ptrSz, wordSz,
                      false /* this is a nop since we delegate to RawMemMgr */),
-      m_main(sem, ctx, ptrSz, wordSz, useLambdas),
-      m_w_metadata(sem, ctx, ptrSz, TrackingRawMemManager::g_MetadataByteWidth,
-                   useLambdas, true),
-      m_r_metadata(sem, ctx, ptrSz, TrackingRawMemManager::g_MetadataByteWidth,
-                   useLambdas, true),
-      m_a_metadata(sem, ctx, ptrSz, TrackingRawMemManager::g_MetadataByteWidth,
-                   useLambdas, true) {
-  m_metadata_map = {
-      {MetadataKind::READ, &m_r_metadata},
-      {MetadataKind::WRITE, &m_w_metadata},
-      {MetadataKind::ALLOC, &m_a_metadata},
-  };
-}
+      m_submgrs(sem, ctx, ptrSz, wordSz, useLambdas) {}
 
 TrackingRawMemManager::TrackingRawMemManager(Bv2OpSem &sem,
                                              Bv2OpSemContext &ctx,
@@ -35,19 +45,7 @@ TrackingRawMemManager::TrackingRawMemManager(Bv2OpSem &sem,
                                              bool ignoreAlignment)
     : MemManagerCore(sem, ctx, ptrSz, wordSz,
                      false /* this is a nop since we delegate to RawMemMgr */),
-      m_main(sem, ctx, ptrSz, wordSz, useLambdas, ignoreAlignment),
-      m_w_metadata(sem, ctx, ptrSz, TrackingRawMemManager::g_MetadataByteWidth,
-                   useLambdas, true),
-      m_r_metadata(sem, ctx, ptrSz, TrackingRawMemManager::g_MetadataByteWidth,
-                   useLambdas, true),
-      m_a_metadata(sem, ctx, ptrSz, TrackingRawMemManager::g_MetadataByteWidth,
-                   useLambdas, true) {
-  m_metadata_map = {
-      {MetadataKind::READ, &m_r_metadata},
-      {MetadataKind::WRITE, &m_w_metadata},
-      {MetadataKind::ALLOC, &m_a_metadata},
-  };
-}
+      m_submgrs(sem, ctx, ptrSz, wordSz, useLambdas, ignoreAlignment) {}
 
 TrackingRawMemManager::PtrTy
 TrackingRawMemManager::getAddressable(TrackingRawMemManager::PtrTy p) const {
@@ -70,83 +68,79 @@ Expr TrackingRawMemManager::isDereferenceable(TrackingRawMemManager::PtrTy p,
   return m_ctx.alu().getFalse();
 }
 TrackingRawMemManager::MemValTy TrackingRawMemManager::zeroedMemory() const {
-  return MemValTy(m_main.zeroedMemory(),
-                  m_metadata_map.at(MetadataKind::READ)->zeroedMemory(),
-                  m_metadata_map.at(MetadataKind::WRITE)->zeroedMemory(),
-                  m_metadata_map.at(MetadataKind::ALLOC)->zeroedMemory());
+  auto x = hana::transform(hana::keys(m_submgrs), [&](auto key) {
+    return hana::at_key(m_submgrs, key).zeroedMemory();
+  });
+  return MemValTy(x);
 }
 
 std::pair<char *, unsigned int>
 TrackingRawMemManager::getGlobalVariableInitValue(const GlobalVariable &gv) {
-  return m_main.getGlobalVariableInitValue(gv);
+  return MAIN_MEM_MGR.getGlobalVariableInitValue(gv);
 }
-void TrackingRawMemManager::dumpGlobalsMap() { m_main.dumpGlobalsMap(); }
+void TrackingRawMemManager::dumpGlobalsMap() { MAIN_MEM_MGR.dumpGlobalsMap(); }
 void TrackingRawMemManager::onFunctionEntry(const Function &fn) {
-  m_main.onFunctionEntry(fn);
+  MAIN_MEM_MGR.onFunctionEntry(fn);
 }
 TrackingRawMemManager::PtrTy
 TrackingRawMemManager::gep(TrackingRawMemManager::PtrTy ptr,
                            gep_type_iterator it, gep_type_iterator end) const {
-  return m_main.gep(ptr, it, end);
+  return MAIN_MEM_MGR.gep(ptr, it, end);
 }
 Expr TrackingRawMemManager::ptrEq(TrackingRawMemManager::PtrTy p1,
                                   TrackingRawMemManager::PtrTy p2) const {
-  return m_main.ptrEq(p1, p2);
+  return MAIN_MEM_MGR.ptrEq(p1, p2);
 }
 Expr TrackingRawMemManager::ptrtoint(TrackingRawMemManager::PtrTy ptr,
                                      const Type &ptrTy,
                                      const Type &intTy) const {
-  return m_main.ptrtoint(ptr, ptrTy, intTy);
+  return MAIN_MEM_MGR.ptrtoint(ptr, ptrTy, intTy);
 }
 TrackingRawMemManager::PtrTy
 TrackingRawMemManager::inttoptr(Expr intVal, const Type &intTy,
                                 const Type &ptrTy) const {
-  return m_main.inttoptr(intVal, intTy, ptrTy);
+  return MAIN_MEM_MGR.inttoptr(intVal, intTy, ptrTy);
 }
 TrackingRawMemManager::MemValTy TrackingRawMemManager::MemFill(
     TrackingRawMemManager::PtrTy dPtr, char *sPtr, unsigned int len,
     TrackingRawMemManager::MemValTy mem, uint32_t align) {
-  RawMemValTy rawVal = m_main.MemFill(dPtr, sPtr, len, mem.getRaw(), align);
-  return MemValTy(rawVal, mem.getMetadata(MetadataKind::READ),
-                  mem.getMetadata(MetadataKind::WRITE),
-                  mem.getMetadata(MetadataKind::ALLOC));
+  RawMemValTy rawVal =
+      MAIN_MEM_MGR.MemFill(dPtr, sPtr, len, mem.getRaw(), align);
+  auto c = hana::prepend(mem.tail(), rawVal);
+  return MemValTy(c);
 }
 TrackingRawMemManager::MemValTy TrackingRawMemManager::MemCpy(
     TrackingRawMemManager::PtrTy dPtr, TrackingRawMemManager::PtrTy sPtr,
     Expr len, TrackingRawMemManager::MemValTy memTrsfrRead,
     TrackingRawMemManager::MemValTy memRead, uint32_t align) {
-  RawMemValTy rawVal = m_main.MemCpy(dPtr, sPtr, len, memTrsfrRead.getRaw(),
-                                     memRead.getRaw(), align);
-  return MemValTy(rawVal, memRead.getMetadata(MetadataKind::READ),
-                  memRead.getMetadata(MetadataKind::WRITE),
-                  memRead.getMetadata(MetadataKind::ALLOC));
+  RawMemValTy rawVal = MAIN_MEM_MGR.MemCpy(
+      dPtr, sPtr, len, memTrsfrRead.getRaw(), memRead.getRaw(), align);
+  auto c = hana::prepend(memRead.tail(), rawVal);
+  return MemValTy(c);
 }
 TrackingRawMemManager::MemValTy TrackingRawMemManager::MemCpy(
     TrackingRawMemManager::PtrTy dPtr, TrackingRawMemManager::PtrTy sPtr,
     unsigned int len, TrackingRawMemManager::MemValTy memTrsfrRead,
     TrackingRawMemManager::MemValTy memRead, uint32_t align) {
-  RawMemValTy rawVal = m_main.MemCpy(dPtr, sPtr, len, memTrsfrRead.getRaw(),
-                                     memRead.getRaw(), align);
-  return MemValTy(rawVal, memRead.getMetadata(MetadataKind::READ),
-                  memRead.getMetadata(MetadataKind::WRITE),
-                  memRead.getMetadata(MetadataKind::ALLOC));
+  RawMemValTy rawVal = MAIN_MEM_MGR.MemCpy(
+      dPtr, sPtr, len, memTrsfrRead.getRaw(), memRead.getRaw(), align);
+  auto c = hana::prepend(memRead.tail(), rawVal);
+  return MemValTy(c);
 }
 TrackingRawMemManager::MemValTy
 TrackingRawMemManager::MemSet(TrackingRawMemManager::PtrTy ptr, Expr _val,
                               Expr len, TrackingRawMemManager::MemValTy mem,
                               uint32_t align) {
-  RawMemValTy rawVal = m_main.MemSet(ptr, _val, len, mem.getRaw(), align);
-  return MemValTy(rawVal, mem.getMetadata(MetadataKind::READ),
-                  mem.getMetadata(MetadataKind::WRITE),
-                  mem.getMetadata(MetadataKind::ALLOC));
+  RawMemValTy rawVal = MAIN_MEM_MGR.MemSet(ptr, _val, len, mem.getRaw(), align);
+  auto c = hana::prepend(mem.tail(), rawVal);
+  return MemValTy(c);
 }
 TrackingRawMemManager::MemValTy TrackingRawMemManager::MemSet(
     TrackingRawMemManager::PtrTy ptr, Expr _val, unsigned int len,
     TrackingRawMemManager::MemValTy mem, uint32_t align) {
-  RawMemValTy rawVal = m_main.MemSet(ptr, _val, len, mem.getRaw(), align);
-  return MemValTy(rawVal, mem.getMetadata(MetadataKind::READ),
-                  mem.getMetadata(MetadataKind::WRITE),
-                  mem.getMetadata(MetadataKind::ALLOC));
+  RawMemValTy rawVal = MAIN_MEM_MGR.MemSet(ptr, _val, len, mem.getRaw(), align);
+  auto c = hana::prepend(mem.tail(), rawVal);
+  return MemValTy(c);
 }
 
 // TODO: refactor this dispatch function in Mixin class
@@ -228,10 +222,9 @@ TrackingRawMemManager::MemValTy TrackingRawMemManager::storePtrToMem(
     TrackingRawMemManager::PtrTy val, TrackingRawMemManager::PtrTy ptr,
     TrackingRawMemManager::MemValTy mem, unsigned int byteSz, uint64_t align) {
   RawMemValTy rawVal =
-      m_main.storePtrToMem(val, ptr, mem.getRaw(), byteSz, align);
-  return MemValTy(rawVal, mem.getMetadata(MetadataKind::READ),
-                  mem.getMetadata(MetadataKind::WRITE),
-                  mem.getMetadata(MetadataKind::ALLOC));
+      MAIN_MEM_MGR.storePtrToMem(val, ptr, mem.getRaw(), byteSz, align);
+  auto c = hana::prepend(mem.tail(), rawVal);
+  return MemValTy(c);
 }
 TrackingRawMemManager::MemValTy TrackingRawMemManager::storeIntToMem(
     Expr _val, TrackingRawMemManager::PtrTy ptr,
@@ -239,36 +232,51 @@ TrackingRawMemManager::MemValTy TrackingRawMemManager::storeIntToMem(
   // We expect _val to be a primitive rather than a container
   assert(!strct::isStructVal(_val));
   RawMemValTy rawVal =
-      m_main.storeIntToMem(_val, ptr, mem.getRaw(), byteSz, align);
-  return MemValTy(rawVal, mem.getMetadata(MetadataKind::READ),
-                  mem.getMetadata(MetadataKind::WRITE),
-                  mem.getMetadata(MetadataKind::ALLOC));
+      MAIN_MEM_MGR.storeIntToMem(_val, ptr, mem.getRaw(), byteSz, align);
+  auto c = hana::prepend(mem.tail(), rawVal);
+  return MemValTy(c);
 }
 TrackingRawMemManager::PtrTy
 TrackingRawMemManager::loadPtrFromMem(TrackingRawMemManager::PtrTy ptr,
                                       TrackingRawMemManager::MemValTy mem,
                                       unsigned int byteSz, uint64_t align) {
-  PtrTy rawPtr = m_main.loadPtrFromMem(ptr, mem.getRaw(), byteSz, align);
+  PtrTy rawPtr = MAIN_MEM_MGR.loadPtrFromMem(ptr, mem.getRaw(), byteSz, align);
   return rawPtr;
 }
 Expr TrackingRawMemManager::loadIntFromMem(TrackingRawMemManager::PtrTy ptr,
                                            TrackingRawMemManager::MemValTy mem,
                                            unsigned int byteSz,
                                            uint64_t align) {
-  Expr res = m_main.loadIntFromMem(ptr, mem.getRaw(), byteSz, align);
+  Expr res = MAIN_MEM_MGR.loadIntFromMem(ptr, mem.getRaw(), byteSz, align);
   return res;
 }
+// Note that the setMetadata and getMetadata functions, kind is not known at
+// compile time because we can't use compile time constants across virtual
+// functions. Thus, we need to check whether kind equals ith element for each i.
 TrackingRawMemManager::MemValTy
 TrackingRawMemManager::memsetMetaData(MetadataKind kind, PtrTy ptr, Expr len,
                                       MemValTy memIn, unsigned int val) {
   // make sure we can fit the supplied value in metadata memory slot
   assert(llvm::Log2_64(val) + 1 <= g_MetadataBitWidth &&
          "Metadata cannot fit!");
-  return MemValTy(
-      kind, memIn,
-      m_metadata_map[kind]->MemSet(ptr, m_ctx.alu().ui(val, g_MetadataBitWidth),
-                                   len, memIn.getMetadata(kind),
-                                   m_metadata_map[kind]->wordSzInBytes()));
+  auto index = static_cast<size_t>(kind) + 1;
+  auto r =
+      hana::make_range(hana::size_c<0>, TrackingMemoryTuple::GetTupleSize());
+  auto r_t = hana::to_tuple(r);
+  auto c =
+      hana::transform(hana::zip(r_t, hana::keys(m_submgrs)), [&](auto pair) {
+        auto current = hana::at(pair, hana::size_c<0>);
+        auto key = hana::at(pair, hana::size_c<1>);
+        if (current == index) {
+          return hana::at_key(m_submgrs, key)
+              .MemSet(ptr, m_ctx.alu().ui(val, g_MetadataBitWidth), len,
+                      memIn.getElementVal(index),
+                      hana::at_key(m_submgrs, key).wordSzInBytes());
+        } else {
+          return memIn.getElementVal(current);
+        }
+      });
+  return MemValTy(c);
 }
 TrackingRawMemManager::MemValTy
 TrackingRawMemManager::memsetMetaData(MetadataKind kind, PtrTy ptr,
@@ -277,28 +285,53 @@ TrackingRawMemManager::memsetMetaData(MetadataKind kind, PtrTy ptr,
   // make sure we can fit the supplied value in metadata memory slot
   assert(llvm::Log2_64(val) + 1 <= g_MetadataBitWidth &&
          "Metadata cannot fit!");
-  return MemValTy(
-      kind, memIn,
-      m_metadata_map[kind]->MemSet(ptr, m_ctx.alu().ui(val, g_MetadataBitWidth),
-                                   len, memIn.getMetadata(kind),
-                                   m_metadata_map[kind]->wordSzInBytes()));
+  auto index = static_cast<size_t>(kind) + 1;
+  auto r =
+      hana::make_range(hana::int_c<0>, TrackingMemoryTuple::GetTupleSize());
+  auto r_t = hana::to_tuple(r);
+  auto z_t = hana::zip(r_t, hana::keys(m_submgrs));
+  auto c = hana::transform(z_t, [&](auto pair) {
+    auto current = hana::at(pair, hana::size_c<0>);
+    auto key = hana::at(pair, hana::size_c<1>);
+    if (current == index) {
+      return hana::at_key(m_submgrs, key)
+          .MemSet(ptr, m_ctx.alu().ui(val, g_MetadataBitWidth), len,
+                  memIn.getElementVal(index),
+                  hana::at_key(m_submgrs, key).wordSzInBytes());
+    } else {
+      return memIn.getElementVal(current);
+    }
+  });
+  return MemValTy(c);
 }
 Expr TrackingRawMemManager::getMetaData(MetadataKind kind, PtrTy ptr,
                                         MemValTy memIn, unsigned int byteSz) {
   // TODO: expose a method in OpSemMemManager to loadAlignedWordFromMem
-  return m_metadata_map.at(kind)->loadIntFromMem(
-      ptr, memIn.getMetadata(kind), byteSz,
-      m_metadata_map.at(kind)->wordSizeInBytes());
+  auto index = static_cast<size_t>(kind) + 1;
+  auto r =
+      hana::make_range(hana::int_c<0>, TrackingMemoryTuple::GetTupleSize());
+  auto r_t = hana::to_tuple(r);
+  Expr ret;
+  hana::for_each(hana::zip(r_t, hana::keys(m_submgrs)), [&](auto pair) {
+    auto current = hana::at(pair, hana::size_c<0>);
+    auto key = hana::at(pair, hana::size_c<1>);
+    if (current == index) {
+      ret = hana::at_key(m_submgrs, key)
+                .loadIntFromMem(ptr, memIn.getElementVal(current), byteSz,
+                                hana::at_key(m_submgrs, key).wordSzInBytes());
+    }
+  });
+  return ret;
 }
 TrackingRawMemManager::PtrTy
 TrackingRawMemManager::ptrAdd(TrackingRawMemManager::PtrTy ptr,
                               Expr offset) const {
-  return m_main.ptrAdd(ptr, offset);
+  return MAIN_MEM_MGR.ptrAdd(ptr, offset);
 }
 TrackingRawMemManager::PtrTy
 TrackingRawMemManager::ptrAdd(TrackingRawMemManager::PtrTy ptr,
                               int32_t _offset) const {
-  return m_main.ptrAdd(ptr, _offset);
+  return MAIN_MEM_MGR.ptrAdd(ptr, _offset);
 }
 Expr TrackingRawMemManager::coerce(Expr sort, Expr val) {
   if (strct::isStructVal(val)) {
@@ -306,90 +339,95 @@ Expr TrackingRawMemManager::coerce(Expr sort, Expr val) {
     assert(isOp<STRUCT_TY>(sort));
     assert(sort->arity() == val->arity());
     assert(sort->arity() == g_num_slots);
-    kids.push_back(m_main.coerce(sort->arg(0), val->arg(0)));
+    kids.push_back(MAIN_MEM_MGR.coerce(sort->arg(0), val->arg(0)));
     // when havocing a value; don't havoc(ignore) value for metadata memory,
     // instead intialize memory to a constant value.
-    kids.push_back(m_metadata_map.at(MetadataKind::READ)->zeroedMemory());
-    kids.push_back(m_metadata_map.at(MetadataKind::WRITE)->zeroedMemory());
-    kids.push_back(m_metadata_map.at(MetadataKind::ALLOC)->zeroedMemory());
+    hana::for_each(hana::keys(m_submgrs), [&](auto key) {
+      kids.push_back(hana::at_key(m_submgrs, key).zeroedMemory());
+    });
     return strct::mk(kids);
   }
-  return m_main.coerce(sort, val);
+  return MAIN_MEM_MGR.coerce(sort, val);
 }
 TrackingRawMemManager::PtrTy TrackingRawMemManager::nullPtr() const {
-  return m_main.nullPtr();
+  return MAIN_MEM_MGR.nullPtr();
 }
 TrackingRawMemManager::PtrTy TrackingRawMemManager::freshPtr() {
-  return m_main.freshPtr();
+  return MAIN_MEM_MGR.freshPtr();
 }
 TrackingRawMemManager::MemSortTy
 TrackingRawMemManager::mkMemRegisterSort(const Instruction &inst) const {
-  return MemSortTy(
-      m_main.mkMemRegisterSort(inst),
-      m_metadata_map.at(MetadataKind::READ)->mkMemRegisterSort(inst),
-      m_metadata_map.at(MetadataKind::WRITE)->mkMemRegisterSort(inst),
-      m_metadata_map.at(MetadataKind::ALLOC)->mkMemRegisterSort(inst));
+  auto c = hana::transform(hana::keys(m_submgrs), [&](auto key) {
+    return hana::at_key(m_submgrs, key).mkMemRegisterSort(inst);
+  });
+  return MemSortTy(c);
 }
 TrackingRawMemManager::PtrSortTy
 TrackingRawMemManager::mkPtrRegisterSort(const GlobalVariable &gv) const {
-  return m_main.mkPtrRegisterSort(gv);
+  return MAIN_MEM_MGR.mkPtrRegisterSort(gv);
 }
 TrackingRawMemManager::PtrSortTy
 TrackingRawMemManager::mkPtrRegisterSort(const Function &fn) const {
-  return m_main.mkPtrRegisterSort(fn);
+  return MAIN_MEM_MGR.mkPtrRegisterSort(fn);
 }
 TrackingRawMemManager::PtrSortTy
 TrackingRawMemManager::mkPtrRegisterSort(const Instruction &inst) const {
-  return m_main.mkPtrRegisterSort(inst);
+  return MAIN_MEM_MGR.mkPtrRegisterSort(inst);
 }
 TrackingRawMemManager::PtrTy
 TrackingRawMemManager::mkAlignedPtr(Expr name, uint32_t align) const {
-  return m_main.mkAlignedPtr(name, align);
+  return MAIN_MEM_MGR.mkAlignedPtr(name, align);
 }
 void TrackingRawMemManager::initGlobalVariable(const GlobalVariable &gv) const {
-  return m_main.initGlobalVariable(gv);
+  return MAIN_MEM_MGR.initGlobalVariable(gv);
 }
 TrackingRawMemManager::PtrTy
 TrackingRawMemManager::getPtrToGlobalVariable(const GlobalVariable &gv) {
-  return m_main.getPtrToGlobalVariable(gv);
+  return MAIN_MEM_MGR.getPtrToGlobalVariable(gv);
 }
 TrackingRawMemManager::PtrTy TrackingRawMemManager::falloc(const Function &fn) {
-  return m_main.falloc(fn);
+  return MAIN_MEM_MGR.falloc(fn);
 }
 TrackingRawMemManager::PtrTy
 TrackingRawMemManager::galloc(const GlobalVariable &gv, uint32_t align) {
-  return m_main.galloc(gv, align);
+  return MAIN_MEM_MGR.galloc(gv, align);
 }
 TrackingRawMemManager::PtrTy TrackingRawMemManager::halloc(Expr bytes,
                                                            uint32_t align) {
-  return m_main.halloc(bytes, align);
+  return MAIN_MEM_MGR.halloc(bytes, align);
 }
 TrackingRawMemManager::PtrTy TrackingRawMemManager::halloc(unsigned int _bytes,
                                                            uint32_t align) {
-  return m_main.halloc(_bytes, align);
+  return MAIN_MEM_MGR.halloc(_bytes, align);
 }
 TrackingRawMemManager::PtrTy TrackingRawMemManager::salloc(unsigned int bytes,
                                                            uint32_t align) {
-  return m_main.salloc(bytes, align);
+  return MAIN_MEM_MGR.salloc(bytes, align);
 }
 TrackingRawMemManager::PtrTy
 TrackingRawMemManager::getPtrToFunction(const Function &F) {
-  return m_main.getPtrToFunction(F);
+  return MAIN_MEM_MGR.getPtrToFunction(F);
 }
 TrackingRawMemManager::PtrTy
 TrackingRawMemManager::salloc(Expr elmts, unsigned int typeSz, uint32_t align) {
-  return m_main.salloc(elmts, typeSz, align);
+  return MAIN_MEM_MGR.salloc(elmts, typeSz, align);
 }
 TrackingRawMemManager::PtrTy
 TrackingRawMemManager::mkStackPtr(unsigned int offset) {
-  return m_main.mkStackPtr(offset);
+  return MAIN_MEM_MGR.mkStackPtr(offset);
 }
 unsigned int TrackingRawMemManager::getMetaDataMemWordSzInBits() {
-  assert(m_metadata_map.at(MetadataKind::READ)->wordSzInBits() ==
-         m_metadata_map.at(MetadataKind::WRITE)->wordSzInBits());
-  assert(m_metadata_map.at(MetadataKind::READ)->wordSzInBits() ==
-         m_metadata_map.at(MetadataKind::ALLOC)->wordSzInBits());
-  return m_metadata_map.at(MetadataKind::READ)->wordSzInBits();
+  // slice of metadata keys 2nd metadata key onwards
+  auto sec_metadata_keys = hana::slice(
+      hana::keys(m_submgrs),
+      hana::make_range(hana::size_c<2>, TrackingMemoryTuple::GetTupleSize()));
+  auto first_metadata_key = hana::keys(m_submgrs)[hana::size_c<1>];
+  auto wordSz = hana::at_key(m_submgrs, first_metadata_key).wordSzInBits();
+  // assert that all metadata has same word size
+  BOOST_HANA_RUNTIME_ASSERT(hana::all_of(sec_metadata_keys, [&](auto key) {
+    return hana::at_key(m_submgrs, key).wordSzInBits() == wordSz;
+  }));
+  return wordSz;
 }
 Expr TrackingRawMemManager::isMetadataSet(MetadataKind kind, PtrTy p,
                                           MemValTy mem) {
@@ -404,31 +442,31 @@ TrackingRawMemManager::MemValTy TrackingRawMemManager::setMetadata(
 }
 Expr TrackingRawMemManager::ptrUlt(TrackingRawMemManager::PtrTy p1,
                                    TrackingRawMemManager::PtrTy p2) const {
-  return m_main.ptrUlt(getAddressable(p1), getAddressable(p2));
+  return MAIN_MEM_MGR.ptrUlt(getAddressable(p1), getAddressable(p2));
 }
 Expr TrackingRawMemManager::ptrSlt(TrackingRawMemManager::PtrTy p1,
                                    TrackingRawMemManager::PtrTy p2) const {
-  return m_main.ptrSlt(getAddressable(p1), getAddressable(p2));
+  return MAIN_MEM_MGR.ptrSlt(getAddressable(p1), getAddressable(p2));
 }
 Expr TrackingRawMemManager::ptrUle(TrackingRawMemManager::PtrTy p1,
                                    TrackingRawMemManager::PtrTy p2) const {
-  return m_main.ptrUle(getAddressable(p1), getAddressable(p2));
+  return MAIN_MEM_MGR.ptrUle(getAddressable(p1), getAddressable(p2));
 }
 Expr TrackingRawMemManager::ptrSle(TrackingRawMemManager::PtrTy p1,
                                    TrackingRawMemManager::PtrTy p2) const {
-  return m_main.ptrSle(getAddressable(p1), getAddressable(p2));
+  return MAIN_MEM_MGR.ptrSle(getAddressable(p1), getAddressable(p2));
 }
 Expr TrackingRawMemManager::ptrUgt(TrackingRawMemManager::PtrTy p1,
                                    TrackingRawMemManager::PtrTy p2) const {
-  return m_main.ptrUgt(getAddressable(p1), getAddressable(p2));
+  return MAIN_MEM_MGR.ptrUgt(getAddressable(p1), getAddressable(p2));
 }
 Expr TrackingRawMemManager::ptrSgt(TrackingRawMemManager::PtrTy p1,
                                    TrackingRawMemManager::PtrTy p2) const {
-  return m_main.ptrSgt(getAddressable(p1), getAddressable(p2));
+  return MAIN_MEM_MGR.ptrSgt(getAddressable(p1), getAddressable(p2));
 }
 Expr TrackingRawMemManager::ptrUge(TrackingRawMemManager::PtrTy p1,
                                    TrackingRawMemManager::PtrTy p2) const {
-  return m_main.ptrUge(getAddressable(p1), getAddressable(p2));
+  return MAIN_MEM_MGR.ptrUge(getAddressable(p1), getAddressable(p2));
 }
 Expr TrackingRawMemManager::ptrSge(TrackingRawMemManager::PtrTy p1,
                                    TrackingRawMemManager::PtrTy p2) const {
@@ -436,11 +474,11 @@ Expr TrackingRawMemManager::ptrSge(TrackingRawMemManager::PtrTy p1,
 }
 Expr TrackingRawMemManager::ptrNe(TrackingRawMemManager::PtrTy p1,
                                   TrackingRawMemManager::PtrTy p2) const {
-  return m_main.ptrNe(getAddressable(p1), getAddressable(p2));
+  return MAIN_MEM_MGR.ptrNe(getAddressable(p1), getAddressable(p2));
 }
 Expr TrackingRawMemManager::ptrSub(TrackingRawMemManager::PtrTy p1,
                                    TrackingRawMemManager::PtrTy p2) const {
-  return m_main.ptrSub(getAddressable(p1), getAddressable(p2));
+  return MAIN_MEM_MGR.ptrSub(getAddressable(p1), getAddressable(p2));
 }
 } // namespace details
 } // namespace seahorn

--- a/lib/seahorn/BvOpSem2TrackingRawMemMgr.hh
+++ b/lib/seahorn/BvOpSem2TrackingRawMemMgr.hh
@@ -12,25 +12,48 @@
 #include <array>
 #include <cstdint>
 
+#include <boost/hana/ext/std/integral_constant.hpp>
+
+#define MAIN_MEM_MGR hana::at_key(m_submgrs, BOOST_HANA_STRING("m_main"))
+
 namespace seahorn {
 namespace details {
+
+/// \brief Container for sub memory managers to be passed to TrackingRawMemMgr
+//
+// Adding a new element (shadow slot) involves adding a new memory manager
+// inside this and in MetadataKind Use of MetadataKind is still needed because
+// setMetadata and getMetadata methods are virtual and thus calls to specific
+// metadata sub managers cannot be resolved at compile-time.
+struct TrackingMemoryTuple {
+  BOOST_HANA_DEFINE_STRUCT(TrackingMemoryTuple, (RawMemManager, m_main),
+                           (RawMemManager, m_r_metadata),
+                           (RawMemManager, m_w_metadata),
+                           (RawMemManager, m_a_metadata));
+
+  /// \brief A helper function to get number of memory elements in tuple
+  static constexpr auto GetTupleSize() {
+    constexpr auto accessors = hana::accessors<TrackingMemoryTuple>();
+    return hana::size(accessors);
+  }
+
+  TrackingMemoryTuple(Bv2OpSem &sem, Bv2OpSemContext &ctx, unsigned ptrSz,
+                      unsigned wordSz, bool useLambdas);
+
+  TrackingMemoryTuple(Bv2OpSem &sem, Bv2OpSemContext &ctx, unsigned ptrSz,
+                      unsigned wordSz, bool useLambdas, bool ignoreAlignment);
+
+  ~TrackingMemoryTuple() = default;
+};
 
 // This memory manager adds a metadata memory(backed by raw memory) sitting side
 // by side to conventional memory(backed by raw memory). The word size for
 // conventional memory can be greater than metadata memory.
 //
 // Currently this implementation has a metadata memory word size of 1 byte.
-// For every byte written to conventional memory, we set the corresponding
-// metadata memory address to value 1.
 class TrackingRawMemManager : public MemManagerCore {
 private:
-  RawMemManager m_main;
-  RawMemManager m_w_metadata;
-  RawMemManager m_r_metadata;
-  RawMemManager m_a_metadata;
-
-  // All accesses to metadata memory managers should be through this map
-  std::map<MetadataKind, RawMemManager *> m_metadata_map;
+  TrackingMemoryTuple m_submgrs;
 
 public:
   // This memory manager supports tracking
@@ -49,47 +72,39 @@ public:
   using RawMemSortTy = OpSemMemManager::MemSortTy;
 
   struct MemValTyImpl {
-    // The order of metadata in a struct expr is expected to be the same as
-    // the order in the enum MetadataKind
     Expr m_v;
 
-    MemValTyImpl(RawMemValTy &&raw_val, RawMemValTy &&r_metadata_val,
-                 RawMemValTy &&w_metadata_val, RawMemValTy &&a_metadata_val) {
-      assert(!strct::isStructVal(raw_val));
-      assert(!strct::isStructVal(r_metadata_val));
-      assert(!strct::isStructVal(w_metadata_val));
-      assert(!strct::isStructVal(a_metadata_val));
-      std::array<RawMemValTy, 4> kids = {
-          std::move(raw_val), std::move(r_metadata_val),
-          std::move(w_metadata_val), std::move(a_metadata_val)};
-      m_v = strct::mk(kids);
+    // Dummy function to typecheck the args passed to MemValTyImpl ctor
+    template <typename R, typename...> struct fst { typedef R type; };
+
+    /// \Brief Construct only with a tuple of RawMemValTy elements
+    //
+    // The second template param can be interpreted as follows
+    // 1. If each element of the passed tuple is_same as RawMemValTy, then
+    // 2. set enable_if to true and consequently the second template parameter
+    // in
+    //    fst to void..., finally
+    // 3. fst::type is the second template param
+    template <typename... Args,
+              typename = typename fst<
+                  void, typename std::enable_if<std::is_same<
+                            Args, RawMemValTy>::value>::type...>::type>
+    explicit MemValTyImpl(hana::tuple<Args &&...> args) {
+      auto a = hana::unpack(args, [](auto... i) {
+        return std::array<RawMemValTy, sizeof...(i)>{{std::move(i)...}};
+      });
+      m_v = strct::mk(a);
     }
 
-    MemValTyImpl(const RawMemValTy &raw_val, const RawMemValTy &r_metadata_val,
-                 const RawMemValTy &w_metadata_val,
-                 const RawMemValTy &a_metadata_val) {
-      assert(!strct::isStructVal(raw_val));
-      assert(!strct::isStructVal(r_metadata_val));
-      assert(!strct::isStructVal(w_metadata_val));
-      assert(!strct::isStructVal(a_metadata_val));
-      std::array<RawMemValTy, 4> kids = {raw_val, r_metadata_val,
-                                         w_metadata_val, a_metadata_val};
-      m_v = strct::mk(kids);
-    }
-
-    // Create a new MemValTyImpl object by copying from an existing object
-    // except the metadata field given by 'kind'. Use raw_val for this field.
-    MemValTyImpl(MetadataKind kind, const MemValTyImpl &orig_val,
-                 const RawMemValTy &raw_val) {
-      llvm::SmallVector<RawMemValTy, 4> kids;
-      // Copy all fields from the original object one by one.
-      for (unsigned i = 0, sz = orig_val.toExpr()->arity(); i < sz; ++i) {
-        // kind + 1 indexes the intended kind in a compound expression.
-        kids.push_back(i == (static_cast<std::size_t>(kind) + 1)
-                           ? raw_val
-                           : orig_val.toExpr()->arg(i));
-      }
-      m_v = strct::mk(kids);
+    template <typename... Args,
+              typename = typename fst<
+                  void, typename std::enable_if<std::is_same<
+                            Args, RawMemValTy>::value>::type...>::type>
+    explicit MemValTyImpl(hana::tuple<Args...> args) {
+      auto a = hana::unpack(args, [](auto... i) {
+        return std::array<RawMemValTy, sizeof...(i)>{{i...}};
+      });
+      m_v = strct::mk(a);
     }
 
     explicit MemValTyImpl(const Expr &e) {
@@ -108,34 +123,50 @@ public:
 
     RawMemValTy getRaw() { return strct::extractVal(m_v, 0); }
 
-    Expr getMetadata(MetadataKind kind) {
-      return strct::extractVal(m_v, static_cast<std::size_t>(kind) + 1);
+    Expr getElementVal(size_t index) { return strct::extractVal(m_v, index); }
+
+    auto tail() {
+      auto indices =
+          hana::make_range(hana::int_c<1>, TrackingMemoryTuple::GetTupleSize());
+      auto indices_t = hana::to_tuple(indices);
+      auto exprs = hana::transform(
+          indices_t, [this](size_t i) { return this->getElementVal(i); });
+      return exprs;
     }
   };
 
   struct MemSortTyImpl {
-    Expr m_mem_sort;
+    Expr m_sort_v;
 
-    MemSortTyImpl(RawMemSortTy &&mem_sort, RawMemSortTy &&r_metadata_sort,
-                  RawMemSortTy &&w_metadata_sort,
-                  RawMemSortTy &&a_metadata_sort) {
-      std::array<RawMemSortTy, 4> kids = {
-          std::move(mem_sort), std::move(r_metadata_sort),
-          std::move(w_metadata_sort), std::move(a_metadata_sort)};
+    // Dummy function to typecheck the args passed to MemSortTyImpl ctor
+    template <typename R, typename...> struct fst { typedef R type; };
 
-      m_mem_sort = sort::structTy(kids);
+    /// \Brief Construct only with a tuple of RawMemValTy elements
+    //
+    // See MemValTyImpl ctor for details.
+    template <typename... Args,
+              typename = typename fst<
+                  void, typename std::enable_if<std::is_same<
+                            Args, RawMemSortTy>::value>::type...>::type>
+    explicit MemSortTyImpl(hana::tuple<Args &&...> args) {
+      auto a = hana::unpack(args, [](auto... i) {
+        return std::array<RawMemSortTy, sizeof...(i)>{{std::move(i)...}};
+      });
+      m_sort_v = sort::structTy(a);
     }
 
-    MemSortTyImpl(const RawMemSortTy &mem_sort,
-                  const RawMemSortTy &r_metadata_sort,
-                  const RawMemSortTy &w_metadata_sort,
-                  const RawMemSortTy &a_metadata_sort) {
-      std::array<RawMemSortTy, 4> kids = {mem_sort, r_metadata_sort,
-                                          w_metadata_sort, a_metadata_sort};
-
-      m_mem_sort = sort::structTy(kids);
+    template <typename... Args,
+              typename = typename fst<
+                  void, typename std::enable_if<std::is_same<
+                            Args, RawMemSortTy>::value>::type...>::type>
+    explicit MemSortTyImpl(hana::tuple<Args...> args) {
+      auto a = hana::unpack(args, [](auto... i) {
+        return std::array<RawMemSortTy, sizeof...(i)>{{i...}};
+      });
+      m_sort_v = sort::structTy(a);
     }
-    Expr v() const { return m_mem_sort; }
+
+    Expr v() const { return m_sort_v; }
     Expr toExpr() const { return v(); }
     explicit operator Expr() const { return toExpr(); }
   };
@@ -151,11 +182,11 @@ public:
 
   ~TrackingRawMemManager() = default;
 
-  OpSemAllocator &getMAllocator() const { return m_main.getMAllocator(); }
+  OpSemAllocator &getMAllocator() const { return MAIN_MEM_MGR.getMAllocator(); }
 
-  const OpSemMemManager &getMainMemMgr() const { return m_main; }
+  const OpSemMemManager &getMainMemMgr() const { return MAIN_MEM_MGR; }
 
-  PtrSortTy ptrSort() const { return m_main.ptrSort(); }
+  PtrSortTy ptrSort() const { return MAIN_MEM_MGR.ptrSort(); }
 
   PtrTy salloc(unsigned int bytes, uint32_t align);
 
@@ -163,7 +194,7 @@ public:
 
   PtrTy mkStackPtr(unsigned int offset);
 
-  PtrTy brk0Ptr() { return m_main.brk0Ptr(); }
+  PtrTy brk0Ptr() { return MAIN_MEM_MGR.brk0Ptr(); }
 
   PtrTy halloc(unsigned int _bytes, uint32_t align);
 
@@ -276,7 +307,7 @@ public:
 
   PtrTy gep(PtrTy ptr, gep_type_iterator it, gep_type_iterator end) const;
   void onFunctionEntry(const Function &fn);
-  void onModuleEntry(const Module &M) { m_main.onModuleEntry(M); }
+  void onModuleEntry(const Module &M) { MAIN_MEM_MGR.onModuleEntry(M); }
 
   void dumpGlobalsMap();
 


### PR DESCRIPTION
details:
Replace hardcoded sub mem managers in TrackingMemMgr by a
configurable struct of Sub MemoryManagers.
This allows adding new shadow slots without necessarily
touching TrackingMemoryMgr.
Inside TrackingMemoryMgr, calls to sub memory managers are
unrolled at compile time except calls to set/get metadata
methods since they take in a metadata kind which is only
known at runtime. This can be optimized away in a separate effort.

more details:
Most of memory manager code involves taking a memory tuple(MemValTy),
operating on some or all elements and giving a memory tuple back.
Since most methods operate in this pure way, they are good candidates to
use a functional style of programming.
This change makes extensive use of boost::hana to work with memory tuples.
Hana has zero-cost abstraction since the loops are unrolled at
compile time so all iteration should be preprocessed to a bunch of
hand crafted statements.