### PR TITLE
Crab in seapp

### DIFF
--- a/include/seahorn/Passes.hh
+++ b/include/seahorn/Passes.hh
@@ -110,6 +110,7 @@ llvm::Pass *createGeneratePartialFnPass();
 llvm::Pass *createCHAPass();
 llvm::ModulePass *createDebugVerifierPass(int instanceID, llvm::StringRef name);
 llvm::Pass *createUnifyAssumesPass();
+llvm::Pass *createCrabLowerIsDerefPass();
 } // namespace seahorn
 
 #ifdef HAVE_LLVM_SEAHORN

--- a/include/seahorn/Transforms/Instrumentation/CrabAnalysis.hh
+++ b/include/seahorn/Transforms/Instrumentation/CrabAnalysis.hh
@@ -36,7 +36,8 @@ public:
   void runCrabAnalysisOnModule(const llvm::Module &M,
                                seadsa::GlobalAnalysis &dsa,
                                llvm::TargetLibraryInfoWrapperPass &tliPass);
-  clam::InterGlobalClam &getCrab() { return *m_crab; }
+  const clam::InterGlobalClam &getCrab() const;
+  clam::InterGlobalClam &getCrab();
 };
 } // namespace seahorn
 

--- a/include/seahorn/Transforms/Instrumentation/CrabAnalysis.hh
+++ b/include/seahorn/Transforms/Instrumentation/CrabAnalysis.hh
@@ -1,0 +1,43 @@
+#ifndef _CRAB_ANALYSIS_HH_
+#define _CRAB_ANALYSIS_HH_
+
+#include "llvm/IR/Module.h"
+
+namespace llvm {
+class TargetLibraryInfoWrapperPass;
+} // namespace llvm
+
+namespace seadsa {
+class ShadowMem;
+} // namespace seadsa
+
+namespace clam {
+class CrabBuilderManager;
+class InterGlobalClam;
+} // namespace clam
+
+namespace seahorn {
+using namespace llvm;
+
+class CrabAnalysis {
+  //// \brief crab's cfg builder manager
+  std::unique_ptr<clam::CrabBuilderManager> m_cfg_builder_man;
+  //// \brief crab instance to solve alloc bounds
+  std::shared_ptr<clam::InterGlobalClam> m_crab;
+
+  /// \brief Creates a crab's cfg builder manager
+  void initCrabAnalysis(const llvm::Module &M, seadsa::ShadowMem &dsaPass,
+                        llvm::TargetLibraryInfoWrapperPass &tliPass);
+  /// \brief Run crab analysis
+  void runCrabAnalysis();
+
+public:
+  CrabAnalysis() {}
+  void runCrabAnalysisOnModule(const llvm::Module &M,
+                               seadsa::ShadowMem &dsaPass,
+                               llvm::TargetLibraryInfoWrapperPass &tliPass);
+  std::shared_ptr<clam::InterGlobalClam> getCrab() { return m_crab; }
+};
+} // namespace seahorn
+
+#endif /* _CRAB_ANALYSIS_HH_ */

--- a/include/seahorn/Transforms/Instrumentation/CrabAnalysis.hh
+++ b/include/seahorn/Transforms/Instrumentation/CrabAnalysis.hh
@@ -22,8 +22,8 @@ using namespace llvm;
 class CrabAnalysis {
   //// \brief crab's cfg builder manager
   std::unique_ptr<clam::CrabBuilderManager> m_cfg_builder_man;
-  //// \brief crab instance to solve alloc bounds
-  std::shared_ptr<clam::InterGlobalClam> m_crab;
+  //// \brief crab instance
+  std::unique_ptr<clam::InterGlobalClam> m_crab;
 
   /// \brief Creates a crab's cfg builder manager
   void initCrabAnalysis(const llvm::Module &M, seadsa::GlobalAnalysis &dsa,
@@ -36,7 +36,7 @@ public:
   void runCrabAnalysisOnModule(const llvm::Module &M,
                                seadsa::GlobalAnalysis &dsa,
                                llvm::TargetLibraryInfoWrapperPass &tliPass);
-  std::shared_ptr<clam::InterGlobalClam> getCrab() { return m_crab; }
+  clam::InterGlobalClam &getCrab() { return *m_crab; }
 };
 } // namespace seahorn
 

--- a/include/seahorn/Transforms/Instrumentation/CrabAnalysis.hh
+++ b/include/seahorn/Transforms/Instrumentation/CrabAnalysis.hh
@@ -8,7 +8,7 @@ class TargetLibraryInfoWrapperPass;
 } // namespace llvm
 
 namespace seadsa {
-class ShadowMem;
+class GlobalAnalysis;
 } // namespace seadsa
 
 namespace clam {
@@ -26,7 +26,7 @@ class CrabAnalysis {
   std::shared_ptr<clam::InterGlobalClam> m_crab;
 
   /// \brief Creates a crab's cfg builder manager
-  void initCrabAnalysis(const llvm::Module &M, seadsa::ShadowMem &dsaPass,
+  void initCrabAnalysis(const llvm::Module &M, seadsa::GlobalAnalysis &dsa,
                         llvm::TargetLibraryInfoWrapperPass &tliPass);
   /// \brief Run crab analysis
   void runCrabAnalysis();
@@ -34,7 +34,7 @@ class CrabAnalysis {
 public:
   CrabAnalysis() {}
   void runCrabAnalysisOnModule(const llvm::Module &M,
-                               seadsa::ShadowMem &dsaPass,
+                               seadsa::GlobalAnalysis &dsa,
                                llvm::TargetLibraryInfoWrapperPass &tliPass);
   std::shared_ptr<clam::InterGlobalClam> getCrab() { return m_crab; }
 };

--- a/lib/Transforms/Instrumentation/CMakeLists.txt
+++ b/lib/Transforms/Instrumentation/CMakeLists.txt
@@ -13,4 +13,9 @@ add_llvm_library(SeaInstrumentation DISABLE_LLVM_LINK_LLVM_DYLIB
   FatBufferBoundsCheck.cc
   BranchSentinelPass.cc
   GeneratePartialFnPass.cc
+  CrabAnalysis.cc
   )
+
+if (HAVE_CLAM)
+  target_link_libraries (SeaInstrumentation PRIVATE ${CLAM_LIBS})
+endif()

--- a/lib/Transforms/Instrumentation/CrabAnalysis.cc
+++ b/lib/Transforms/Instrumentation/CrabAnalysis.cc
@@ -11,8 +11,6 @@
 #include "crab/domains/abstract_domain_params.hpp"
 #include "crab/support/stats.hpp"
 
-#include "seadsa/ShadowMem.hh"
-
 #include "seahorn/Support/SeaDebug.h"
 #include "seahorn/Support/Stats.hh"
 
@@ -50,10 +48,9 @@ namespace seahorn {
 using namespace llvm;
 
 void CrabAnalysis::initCrabAnalysis(
-    const llvm::Module &M, seadsa::ShadowMem &dsaPass,
+    const llvm::Module &M, seadsa::GlobalAnalysis &dsa,
     llvm::TargetLibraryInfoWrapperPass &tliPass) {
 
-  auto &dsa = dsaPass.getDsaAnalysis();
   std::unique_ptr<clam::HeapAbstraction> heap_abs =
       std::make_unique<clam::SeaDsaHeapAbstraction>(M, dsa);
 
@@ -91,12 +88,12 @@ void CrabAnalysis::runCrabAnalysis() {
 }
 
 void CrabAnalysis::runCrabAnalysisOnModule(
-    const llvm::Module &M, seadsa::ShadowMem &dsaPass,
+    const llvm::Module &M, seadsa::GlobalAnalysis &dsa,
     llvm::TargetLibraryInfoWrapperPass &tliPass) {
   LOG("crab-analysis", errs() << "Start Running Crab Analysis\n";);
 
   // Step 1. Set up crab analysis
-  initCrabAnalysis(M, dsaPass, tliPass);
+  initCrabAnalysis(M, dsa, tliPass);
   // Step 2. Run crab analysis
   runCrabAnalysis();
   LOG("crab-analysis", errs() << "Crab Analysis Complete\n";);

--- a/lib/Transforms/Instrumentation/CrabAnalysis.cc
+++ b/lib/Transforms/Instrumentation/CrabAnalysis.cc
@@ -17,7 +17,7 @@
 #include "seahorn/Support/Stats.hh"
 
 namespace {
-  clam::CrabDomain::Type CrabDom;
+clam::CrabDomain::Type CrabDom;
 }
 
 // Crab reason natively about sea.is_dereferenceable without any
@@ -28,8 +28,7 @@ static llvm::cl::opt<bool> UseCrabCheckIsDeref(
     llvm::cl::init(false));
 
 static llvm::cl::opt<clam::CrabDomain::Type, true, clam::CrabDomainParser>
-    XCrabDom("set-crab-dom",
-             llvm::cl::desc("set Crab abstract domain"),
+    XCrabDom("set-crab-dom", llvm::cl::desc("set Crab abstract domain"),
              llvm::cl::values(
                  clEnumValN(clam::CrabDomain::INTERVALS, "int",
                             "Classical interval domain (default)"),
@@ -77,7 +76,7 @@ void CrabAnalysis::runCrabAnalysis() {
   aparams.run_inter = true;
   aparams.check = clam::CheckerKind::NOCHECKS;
   aparams.widening_delay = 2; // set to delay widening
-  aparams.dom = CrabDom; // set Crab abstract domain
+  aparams.dom = CrabDom;      // set Crab abstract domain
 
   if (UseCrabCheckIsDeref) {
     crab::domains::crab_domain_params_man::get().set_param(

--- a/lib/Transforms/Instrumentation/CrabAnalysis.cc
+++ b/lib/Transforms/Instrumentation/CrabAnalysis.cc
@@ -12,6 +12,7 @@
 #include "crab/support/stats.hpp"
 
 #include "seahorn/Support/SeaDebug.h"
+#include "seahorn/Support/SeaLog.hh"
 #include "seahorn/Support/Stats.hh"
 
 namespace {
@@ -97,6 +98,20 @@ void CrabAnalysis::runCrabAnalysisOnModule(
   // Step 2. Run crab analysis
   runCrabAnalysis();
   LOG("crab-analysis", errs() << "Crab Analysis Complete\n";);
+}
+
+const clam::InterGlobalClam &CrabAnalysis::getCrab() const {
+  if (!m_crab) {
+    ERR << "Error: failed to run crab analysis.";
+  }
+  return *m_crab;
+}
+
+clam::InterGlobalClam &CrabAnalysis::getCrab() {
+  if (!m_crab) {
+    ERR << "Error: failed to run crab analysis.";
+  }
+  return *m_crab;
 }
 
 } // namespace seahorn

--- a/lib/Transforms/Instrumentation/CrabAnalysis.cc
+++ b/lib/Transforms/Instrumentation/CrabAnalysis.cc
@@ -26,7 +26,7 @@ static llvm::cl::opt<bool> UseCrabCheckIsDeref(
     llvm::cl::init(false));
 
 static llvm::cl::opt<clam::CrabDomain::Type, true, clam::CrabDomainParser>
-    XCrabDom("set-crab-dom", llvm::cl::desc("set Crab abstract domain"),
+    XCrabDom("sea-crab-dom", llvm::cl::desc("set Crab abstract domain"),
              llvm::cl::values(
                  clEnumValN(clam::CrabDomain::INTERVALS, "int",
                             "Classical interval domain (default)"),
@@ -64,7 +64,7 @@ void CrabAnalysis::initCrabAnalysis(
   m_cfg_builder_man = std::make_unique<clam::CrabBuilderManager>(
       cfg_builder_params, tliPass, std::move(heap_abs));
   // -- Initialize crab for solving ranges
-  m_crab = std::make_shared<clam::InterGlobalClam>(M, *m_cfg_builder_man);
+  m_crab = std::make_unique<clam::InterGlobalClam>(M, *m_cfg_builder_man);
 }
 
 void CrabAnalysis::runCrabAnalysis() {

--- a/lib/Transforms/Instrumentation/CrabAnalysis.cc
+++ b/lib/Transforms/Instrumentation/CrabAnalysis.cc
@@ -1,0 +1,82 @@
+#include "seahorn/Transforms/Instrumentation/CrabAnalysis.hh"
+
+#include "llvm/Analysis/TargetLibraryInfo.h"
+#include "llvm/Support/CommandLine.h"
+
+#include "clam/CfgBuilder.hh"
+#include "clam/Clam.hh"
+#include "clam/ClamQueryAPI.hh"
+#include "clam/CrabDomainParser.hh"
+#include "clam/SeaDsaHeapAbstraction.hh"
+#include "crab/domains/abstract_domain_params.hpp"
+#include "crab/support/stats.hpp"
+
+#include "seadsa/ShadowMem.hh"
+
+#include "seahorn/Support/SeaDebug.h"
+#include "seahorn/Support/Stats.hh"
+
+// Crab reason natively about sea.is_dereferenceable without any
+// lowering.
+static llvm::cl::opt<bool> UseCrabCheckIsDeref(
+    "crab-check-is-deref",
+    llvm::cl::desc("Use crab to check sea.is_dereferenceable"),
+    llvm::cl::init(false));
+
+namespace seahorn {
+using namespace llvm;
+
+void CrabAnalysis::initCrabAnalysis(
+    const llvm::Module &M, seadsa::ShadowMem &dsaPass,
+    llvm::TargetLibraryInfoWrapperPass &tliPass) {
+
+  auto &dsa = dsaPass.getDsaAnalysis();
+  std::unique_ptr<clam::HeapAbstraction> heap_abs =
+      std::make_unique<clam::SeaDsaHeapAbstraction>(M, dsa);
+
+  // -- Set parameters for CFG
+  clam::CrabBuilderParams cfg_builder_params;
+  cfg_builder_params.setPrecision(clam::CrabBuilderPrecision::MEM);
+  cfg_builder_params.interprocedural = true;
+  cfg_builder_params.lowerUnsignedICmpIntoSigned();
+  cfg_builder_params.lower_arithmetic_with_overflow_intrinsics = true;
+
+  m_cfg_builder_man = std::make_unique<clam::CrabBuilderManager>(
+      cfg_builder_params, tliPass, std::move(heap_abs));
+  // -- Initialize crab for solving ranges
+  m_crab = std::make_shared<clam::InterGlobalClam>(M, *m_cfg_builder_man);
+}
+
+void CrabAnalysis::runCrabAnalysis() {
+  /// Set Crab parameters
+  clam::AnalysisParams aparams;
+  aparams.run_inter = true;
+  aparams.check = clam::CheckerKind::NOCHECKS;
+  aparams.widening_delay = 2; // set to delay widening
+  // Note that the abstract domain is set by using clam option
+
+  if (UseCrabCheckIsDeref) {
+    crab::domains::crab_domain_params_man::get().set_param(
+        "region.is_dereferenceable", "true");
+  }
+  /// Run the Crab analysis
+  clam::ClamGlobalAnalysis::abs_dom_map_t assumptions;
+  LOG("seapp-crab", aparams.print_invars = true;);
+  Stats::resume("seapp.crab");
+  m_crab->analyze(aparams, assumptions);
+  Stats::stop("seapp.crab");
+}
+
+void CrabAnalysis::runCrabAnalysisOnModule(
+    const llvm::Module &M, seadsa::ShadowMem &dsaPass,
+    llvm::TargetLibraryInfoWrapperPass &tliPass) {
+  LOG("crab-analysis", errs() << "Start Running Crab Analysis\n";);
+
+  // Step 1. Set up crab analysis
+  initCrabAnalysis(M, dsaPass, tliPass);
+  // Step 2. Run crab analysis
+  runCrabAnalysis();
+  LOG("crab-analysis", errs() << "Crab Analysis Complete\n";);
+}
+
+} // namespace seahorn

--- a/lib/Transforms/Scalar/CMakeLists.txt
+++ b/lib/Transforms/Scalar/CMakeLists.txt
@@ -19,4 +19,9 @@ add_llvm_library (SeaTransformsScalar DISABLE_LLVM_LINK_LLVM_DYLIB
   LoopPeeler.cc
   BackedgeCutter.cc
   LowerIsDeref.cc
+  CrabLowerIsDeref.cc
   )
+
+if (HAVE_CLAM)
+  target_link_libraries (SeaTransformsScalar PRIVATE ${CLAM_LIBS})
+endif()

--- a/lib/Transforms/Scalar/CrabLowerIsDeref.cc
+++ b/lib/Transforms/Scalar/CrabLowerIsDeref.cc
@@ -26,7 +26,7 @@ namespace {
 struct CrabLowerIsDeref : public ModulePass {
 private:
   Value *crabLowerIsDereferenceable(CallBase *IsDerefCall);
-  const llvm::ConstantRange getCrabInstRng(const llvm::Instruction &I);
+  const llvm::ConstantRange getCrabInstRng(const llvm::Instruction &I) const;
 
   clam::InterGlobalClam *m_crab_ptr;
 
@@ -75,9 +75,6 @@ bool CrabLowerIsDeref::runOnModule(Module &M) {
   // Sea-DSA is the most common use.
   crab.runCrabAnalysisOnModule(M, dsa, tliPass);
   m_crab_ptr = &crab.getCrab();
-  if (!m_crab_ptr) {
-    ERR << "Error: failed to run crab analysis.";
-  }
   auto &SBI = getAnalysis<SeaBuiltinsInfoWrapperPass>().getSBI();
 
   bool Changed = false;
@@ -110,10 +107,8 @@ bool CrabLowerIsDeref::runOnModule(Module &M) {
 }
 
 const llvm::ConstantRange
-CrabLowerIsDeref::getCrabInstRng(const llvm::Instruction &I) {
+CrabLowerIsDeref::getCrabInstRng(const llvm::Instruction &I) const {
   unsigned IntWidth = I.getType()->getIntegerBitWidth();
-  if (!m_crab_ptr)
-    return llvm::ConstantRange::getFull(IntWidth);
   return m_crab_ptr->range(I);
 }
 

--- a/lib/Transforms/Scalar/CrabLowerIsDeref.cc
+++ b/lib/Transforms/Scalar/CrabLowerIsDeref.cc
@@ -1,0 +1,130 @@
+#include "seahorn/Analysis/SeaBuiltinsInfo.hh"
+#include "seahorn/Passes.hh"
+#include "seahorn/Support/SeaDebug.h"
+#include "seahorn/Support/SeaLog.hh"
+#include "seahorn/Support/Stats.hh"
+#include "seahorn/Transforms/Instrumentation/CrabAnalysis.hh"
+
+#include "llvm/Analysis/TargetLibraryInfo.h"
+#include "llvm/IR/DebugInfo.h"
+#include "llvm/IR/DebugLoc.h"
+
+#include "seadsa/ShadowMem.hh"
+
+#include "clam/CfgBuilder.hh"
+#include "clam/Clam.hh"
+
+using namespace llvm;
+using namespace seahorn;
+
+namespace {
+
+struct CrabLowerIsDeref : public ModulePass {
+private:
+  Value *crabLowerIsDereferenceable(CallBase *IsDerefCall);
+  const llvm::ConstantRange getCrabInstRng(const llvm::Instruction &I);
+
+  std::shared_ptr<clam::InterGlobalClam> m_crab_ptr;
+
+public:
+  static char ID;
+
+  CrabLowerIsDeref() : ModulePass(ID) {}
+
+  bool runOnModule(Module &M) override;
+  void getAnalysisUsage(AnalysisUsage &AU) const override {
+    AU.addRequired<seadsa::ShadowMemPass>();
+    AU.addRequired<TargetLibraryInfoWrapperPass>();
+    AU.addRequired<SeaBuiltinsInfoWrapperPass>();
+    AU.setPreservesAll();
+  }
+  StringRef getPassName() const override { return "CrabLowerIsDeref"; }
+};
+char CrabLowerIsDeref::ID = 0;
+
+} // namespace
+
+bool CrabLowerIsDeref::runOnModule(Module &M) {
+  LOG("crab-isderef", errs()
+                          << "Start Running Crab lowering is_deref checks\n";);
+  CrabAnalysis crab = CrabAnalysis();
+  // Get seadsa -- pointer analysis
+  auto &dsaPass = getAnalysis<seadsa::ShadowMemPass>().getShadowMem();
+  // Get target library info pass
+  auto &tliPass = getAnalysis<TargetLibraryInfoWrapperPass>();
+  crab.runCrabAnalysisOnModule(M, dsaPass, tliPass);
+  m_crab_ptr = crab.getCrab();
+  if (!m_crab_ptr) {
+    ERR << "Error: failed to run crab analysis.";
+  }
+  auto &SBI = getAnalysis<SeaBuiltinsInfoWrapperPass>().getSBI();
+
+  bool Changed = false;
+
+  for (auto &F : M) {
+    for (auto &BB : F) {
+      SmallVector<CallInst *, 32> deadCalls;
+      for (auto &I : BB) {
+        if (auto *CB = dyn_cast<CallInst>(&I)) {
+          if (SBI.getSeaBuiltinOp(*CB) != SeaBuiltinsOp::IS_DEREFERENCEABLE)
+            continue;
+
+          // this is a call to sea.is_dereferenceable
+          Value *res = crabLowerIsDereferenceable(CB);
+          if (res) {
+            CB->replaceAllUsesWith(res);
+            deadCalls.push_back(CB);
+            Changed = true;
+          }
+        }
+      }
+      for (auto &DC : deadCalls) {
+        DC->eraseFromParent();
+      }
+    }
+  }
+
+  LOG("crab-isderef", errs() << "Crab lowering is_deref checks complete\n";);
+  return Changed;
+}
+
+const llvm::ConstantRange
+CrabLowerIsDeref::getCrabInstRng(const llvm::Instruction &I) {
+  unsigned IntWidth = I.getType()->getIntegerBitWidth();
+  if (!m_crab_ptr)
+    return llvm::ConstantRange::getFull(IntWidth);
+  return m_crab_ptr->range(I);
+}
+
+Value *CrabLowerIsDeref::crabLowerIsDereferenceable(CallBase *IsDerefCall) {
+
+  auto crabDerefResult = getCrabInstRng(*IsDerefCall);
+  auto &C = IsDerefCall->getContext();
+  if (crabDerefResult.isEmptySet()) {
+    // Crab skips is_deref due to invariant inferred along the path is bottom
+    // This means the is_deref cannot reach, delete it.
+    Stats::count("crab.pp.isderef.solve");
+    return ConstantInt::getTrue(C);
+  } else if (crabDerefResult.isSingleElement()) {
+    // Crab inferred is_deref call is either true or false
+    Stats::count("crab.pp.isderef.solve");
+    return crabDerefResult.getSingleElement()->getBoolValue()
+               ? ConstantInt::getTrue(C)
+               : ConstantInt::getFalse(C);
+  } else {
+    // Crab cannot know the is_deref result
+    const llvm::DebugLoc &dloc = IsDerefCall->getDebugLoc();
+    unsigned Line = dloc.getLine();
+    unsigned Col = dloc.getCol();
+    const std::string &File = (*dloc).getFilename();
+    Stats::count("crab.pp.isderef.not.solve");
+    LOG("seapp-crab", MSG << "crab cannot solve: " << *IsDerefCall
+                          << " at File=" << File << " Line=" << Line
+                          << " col=" << Col;);
+    return nullptr;
+  }
+}
+
+llvm::Pass *seahorn::createCrabLowerIsDerefPass() {
+  return new CrabLowerIsDeref();
+}

--- a/lib/seahorn/BvOpSem2.cc
+++ b/lib/seahorn/BvOpSem2.cc
@@ -799,12 +799,11 @@ public:
         crabSolved = true;
       } else {
         Stats::count("crab.isderef.not.solve");
-        const llvm::DebugLoc &dloc = inst->getDebugLoc();
-        unsigned Line = dloc.getLine();
-        unsigned Col = dloc.getCol();
-        const std::string &File = (*dloc).getFilename();
-        LOG("opsem-crab", MSG << "crab cannot solve: " << *inst << " at File="
-                              << File << " Line=" << Line << " col=" << Col;);
+        LOG("opsem-crab", const llvm::DebugLoc &dloc = inst->getDebugLoc();
+            unsigned Line = dloc.getLine(); unsigned Col = dloc.getCol();
+            const std::string &File = (*dloc).getFilename();
+            MSG << "crab cannot solve: " << *inst << " at File=" << File
+                << " Line=" << Line << " col=" << Col;);
       }
     }
     if (!crabSolved) {

--- a/lib/seahorn/BvOpSem2.cc
+++ b/lib/seahorn/BvOpSem2.cc
@@ -799,7 +799,12 @@ public:
         crabSolved = true;
       } else {
         Stats::count("crab.isderef.not.solve");
-        LOG("opsem-crab", MSG << "crab cannot solve: " << *inst;);
+        const llvm::DebugLoc &dloc = inst->getDebugLoc();
+        unsigned Line = dloc.getLine();
+        unsigned Col = dloc.getCol();
+        const std::string &File = (*dloc).getFilename();
+        LOG("opsem-crab", MSG << "crab cannot solve: " << *inst << " at File="
+                              << File << " Line=" << Line << " col=" << Col;);
       }
     }
     if (!crabSolved) {
@@ -3343,6 +3348,7 @@ void Bv2OpSem::runCrabAnalysis() {
   aparams.dom = CrabDom;
   aparams.run_inter = true;
   aparams.check = clam::CheckerKind::NOCHECKS;
+  aparams.widening_delay = 2; // set to delay widening
 
   if (UseCrabCheckIsDeref) {
     crab::domains::crab_domain_params_man::get().
@@ -3351,7 +3357,9 @@ void Bv2OpSem::runCrabAnalysis() {
   /// Run the Crab analysis
   clam::ClamGlobalAnalysis::abs_dom_map_t assumptions;
   LOG("opsem-crab", aparams.print_invars = true;);
+  Stats::resume("opsem.crab");
   m_crab_rng_solver->analyze(aparams, assumptions);
+  Stats::stop("opsem.crab");
 }
 
 void Bv2OpSem::runLVIAnalysis(const Function &F) {

--- a/py/sea/commands.py
+++ b/py/sea/commands.py
@@ -590,7 +590,7 @@ class CrabPP(sea.LimitedCmd):
             argv.append('--crab-check-is-deref')
             argv.append('--crab-lower-is-deref')
         
-        if args.crab_dom is not None: argv.extend (['--crab-dom', args.crab_dom])
+        if args.crab_dom is not None: argv.extend (['--set-crab-dom', args.crab_dom])
 
         if args.log is not None:
             for l in args.log.split (':'): argv.extend (['-log', l])
@@ -1643,7 +1643,9 @@ class InspectBitcode(sea.LimitedCmd):
 
 
 ## SeaHorn aliases
-FrontEnd = sea.SeqCmd ('fe', 'Front end: alias for clang|pp|ms|crabpp|opt',
+FrontEnd = sea.SeqCmd ('fe', 'Front end: alias for clang|pp|ms|opt',
+                       [Clang(), Seapp(), MixedSem(), Seaopt ()])
+FECrab = sea.SeqCmd ('fec', 'Front end: alias for clang|pp|ms|crabpp|opt',
                        [Clang(), Seapp(), MixedSem(), CrabPP(), Seaopt ()])
 Smt = sea.SeqCmd ('smt', 'alias for fe|horn', FrontEnd.cmds + [Seahorn()])
 Clp = sea.SeqCmd ('clp', 'alias for fe|horn-clp', FrontEnd.cmds + [SeahornClp()])
@@ -1678,5 +1680,7 @@ Smc = sea.SeqCmd ('smc', 'alias for fe|opt|smc',
 # run clang before anything else so that we accept both high level source and bitcode.
 Fpf = sea.SeqCmd('fpf', 'clang|fat-bnd-check|fe|unroll|cut-loops|opt|horn --solve',
                  [Clang(), FatBoundsCheck()] + FrontEnd.cmds + [Unroll(), CutLoops(), Seaopt(), Seahorn(solve=True)])
+Fpcf = sea.SeqCmd('fpcf', 'clang|fat-bnd-check|fec|unroll|cut-loops|opt|horn --solve',
+                 [Clang(), FatBoundsCheck()] + FECrab.cmds + [Unroll(), CutLoops(), Seaopt(), Seahorn(solve=True)])
 Spf = sea.SeqCmd('spf', 'clang|add-branch-sentinel|fat-bnd-check|fe|unroll|cut-loops|opt|horn --solve',
                  [Clang(), AddBranchSentinel(), FatBoundsCheck()] + FrontEnd.cmds + [Unroll(), CutLoops(), Seaopt(), Seahorn(solve=True)])

--- a/py/sea/commands.py
+++ b/py/sea/commands.py
@@ -548,6 +548,59 @@ class MixedSem(sea.LimitedCmd):
         argv.extend (args.in_files)
         return self.seappCmd.run (args, argv)
 
+class CrabPP(sea.LimitedCmd):
+    def __init__(self, quiet=False):
+        super(CrabPP, self).__init__('crabpp', 'Crab analysis in Seapp',
+                                       allow_extra=True)
+
+    @property
+    def stdout (self):
+        return self.seappCmd.stdout
+
+    def name_out_file (self, in_files, args=None, work_dir=None):
+        ext = '.crab.bc'
+        # if args.llvm_asm: ext = '.crab.ll'
+        return _remap_file_name (in_files[0], ext, work_dir)
+
+    def mk_arg_parser (self, ap):
+        ap = super (CrabPP, self).mk_arg_parser (ap)
+        ap.add_argument ('--log', dest='log', default=None,
+                         metavar='STR', help='Log level')
+        ap.add_argument ('--seapp-crab-dom', dest='crab_dom', default=None,
+                         metavar='STR', help='Crab numerical abstract domain')
+        add_bool_argument(ap, 'seapp-crab-lower-is-deref', dest='crab_lower_is_deref',
+                            default=False, help='Use Crab to lower is_deref')
+        add_bool_argument(ap, 'seapp-crab-stats', dest='crab_stats',
+                            default=False, help='Print Crab Statistics')
+
+        add_in_out_args (ap)
+        _add_S_arg (ap)
+        return ap
+
+    def run (self, args, extra):
+        cmd_name = which ('seapp')
+        if cmd_name is None: raise IOError ('seapp not found')
+        self.seappCmd = sea.ExtCmd (cmd_name,'',quiet)
+
+        argv = list()
+        if args.out_file is not None: argv.extend (['-o', args.out_file])
+        if args.llvm_asm: argv.append ('-S')
+
+        if args.crab_lower_is_deref:
+            argv.append('--crab-check-is-deref')
+            argv.append('--crab-lower-is-deref')
+        
+        if args.crab_dom is not None: argv.extend (['--crab-dom', args.crab_dom])
+
+        if args.log is not None:
+            for l in args.log.split (':'): argv.extend (['-log', l])
+
+        if args.crab_stats:
+            argv.append('--seapp-stats')
+
+        argv.extend (args.in_files)
+        return self.seappCmd.run(args, argv)
+
 class NdcInst(sea.LimitedCmd):
     def __init__(self, quiet=False):
         super(NdcInst, self).__init__('ndc-inst',
@@ -1590,8 +1643,8 @@ class InspectBitcode(sea.LimitedCmd):
 
 
 ## SeaHorn aliases
-FrontEnd = sea.SeqCmd ('fe', 'Front end: alias for clang|pp|ms|opt',
-                       [Clang(), Seapp(), MixedSem(), Seaopt ()])
+FrontEnd = sea.SeqCmd ('fe', 'Front end: alias for clang|pp|ms|crabpp|opt',
+                       [Clang(), Seapp(), MixedSem(), CrabPP(), Seaopt ()])
 Smt = sea.SeqCmd ('smt', 'alias for fe|horn', FrontEnd.cmds + [Seahorn()])
 Clp = sea.SeqCmd ('clp', 'alias for fe|horn-clp', FrontEnd.cmds + [SeahornClp()])
 Boogie= sea.SeqCmd ('boogie', 'alias for fe|horn --boogie',

--- a/py/sea/commands.py
+++ b/py/sea/commands.py
@@ -590,7 +590,7 @@ class CrabPP(sea.LimitedCmd):
             argv.append('--crab-check-is-deref')
             argv.append('--crab-lower-is-deref')
         
-        if args.crab_dom is not None: argv.extend (['--set-crab-dom', args.crab_dom])
+        if args.crab_dom is not None: argv.extend (['--sea-crab-dom', args.crab_dom])
 
         if args.log is not None:
             for l in args.log.split (':'): argv.extend (['-log', l])

--- a/py/seapy
+++ b/py/seapy
@@ -45,6 +45,7 @@ def main (argv):
             sea.commands.Smc,
             sea.commands.RemoveTargetFeatures(),
             sea.commands.Fpf,
+            sea.commands.Fpcf,
             sea.commands.Spf,
             sea.yama.Yama(),
             sea.cex.CexGen(),

--- a/test/crab/crab_is_deref_3.c
+++ b/test/crab/crab_is_deref_3.c
@@ -1,0 +1,33 @@
+// RUN: %sea -O3 fpcf --inline --seapp-crab-lower-is-deref --seapp-crab-dom=zones --seapp-crab-stats=true --dsa=sea-cs-t --bmc=opsem --horn-vcgen-use-ite --horn-vcgen-only-dataflow=false --horn-bmc-coi=false --horn-stats=true --sea-opsem-allocator=static "%s" 2>&1 | OutputCheck %s
+// CHECK: crab.pp.isderef.solve 4
+
+#include <seahorn/seahorn.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+extern int nd_int(void);
+extern bool nd_bool(void);
+extern void memhavoc(void *, size_t);
+
+// Domain: zones
+int main() {
+    int len = nd_int();
+    assume(len > 0);
+    uint8_t *ptr = malloc(len);
+    sassert(sea_is_dereferenceable(ptr, len));
+    for (int j = 1; j < len; ++j) {
+      uint8_t *p_j = ptr + j;
+      sassert(sea_is_dereferenceable(p_j, 1));
+      int i = j - 1;
+      while (i >= 0) {
+        uint8_t *p_i = ptr + i;
+        sassert(sea_is_dereferenceable(p_i, 1));
+        sassert(sea_is_dereferenceable(p_i + 1, 1));
+        -- i;
+      }
+    }
+   return 0;
+}

--- a/tools/seapp/seapp.cc
+++ b/tools/seapp/seapp.cc
@@ -471,15 +471,7 @@ int main(int argc, char **argv) {
     // -- Externalize some user-selected functions
     pm_wrapper.add(seahorn::createExternalizeFunctionsPass());
   } else if (CrabLowerIsDeref) {
-    // -- prerequisite 1 : Sea-DSA analysis
-    llvm::initializeRemovePtrToIntPass(Registry);
-    llvm::initializeDsaAnalysisPass(Registry);
-    llvm::initializeAllocWrapInfoPass(Registry);
-    llvm::initializeDsaLibFuncInfoPass(Registry);
-    llvm::initializeAllocSiteInfoPass(Registry);
-    llvm::initializeCompleteCallGraphPass(Registry);
-    pm_wrapper.add(seahorn::createSeaDsaShadowMemPass());
-    // -- prerequisite 2 : Run Name Values Pass
+    // -- prerequisite 1 : Run Name Values Pass
     pm_wrapper.add(seahorn::createNameValuesPass());
     // -- attempt to lower any left sea.is_dereferenceable()
     // First pass is attempted by using LLVM Memory Builtins to compute
@@ -487,6 +479,8 @@ int main(int argc, char **argv) {
     pm_wrapper.add(seahorn::createLowerIsDerefPass());
     // Second pass is using Crab Analysis to compute size and offset
     // invariants for each pointer.
+    // Note that, another prerequisite: Sea-DSA analysis is run inside
+    // the below LLVM pass.
     pm_wrapper.add(seahorn::createCrabLowerIsDerefPass());
   }
   // default pre-processing pipeline

--- a/tools/seapp/seapp.cc
+++ b/tools/seapp/seapp.cc
@@ -276,6 +276,15 @@ static llvm::cl::opt<bool> AddBranchSentinelOpt(
         "Add a branch sentinel instruction before every branch instruction"),
     llvm::cl::init(false));
 
+static llvm::cl::opt<bool> CrabLowerIsDeref(
+    "crab-lower-is-deref",
+    llvm::cl::desc("Lower sea_is_dereferenceable() calls by Running Crab"),
+    llvm::cl::init(false));
+
+static llvm::cl::opt<bool> PrintStats("seapp-stats",
+                                      llvm::cl::desc("Print statistics"),
+                                      llvm::cl::init(false));
+
 // removes extension from filename if there is one
 std::string getFileName(const std::string &str) {
   std::string filename = str;
@@ -461,6 +470,24 @@ int main(int argc, char **argv) {
   } else if (ExternalizeFns) {
     // -- Externalize some user-selected functions
     pm_wrapper.add(seahorn::createExternalizeFunctionsPass());
+  } else if (CrabLowerIsDeref) {
+    // -- prerequisite 1 : Sea-DSA analysis
+    llvm::initializeRemovePtrToIntPass(Registry);
+    llvm::initializeDsaAnalysisPass(Registry);
+    llvm::initializeAllocWrapInfoPass(Registry);
+    llvm::initializeDsaLibFuncInfoPass(Registry);
+    llvm::initializeAllocSiteInfoPass(Registry);
+    llvm::initializeCompleteCallGraphPass(Registry);
+    pm_wrapper.add(seahorn::createSeaDsaShadowMemPass());
+    // -- prerequisite 2 : Run Name Values Pass
+    pm_wrapper.add(seahorn::createNameValuesPass());
+    // -- attempt to lower any left sea.is_dereferenceable()
+    // First pass is attempted by using LLVM Memory Builtins to compute
+    // the requested size of access <= object size.
+    pm_wrapper.add(seahorn::createLowerIsDerefPass());
+    // Second pass is using Crab Analysis to compute size and offset
+    // invariants for each pointer.
+    pm_wrapper.add(seahorn::createCrabLowerIsDerefPass());
   }
   // default pre-processing pipeline
   else {
@@ -684,6 +711,9 @@ int main(int argc, char **argv) {
   }
 
   pm_wrapper.run(*module.get());
+
+  if (PrintStats)
+    seahorn::Stats::PrintBrunch(llvm::outs());
 
   if (!OutputFilename.empty())
     output->keep();


### PR DESCRIPTION
This PR includes these features:

- A class to run crab analysis in `seapp`
- A LLVM pass to lower `sea.is_dereferenceable` in `seapp`
- A pipeline in `seapp` to support above features