### PR TITLE
fix(opsem): call correct ptrAdd fn in fatmemmgr

### DIFF
--- a/lib/seahorn/BvOpSem2FatMemMgr.cc
+++ b/lib/seahorn/BvOpSem2FatMemMgr.cc
@@ -309,7 +309,7 @@ public:
 
   /// \brief Pointer addition with symbolic offset
   FatPtrTy ptrAdd(FatPtrTy ptr, Expr offset) const {
-    BasePtrTy rawPtr = ptrAdd(mkRawPtr(ptr), offset).v();
+    BasePtrTy rawPtr = m_main.ptrAdd(mkRawPtr(ptr), offset);
     return mkFatPtr(rawPtr, ptr);
   }
 


### PR DESCRIPTION
fixing issue discovered in https://github.com/seahorn/seahorn/issues/450