### PR TITLE
fix(ci): get archive sig before install

### DIFF
--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -10,6 +10,7 @@ jobs:
     steps:
       - name: Setup environment
         run: |
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
           sudo apt-get install -yqq clang-format-14
       - name: Checkout
         run: |


### PR DESCRIPTION
Fixes #474 
Retrieve the archive signature before installing `clang-format-14` according to https://apt.llvm.org/ _"Install
(stable branch)"_.

See successful CI run here: https://github.com/danblitzhou/seahorn/actions/runs/3578595267/jobs/6018916620