### PR TITLE
fix(ci): force latest ubuntu

### DIFF
--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -6,10 +6,11 @@ on:
 jobs:
   clang-format-check:
     name: clang-format
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-22.04"
     steps:
       - name: Setup environment
         run: |
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
           sudo apt-get install -yqq clang-format-14
       - name: Checkout
         run: |


### PR DESCRIPTION
Fixes #474 
Github actions does not always use ubuntu 22.04 for `ubuntu-latest` [see blog](https://github.blog/changelog/2022-08-09-github-actions-ubuntu-22-04-is-now-generally-available-on-github-hosted-runners/)
Use Retrieve the archive signature before installing `clang-format-14` according to https://apt.llvm.org/ _"Install
(stable branch)"_.
