### PR TITLE
Cleaning up Expr visit family of functions

### DIFF
--- a/include/seahorn/Bmc.hh
+++ b/include/seahorn/Bmc.hh
@@ -8,7 +8,7 @@
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/raw_ostream.h"
 
-#include "boost/container/flat_set.hpp"
+#include "seahorn/boost_flat_set.hh"
 #include "boost/logic/tribool.hpp"
 
 #include "seahorn/CallUtils.hh"

--- a/include/seahorn/Bmc.hh
+++ b/include/seahorn/Bmc.hh
@@ -1,5 +1,4 @@
-#ifndef __BMC__HH_
-#define __BMC__HH_
+#pragma once
 
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/IR/DebugInfo.h"
@@ -8,8 +7,8 @@
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/raw_ostream.h"
 
-#include "seahorn/boost_flat_set.hh"
 #include "boost/logic/tribool.hpp"
+#include "seahorn/boost_flat_set.hh"
 
 #include "seahorn/CallUtils.hh"
 #include "seahorn/Expr/Expr.hh"
@@ -31,8 +30,8 @@ template <typename model_ref>
 void get_model_implicant(const ExprVector &f, model_ref model, ExprVector &out,
                          ExprMap &active_bool_map);
 // out is a minimal unsat core f based on assumptions
-void unsat_core(ZSolver<EZ3> &solver, const ExprVector &f,
-                bool simplify, ExprVector &out);
+void unsat_core(ZSolver<EZ3> &solver, const ExprVector &f, bool simplify,
+                ExprVector &out);
 
 template <typename Out>
 void dump_evaluated_inst(const Instruction &inst, Expr v, Out &out,
@@ -208,4 +207,3 @@ public:
 } // namespace seahorn
 // implementation
 #include "seahorn/BmcImpl.hh"
-#endif

--- a/include/seahorn/BvOpSem2.hh
+++ b/include/seahorn/BvOpSem2.hh
@@ -8,7 +8,7 @@
 #include "llvm/IR/GetElementPtrTypeIterator.h"
 #include "llvm/Pass.h"
 
-#include <boost/container/flat_set.hpp>
+#include <seahorn/boost_flat_set.hh>
 
 // forward declarations
 namespace llvm {

--- a/include/seahorn/Expr/Evaluate.hh
+++ b/include/seahorn/Expr/Evaluate.hh
@@ -414,7 +414,7 @@ template <typename T> class Evaluate {
   template <typename A> A evaluateHelper(Expr exp) {
     evalImpl::EV<A> visitor(m_evalModel);
 
-    visit(visitor, exp);
+    dagVisit(visitor, exp);
     return visitor.getValue(exp);
   }
 

--- a/include/seahorn/Expr/Expr.hh
+++ b/include/seahorn/Expr/Expr.hh
@@ -18,12 +18,12 @@
 
 #include <seahorn/Expr/ExprGmp.hh>
 
-#include <seahorn/boost_flat_set.hh>
 #include <boost/functional/hash_fwd.hpp>
 #include <boost/intrusive_ptr.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/pool/pool.hpp>
 #include <boost/pool/poolfwd.hpp>
+#include <seahorn/boost_flat_set.hh>
 
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/iterator_range.h"
@@ -51,7 +51,7 @@
 
 #include "seahorn/Expr/ExprOpMisc.hh"
 
-    namespace expr {
+namespace expr {
 namespace op {}
 /** Size of an expression as a DAG */
 size_t dagSize(Expr e);

--- a/include/seahorn/Expr/Expr.hh
+++ b/include/seahorn/Expr/Expr.hh
@@ -18,7 +18,7 @@
 
 #include <seahorn/Expr/ExprGmp.hh>
 
-#include <boost/container/flat_set.hpp>
+#include <seahorn/boost_flat_set.hh>
 #include <boost/functional/hash_fwd.hpp>
 #include <boost/intrusive_ptr.hpp>
 #include <boost/lexical_cast.hpp>

--- a/include/seahorn/Expr/ExprVisitor.hh
+++ b/include/seahorn/Expr/ExprVisitor.hh
@@ -173,7 +173,8 @@ void dagVisit(ExprVisitor &v, const ExprVector &vec) {
 
 /// -- visit expression as though it is a tree
 /// --
-/// -- this does not use a visited table and might visit the same expression multiple times
+/// -- this does not use a visited table and might visit the same expression
+/// multiple times
 template <typename ExprVisitor> Expr treeVisit(ExprVisitor &v, Expr expr) {
   VisitAction va = v(expr);
 

--- a/include/seahorn/HornCex.hh
+++ b/include/seahorn/HornCex.hh
@@ -1,29 +1,28 @@
 #ifndef _HORN_CEX__HH_
 #define _HORN_CEX__HH_
 
-#include "llvm/Pass.h"
-#include "llvm/IR/Module.h"
 #include "seahorn/Bmc.hh"
+#include "llvm/IR/Module.h"
+#include "llvm/Pass.h"
 
-namespace seahorn
-{
-  using namespace llvm;
+namespace seahorn {
+using namespace llvm;
 
-  /*
-   * Reconstructs a counterexample from HornSolver
-   */
-  class HornCex : public llvm::ModulePass {
-  public:
-    static char ID;
-    
-    HornCex () : ModulePass(ID) {}
-    virtual ~HornCex () {}
-    
-    virtual bool runOnModule (Module &M) override;
-    virtual bool runOnFunction (Module &M, Function &F);
-    virtual void getAnalysisUsage (AnalysisUsage &AU) const override;
-    virtual StringRef getPassName () const override {return "HornCex";}
-  };
-}
+/*
+ * Reconstructs a counterexample from HornSolver
+ */
+class HornCex : public llvm::ModulePass {
+public:
+  static char ID;
+
+  HornCex() : ModulePass(ID) {}
+  virtual ~HornCex() {}
+
+  virtual bool runOnModule(Module &M) override;
+  virtual bool runOnFunction(Module &M, Function &F);
+  virtual void getAnalysisUsage(AnalysisUsage &AU) const override;
+  virtual StringRef getPassName() const override { return "HornCex"; }
+};
+} // namespace seahorn
 
 #endif

--- a/include/seahorn/HornClauseDB.hh
+++ b/include/seahorn/HornClauseDB.hh
@@ -4,11 +4,11 @@
 
 #include "llvm/Support/raw_ostream.h"
 
-#include <seahorn/boost_flat_set.hh>
 #include <boost/functional/hash.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/range.hpp>
 #include <boost/range/algorithm/copy.hpp>
+#include <seahorn/boost_flat_set.hh>
 
 #include "seahorn/Expr/Expr.hh"
 #include "seahorn/Expr/ExprOpBinder.hh"
@@ -45,7 +45,7 @@ public:
       : m_vars(boost::begin(v), boost::end(v)), m_head(head), m_body(body) {}
 
   HornRule(const HornRule &r) = default;
-  HornRule& operator=(const HornRule &r) = default;
+  HornRule &operator=(const HornRule &r) = default;
 
   size_t hash() const {
     size_t res = expr::hash_value(m_head);
@@ -272,7 +272,7 @@ public:
   /// -- build call graph
   void buildCallGraph();
 
-  const HornClauseDB& db() const { return m_db; }
+  const HornClauseDB &db() const { return m_db; }
   /// -- returns an entry point of the call graph.
   bool hasEntry() const { return !isOpX<FALSE>(m_cg_entry); }
   Expr entry() const {

--- a/include/seahorn/HornClauseDB.hh
+++ b/include/seahorn/HornClauseDB.hh
@@ -4,7 +4,7 @@
 
 #include "llvm/Support/raw_ostream.h"
 
-#include <boost/container/flat_set.hpp>
+#include <seahorn/boost_flat_set.hh>
 #include <boost/functional/hash.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/range.hpp>

--- a/include/seahorn/boost_flat_set.hh
+++ b/include/seahorn/boost_flat_set.hh
@@ -1,0 +1,9 @@
+#pragma once
+
+#define BOOST_DISABLE_ASSERTS 1
+// boost/ptr_vector.hpp has BOOST_ASSERT that rely on rtti
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wsuggest-override"
+#include <boost/container/flat_set.hpp>
+#pragma clang diagnostic pop
+#undef BOOST_DISABLE_ASSERTS

--- a/lib/seahorn/FiniteMapTransf.cc
+++ b/lib/seahorn/FiniteMapTransf.cc
@@ -730,7 +730,7 @@ Expr rewriteFiniteMapArgs(Expr e, const ExprMap &predDeclMap) {
 Expr rewriteFiniteMapArgs(Expr e, ExprSet &evars, const ExprMap &predDeclMap) {
   DagVisitCache dvc;
   FiniteMapArgsVisitor fmav(evars, predDeclMap, e->efac());
-  return visit(fmav, e, dvc);
+  return visitRec(fmav, e, dvc);
 }
 
 namespace fmap_transf {
@@ -796,7 +796,7 @@ Expr mkSameKeysCore(Expr e) {
 Expr inlineVals(Expr e, ExprMap &valmap) {
   FMVisitor dv(valmap);
   DagVisitCache cache;
-  Expr newE = visit(dv, e, cache);
+  Expr newE = visitRec(dv, e, cache);
   return newE;
 }
 

--- a/lib/seahorn/FiniteMapTransf.cc
+++ b/lib/seahorn/FiniteMapTransf.cc
@@ -277,7 +277,7 @@ public:
 
 static Expr dsaIteSimplify(Expr e) {
   IteTopDownVisitor itdv;
-  return visit(itdv, e);
+  return dagVisit(itdv, e);
 }
 
 // ----------------------------------------------------------------------

--- a/lib/seahorn/HornCex.cc
+++ b/lib/seahorn/HornCex.cc
@@ -30,16 +30,16 @@
 #include "seahorn/Support/CFG.hh"
 #include "seahorn/Transforms/Utils/Local.hh"
 
-#include "seahorn/Support/Stats.hh"
 #include "seahorn/Support/SeaDebug.h"
+#include "seahorn/Support/Stats.hh"
 
 #include "boost/algorithm/string/predicate.hpp"
-#include "seahorn/boost_flat_set.hh"
 #include "boost/container/map.hpp"
 #include "boost/range.hpp"
 #include "boost/range/adaptor/reversed.hpp"
 #include "boost/range/algorithm/reverse.hpp"
 #include "boost/range/algorithm/sort.hpp"
+#include "seahorn/boost_flat_set.hh"
 
 namespace seahorn {
 std::string HornCexFile;
@@ -49,8 +49,7 @@ static llvm::cl::opt<std::string, true> XHornCexFile(
     "horn-cex",
     llvm::cl::desc(
         "Counterexample in SV-COMP (.xml) or LLVM bitcode (.bc or .ll) format"),
-    llvm::cl::location(seahorn::HornCexFile),    
-    llvm::cl::init(""),
+    llvm::cl::location(seahorn::HornCexFile), llvm::cl::init(""),
     llvm::cl::value_desc("filename"));
 
 static llvm::cl::opt<bool>
@@ -177,13 +176,14 @@ bool HornCex::runOnFunction(Module &M, Function &F) {
     }
   }
 
-  LOG("cex", errs() << "TRACE BEGIN\n"; for (auto bb
+  LOG(
+      "cex", errs() << "TRACE BEGIN\n"; for (auto bb
                                              : bbTrace) {
-    errs() << bb->getName();
-    if (cpg.isCutPoint(*bb))
-      errs() << " C";
-    errs() << "\n";
-  } errs() << "TRACE END\n";);
+        errs() << bb->getName();
+        if (cpg.isCutPoint(*bb))
+          errs() << " C";
+        errs() << "\n";
+      } errs() << "TRACE END\n";);
 
   // -- release trace resources
   bbTrace.clear();
@@ -255,7 +255,8 @@ bool HornCex::runOnFunction(Module &M, Function &F) {
   BvOpSem semBv(efac, *this, M.getDataLayout(), MEM);
 
   LegacyOperationalSemantics *sem =
-      UseBv ? static_cast<LegacyOperationalSemantics *>(&semBv) : static_cast<LegacyOperationalSemantics *>(&semUfo);
+      UseBv ? static_cast<LegacyOperationalSemantics *>(&semBv)
+            : static_cast<LegacyOperationalSemantics *>(&semUfo);
 
   const TargetLibraryInfo &tli =
       getAnalysis<TargetLibraryInfoWrapperPass>().getTLI(F);
@@ -455,7 +456,6 @@ static void debugLocToSvComp(const Instruction &inst, SvCompCex<O> &svcomp) {
   const DebugLoc &dloc = inst.getDebugLoc();
   if (!(dloc.get()))
     return;
- 
 
   // DIScope Scope (dloc.getScope ());
   // if (Scope) file = Scope.getFilename ();

--- a/lib/seahorn/HornCex.cc
+++ b/lib/seahorn/HornCex.cc
@@ -34,7 +34,7 @@
 #include "seahorn/Support/SeaDebug.h"
 
 #include "boost/algorithm/string/predicate.hpp"
-#include "boost/container/flat_set.hpp"
+#include "seahorn/boost_flat_set.hh"
 #include "boost/container/map.hpp"
 #include "boost/range.hpp"
 #include "boost/range/adaptor/reversed.hpp"

--- a/lib/seahorn/HornClauseDBTransf.cc
+++ b/lib/seahorn/HornClauseDBTransf.cc
@@ -157,7 +157,7 @@ void removeFiniteMapsBodyHornClausesTransf(HornClauseDB &db, HornClauseDB &tdb,
     if (isOpX<TRUE>(rule.body()))
       tdb.addRule(rule);
     else {
-      Expr body = visit(fmbv, rule.body(), dvc);
+      Expr body = visitRec(fmbv, rule.body(), dvc);
 
       ExprSet newVars;
       copy_if(allVars, newVars, [](Expr expr) { // not finite map

--- a/lib/seahorn/Smt/ExprMemMap.cc
+++ b/lib/seahorn/Smt/ExprMemMap.cc
@@ -176,7 +176,7 @@ VisitAction ArrayVisitor::operator()(Expr exp) {
 bool ExprMemMap::populateCells(Expr exp) {
   if (isOp<ITE>(exp)) {
     m_visitor = std::make_unique<ITEVisitor>(&m_cells);
-    visit(*m_visitor, exp); // note: HD_ITE has its own cache
+    dagVisit(*m_visitor, exp); // note: HD_ITE has its own cache
 
     m_visitor->doneVisiting();
 

--- a/lib/seahorn/Smt/ExprUtil.cc
+++ b/lib/seahorn/Smt/ExprUtil.cc
@@ -78,7 +78,7 @@ size_t dagSize(const ExprVector &vec) {
 /** Size of an expression as a tree */
 size_t treeSize(Expr e) {
   SIZE sz;
-  visit(sz, e);
+  treeVisit(sz, e);
   return sz.count;
 }
 

--- a/lib/seahorn/Smt/TypeChecker.cc
+++ b/lib/seahorn/Smt/TypeChecker.cc
@@ -146,8 +146,7 @@ public:
   Impl(TypeChecker *tc) : m_visitor(tc) {}
 
   Expr typeOf(Expr e) {
-    Expr v = dagVisit(m_visitor, e);
-
+    Expr v = treeVisit(m_visitor, e);
     return m_visitor.knownTypeOf(v);
   }
 

--- a/lib/seahorn/Smt/TypeChecker.cc
+++ b/lib/seahorn/Smt/TypeChecker.cc
@@ -146,7 +146,7 @@ public:
   Impl(TypeChecker *tc) : m_visitor(tc) {}
 
   Expr typeOf(Expr e) {
-    Expr v = visit(m_visitor, e);
+    Expr v = dagVisit(m_visitor, e);
 
     return m_visitor.knownTypeOf(v);
   }

--- a/units/TypeCheckerTests.cpp
+++ b/units/TypeCheckerTests.cpp
@@ -12,12 +12,21 @@
 #include "seahorn/Expr/ExprGmp.hh"
 #include "seahorn/Expr/ExprLlvm.hh"
 #include "seahorn/Expr/ExprOpBinder.hh"
+#include "seahorn/Expr/ExprOpBool.hh"
 #include "seahorn/Expr/ExprOpBv.hh"
 #include "seahorn/Expr/ExprOpFiniteMap.hh"
 #include "seahorn/Expr/TypeChecker.hh"
 
-#include "seahorn/Support/SeaDebug.h"
 #include "sea_doctest.hh" // doctest is last to avoid name clash
+#include "seahorn/Support/SeaDebug.h"
+
+// Resolve name clash on OSX
+#ifdef TRUE
+#undef TRUE
+#endif
+#ifdef FALSE
+#undef FALSE
+#endif
 
 using namespace expr;
 using namespace llvm;
@@ -46,7 +55,7 @@ void checkNotWellFormed(std::vector<Expr> e, std::vector<Expr> error) {
   Expr errorSort = sort::errorTy(e[0]->efac());
   TypeChecker tc;
 
-  for (int i = 0; i < e.size(); i++) {
+  for (unsigned i = 0; i < e.size(); i++) {
     llvm::errs() << "Expression: " << *e[i] << "\n";
     Expr ty = tc.typeOf(e[i]);
 
@@ -62,7 +71,7 @@ void checkNotWellFormed(std::vector<Expr> e, std::vector<Expr> error) {
 void checkWellFormed(std::vector<Expr> e, Expr type) {
   TypeChecker tc;
 
-  for (int i = 0; i < e.size(); i++) {
+  for (unsigned i = 0; i < e.size(); i++) {
     llvm::errs() << "Expression: " << *e[i] << "\n";
     Expr ty = tc.typeOf(e[i]);
 
@@ -619,12 +628,17 @@ TEST_CASE("bvNotWellFormed.test") {
   temp = error.back();
   e.push_back(temp);
 
-  tempError = bv::extract(5, 9, a10); // high is lower than low
+  // high is lower than low
+  tempError =
+      mk<BEXTRACT>(mkTerm<unsigned>(5, efac), mkTerm<unsigned>(9, efac), a10);
+
   error.push_back(tempError);
   temp = mk<BUREM>(mk<BNEG>(a5), b5, error.back());
   e.push_back(temp);
 
-  tempError = bv::extract(6, 4, c5); // high is higher than width
+  // high is higher than width
+  tempError =
+      mk<BEXTRACT>(mkTerm<unsigned>(6, efac), mkTerm<unsigned>(4, efac), c5);
   error.push_back(tempError);
   temp = error.back();
   e.push_back(temp);


### PR DESCRIPTION
There are two visitors for expressions: dagVisit and treeVisit.

`treeVisit` used to be called `visit` that caused unintentional misuse.

`treeVisit` has no visited table and traverses expression as though it was a tree (no shared sub-expressions).

In most cases, `dagVisit` is the one to use