### PR TITLE
fix(gsa): generate undef value when if both incoming undef

### DIFF
--- a/lib/Analysis/GateAnalysis.cc
+++ b/lib/Analysis/GateAnalysis.cc
@@ -20,6 +20,8 @@
 #include "seahorn/Analysis/ControlDependenceAnalysis.hh"
 
 #include "seahorn/Support/SeaDebug.h"
+#include "seahorn/Support/SeaLog.hh"
+
 #include "seahorn/Support/Stats.hh"
 
 #define GSA_LOG(...) LOG("gsa", __VA_ARGS__)
@@ -261,8 +263,11 @@ void GateAnalysisImpl::processPhi(PHINode *PN, Instruction *insertionPt) {
       Value *FalseVal = SuccToVal[FalseDest];
 
       // Construct gamma node only when necessary.
-      assert(TrueVal != Undef || FalseVal != Undef);
-      if (TrueVal == FalseVal) {
+      if (TrueVal == Undef && FalseVal == Undef) {
+        LOG("gsa", errs() << "Inserting unDef since all incoming Undef at "
+                          << *insertionPt << "\n";);
+        flowingValues[BB] = Undef;
+      } else if (TrueVal == FalseVal) {
         flowingValues[BB] = TrueVal;
       } else if (ThinnedGsa && (TrueVal == Undef || FalseVal == Undef)) {
         flowingValues[BB] = FalseVal == Undef ? TrueVal : FalseVal;


### PR DESCRIPTION
Currently we assert that only one of the incoming values must be undef, this is only caught in debug mode. Rust compiler appears to generate undef values on both incoming edges. As such, we should deal with gracefully. This is the simplest attempt at doing so.