### PR TITLE
fix: missing list include

### DIFF
--- a/include/seahorn/Houdini.hh
+++ b/include/seahorn/Houdini.hh
@@ -12,6 +12,8 @@
 #include "seahorn/Expr/Smt/EZ3.hh"
 #include "seahorn/HornClauseDBWto.hh"
 
+#include <list>
+
 namespace seahorn
 {
   using namespace llvm;


### PR DESCRIPTION
Missing list include in header file houdini.hh