### PR TITLE
feat(opsem): symb memcpy now simplifies len

### DIFF
--- a/lib/seahorn/BvOpSem2.cc
+++ b/lib/seahorn/BvOpSem2.cc
@@ -124,6 +124,11 @@ static llvm::cl::opt<bool> SimplifyExpr(
     llvm::cl::desc("Simplify expressions as they are written to memory"),
     llvm::cl::init(false));
 
+static llvm::cl::opt<bool>
+    SimplifyExprNonMem("horn-bv2-simplify-nonmem",
+                       llvm::cl::desc("Simplify non memory expressions"),
+                       llvm::cl::init(true));
+
 static llvm::cl::opt<enum seahorn::details::VacCheckOptions> VacuityCheckOpt(
     "horn-bv2-vacuity-check",
     llvm::cl::desc("A choice for levels of vacuity check"),
@@ -2560,6 +2565,7 @@ Bv2OpSemContext::Bv2OpSemContext(Bv2OpSem &sem, SymStore &values,
   params.set("ctrl_c", true);
   params.set(":rewriter.flat", false);
   m_shouldSimplify = SimplifyExpr;
+  m_shouldSimplifyNonMem = SimplifyExprNonMem;
   m_alu = mkBvOpSemAlu(*this);
   OpSemMemManager *mem = nullptr;
 

--- a/lib/seahorn/BvOpSem2Context.hh
+++ b/lib/seahorn/BvOpSem2Context.hh
@@ -162,7 +162,8 @@ private:
   std::shared_ptr<ZSimplifier<EZ3>> m_z3_simplifier;
   std::shared_ptr<ZSolver<EZ3>> m_z3_solver;
 
-  bool m_shouldSimplify = false;
+  bool m_shouldSimplify = false;       // simplify memory exprs
+  bool m_shouldSimplifyNonMem = false; // simplify non-mem exprs
   std::unordered_set<Expr> m_addedToSolver;
 
   bool m_trackingOn = false;
@@ -181,6 +182,8 @@ public:
   Expr simplify(Expr u);
 
   bool shouldSimplify() { return m_shouldSimplify; }
+
+  bool shouldSimplifyNonMem() { return m_shouldSimplifyNonMem; }
 
   bool isTrackingOn() { return m_trackingOn; }
 

--- a/lib/seahorn/BvOpSem2ExtraWideMemMgr.cc
+++ b/lib/seahorn/BvOpSem2ExtraWideMemMgr.cc
@@ -119,7 +119,7 @@ Expr ExtraWideMemManager<T>::isDereferenceable(ExtraWideMemManager::PtrTy p,
   auto ptr_size = p.getSize();
   auto ptr_offset = p.getOffset();
 
-  if (m_ctx.shouldSimplify()) {
+  if (m_ctx.shouldSimplifyNonMem()) {
     ptr_size = m_ctx.simplify(p.getSize());
     ptr_offset = m_ctx.simplify(p.getOffset());
     byteSz = m_ctx.simplify(byteSz);

--- a/lib/seahorn/BvOpSem2RawMemMgr.cc
+++ b/lib/seahorn/BvOpSem2RawMemMgr.cc
@@ -643,7 +643,7 @@ RawMemManagerCore::MemValTy RawMemManagerCore::MemSet(PtrTy ptr, Expr _val,
                                                       Expr len, MemValTy mem,
                                                       uint32_t align) {
   auto simplifiedLength = len;
-  if (m_ctx.shouldSimplify()) {
+  if (m_ctx.shouldSimplifyNonMem()) {
     simplifiedLength = m_ctx.simplify(len);
   }
   if (m_ctx.alu().isNum(simplifiedLength)) {
@@ -684,7 +684,7 @@ RawMemManagerCore::MemValTy RawMemManagerCore::MemCpy(PtrTy dPtr, PtrTy sPtr,
                                                       MemValTy memRead,
                                                       uint32_t align) {
   auto simplifiedLength = len;
-  if (m_ctx.shouldSimplify()) {
+  if (m_ctx.shouldSimplifyNonMem()) {
     simplifiedLength = m_ctx.simplify(len);
   }
   if (m_ctx.alu().isNum(simplifiedLength)) {

--- a/lib/seahorn/BvOpSem2RawMemMgr.hh
+++ b/lib/seahorn/BvOpSem2RawMemMgr.hh
@@ -362,7 +362,8 @@ public:
   Bv2OpSemContext &ctx() const { return m_ctx; }
 
   /// \brief Add an alignment constrainst on given expr 'e'.
-  void makeMemAligned(std::pair<Expr, unsigned /* bitwidth */> e);
+  void makeMemAligned(std::pair<Expr, unsigned /* bitwidth */> e,
+                      unsigned minBitWidth = 0);
 };
 
 inline std::ostream &operator<<(std::ostream &OS,

--- a/lib/seahorn/BvOpSem2WideMemMgr.cc
+++ b/lib/seahorn/BvOpSem2WideMemMgr.cc
@@ -56,7 +56,7 @@ WideMemManager::getAddressable(WideMemManager::PtrTy p) const {
 Expr WideMemManager::isDereferenceable(WideMemManager::PtrTy p, Expr byteSz) {
   // size should be >= byteSz
   auto ptr_size = p.getSize();
-  if (m_ctx.shouldSimplify()) {
+  if (m_ctx.shouldSimplifyNonMem()) {
     ptr_size = m_ctx.simplify(p.getSize());
     byteSz = m_ctx.simplify(byteSz);
   }


### PR DESCRIPTION
Simplify len expression and if found to be a number, delegate to a concrete mempy, else continue with symbolic one. Also do not add alignment constraint on symb len if ignoreAlignment is set.