### PR TITLE
Lower umin and umax intrinsics

### DIFF
--- a/test/opsem/test_umax_sat.ll
+++ b/test/opsem/test_umax_sat.ll
@@ -1,0 +1,66 @@
+; RUN: %seabmc "%s" 2>&1 | %oc %s
+; RUN: %seabmc --horn-bv2-lambdas --log=opsem3 "%s" 2>&1 | %oc %s
+
+; CHECK: ^sat$
+; ModuleID = 'test_umax_sat.bc'
+source_filename = "unsigned_max.c"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-linux-gnu"
+
+@llvm.used = appending global [4 x i8*] [i8* bitcast (void ()* @seahorn.fail to i8*), i8* bitcast (void (i1)* @verifier.assume to i8*), i8* bitcast (void (i1)* @verifier.assume.not to i8*), i8* bitcast (void ()* @verifier.error to i8*)], section "llvm.metadata"
+
+declare i64 @nd_uint64_t() local_unnamed_addr #0
+
+; Function Attrs: inaccessiblememonly nofree norecurse nounwind
+declare void @seahorn.fail() #1
+
+; Function Attrs: mustprogress nofree nosync nounwind readnone speculatable willreturn
+declare i64 @llvm.umax.i64(i64, i64) #2
+
+; Function Attrs: inaccessiblememonly nofree norecurse nounwind
+declare void @verifier.assume(i1) #1
+
+; Function Attrs: inaccessiblememonly nofree norecurse nounwind
+declare void @verifier.assume.not(i1) #1
+
+; Function Attrs: inaccessiblememonly nofree norecurse noreturn nounwind
+declare void @verifier.error() #3
+
+; Function Attrs: inaccessiblememonly
+declare void @seahorn.fn.enter() local_unnamed_addr #4
+
+; Function Attrs: nounwind uwtable
+define dso_local i32 @main() local_unnamed_addr #5 {
+entry:
+  call void @seahorn.fn.enter() #6
+  %0 = call i64 @nd_uint64_t() #6
+  %1 = icmp ult i64 %0, 10
+  call void @verifier.assume(i1 %1) #6
+  %2 = call i64 @nd_uint64_t() #6
+  %3 = icmp ugt i64 %2, 5
+  call void @verifier.assume(i1 %3) #6
+  %4 = call i64 @llvm.umax.i64(i64 noundef %0, i64 noundef %2) #6
+  %5 = icmp ule i64 %4, 9
+  %.not.i = icmp uge i64 %2, %0
+  %or.cond.i = select i1 %5, i1 %.not.i, i1 false
+  call void @verifier.assume(i1 %or.cond.i)
+  call void @seahorn.fail()
+  ret i32 42
+}
+
+attributes #0 = { "frame-pointer"="none" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #1 = { inaccessiblememonly nofree norecurse nounwind }
+attributes #2 = { mustprogress nofree nosync nounwind readnone speculatable willreturn }
+attributes #3 = { inaccessiblememonly nofree norecurse noreturn nounwind }
+attributes #4 = { inaccessiblememonly }
+attributes #5 = { nounwind uwtable "frame-pointer"="none" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #6 = { nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 7, !"PIC Level", i32 2}
+!2 = !{i32 7, !"PIE Level", i32 2}
+!3 = !{i32 7, !"uwtable", i32 1}
+!4 = !{!"Ubuntu clang version 14.0.0-1ubuntu1.1"}

--- a/test/opsem/test_umax_unsat.ll
+++ b/test/opsem/test_umax_unsat.ll
@@ -1,0 +1,66 @@
+; RUN: %seabmc "%s" 2>&1 | %oc %s
+; RUN: %seabmc --horn-bv2-lambdas --log=opsem3 "%s" 2>&1 | %oc %s
+
+; CHECK: ^unsat$
+; ModuleID = 'test_umax_unsat.bc'
+source_filename = "unsigned_max.c"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-linux-gnu"
+
+@llvm.used = appending global [4 x i8*] [i8* bitcast (void ()* @seahorn.fail to i8*), i8* bitcast (void (i1)* @verifier.assume to i8*), i8* bitcast (void (i1)* @verifier.assume.not to i8*), i8* bitcast (void ()* @verifier.error to i8*)], section "llvm.metadata"
+
+declare i64 @nd_uint64_t() local_unnamed_addr #0
+
+; Function Attrs: inaccessiblememonly nofree norecurse nounwind
+declare void @seahorn.fail() #1
+
+; Function Attrs: mustprogress nofree nosync nounwind readnone speculatable willreturn
+declare i64 @llvm.umax.i64(i64, i64) #2
+
+; Function Attrs: inaccessiblememonly nofree norecurse nounwind
+declare void @verifier.assume(i1) #1
+
+; Function Attrs: inaccessiblememonly nofree norecurse nounwind
+declare void @verifier.assume.not(i1) #1
+
+; Function Attrs: inaccessiblememonly nofree norecurse noreturn nounwind
+declare void @verifier.error() #3
+
+; Function Attrs: inaccessiblememonly
+declare void @seahorn.fn.enter() local_unnamed_addr #4
+
+; Function Attrs: nounwind uwtable
+define dso_local i32 @main() local_unnamed_addr #5 {
+entry:
+  call void @seahorn.fn.enter() #6
+  %0 = call i64 @nd_uint64_t() #6
+  %1 = icmp ult i64 %0, 10
+  call void @verifier.assume(i1 %1) #6
+  %2 = call i64 @nd_uint64_t() #6
+  %3 = icmp ugt i64 %2, 5
+  call void @verifier.assume(i1 %3) #6
+  %4 = call i64 @llvm.umax.i64(i64 noundef %0, i64 noundef %2) #6
+  %5 = icmp ugt i64 %4, 9
+  %.not.i = icmp ult i64 %2, %0
+  %or.cond.i = select i1 %5, i1 %.not.i, i1 false
+  call void @verifier.assume(i1 %or.cond.i)
+  call void @seahorn.fail()
+  ret i32 42
+}
+
+attributes #0 = { "frame-pointer"="none" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #1 = { inaccessiblememonly nofree norecurse nounwind }
+attributes #2 = { mustprogress nofree nosync nounwind readnone speculatable willreturn }
+attributes #3 = { inaccessiblememonly nofree norecurse noreturn nounwind }
+attributes #4 = { inaccessiblememonly }
+attributes #5 = { nounwind uwtable "frame-pointer"="none" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #6 = { nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 7, !"PIC Level", i32 2}
+!2 = !{i32 7, !"PIE Level", i32 2}
+!3 = !{i32 7, !"uwtable", i32 1}
+!4 = !{!"Ubuntu clang version 14.0.0-1ubuntu1.1"}

--- a/test/opsem/test_umin_sat.ll
+++ b/test/opsem/test_umin_sat.ll
@@ -1,0 +1,66 @@
+; RUN: %seabmc "%s" 2>&1 | %oc %s
+; RUN: %seabmc --horn-bv2-lambdas --log=opsem3 "%s" 2>&1 | %oc %s
+
+; CHECK: ^sat$
+; ModuleID = 'test_umin_sat.bc'
+source_filename = "unsigned_min.c"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-linux-gnu"
+
+@llvm.used = appending global [4 x i8*] [i8* bitcast (void ()* @seahorn.fail to i8*), i8* bitcast (void (i1)* @verifier.assume to i8*), i8* bitcast (void (i1)* @verifier.assume.not to i8*), i8* bitcast (void ()* @verifier.error to i8*)], section "llvm.metadata"
+
+declare i64 @nd_uint64_t() local_unnamed_addr #0
+
+; Function Attrs: inaccessiblememonly nofree norecurse nounwind
+declare void @seahorn.fail() #1
+
+; Function Attrs: mustprogress nofree nosync nounwind readnone speculatable willreturn
+declare i64 @llvm.umin.i64(i64, i64) #2
+
+; Function Attrs: inaccessiblememonly nofree norecurse nounwind
+declare void @verifier.assume(i1) #1
+
+; Function Attrs: inaccessiblememonly nofree norecurse nounwind
+declare void @verifier.assume.not(i1) #1
+
+; Function Attrs: inaccessiblememonly nofree norecurse noreturn nounwind
+declare void @verifier.error() #3
+
+; Function Attrs: inaccessiblememonly
+declare void @seahorn.fn.enter() local_unnamed_addr #4
+
+; Function Attrs: nounwind uwtable
+define dso_local i32 @main() local_unnamed_addr #5 {
+entry:
+  call void @seahorn.fn.enter() #6
+  %0 = call i64 @nd_uint64_t() #6
+  %1 = icmp ult i64 %0, 10
+  call void @verifier.assume(i1 %1) #6
+  %2 = call i64 @nd_uint64_t() #6
+  %3 = icmp ugt i64 %2, 5
+  call void @verifier.assume(i1 %3) #6
+  %4 = call i64 @llvm.umin.i64(i64 noundef %0, i64 noundef %2) #6
+  %5 = icmp ule i64 %4, 9
+  %.not.i = icmp ugt i64 %2, %0
+  %or.cond.i = select i1 %5, i1 %.not.i, i1 false
+  call void @verifier.assume(i1 %or.cond.i)
+  call void @seahorn.fail()
+  ret i32 42
+}
+
+attributes #0 = { "frame-pointer"="none" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #1 = { inaccessiblememonly nofree norecurse nounwind }
+attributes #2 = { mustprogress nofree nosync nounwind readnone speculatable willreturn }
+attributes #3 = { inaccessiblememonly nofree norecurse noreturn nounwind }
+attributes #4 = { inaccessiblememonly }
+attributes #5 = { nounwind uwtable "frame-pointer"="none" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #6 = { nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 7, !"PIC Level", i32 2}
+!2 = !{i32 7, !"PIE Level", i32 2}
+!3 = !{i32 7, !"uwtable", i32 1}
+!4 = !{!"Ubuntu clang version 14.0.0-1ubuntu1.1"}

--- a/test/opsem/test_umin_unsat.ll
+++ b/test/opsem/test_umin_unsat.ll
@@ -1,0 +1,66 @@
+; RUN: %seabmc "%s" 2>&1 | %oc %s
+; RUN: %seabmc --horn-bv2-lambdas --log=opsem3 "%s" 2>&1 | %oc %s
+
+; CHECK: ^unsat$
+; ModuleID = 'test_umin_unsat.bc'
+source_filename = "unsigned_min.c"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-linux-gnu"
+
+@llvm.used = appending global [4 x i8*] [i8* bitcast (void ()* @seahorn.fail to i8*), i8* bitcast (void (i1)* @verifier.assume to i8*), i8* bitcast (void (i1)* @verifier.assume.not to i8*), i8* bitcast (void ()* @verifier.error to i8*)], section "llvm.metadata"
+
+declare i64 @nd_uint64_t() local_unnamed_addr #0
+
+; Function Attrs: inaccessiblememonly nofree norecurse nounwind
+declare void @seahorn.fail() #1
+
+; Function Attrs: mustprogress nofree nosync nounwind readnone speculatable willreturn
+declare i64 @llvm.umin.i64(i64, i64) #2
+
+; Function Attrs: inaccessiblememonly nofree norecurse nounwind
+declare void @verifier.assume(i1) #1
+
+; Function Attrs: inaccessiblememonly nofree norecurse nounwind
+declare void @verifier.assume.not(i1) #1
+
+; Function Attrs: inaccessiblememonly nofree norecurse noreturn nounwind
+declare void @verifier.error() #3
+
+; Function Attrs: inaccessiblememonly
+declare void @seahorn.fn.enter() local_unnamed_addr #4
+
+; Function Attrs: nounwind uwtable
+define dso_local i32 @main() local_unnamed_addr #5 {
+entry:
+  call void @seahorn.fn.enter() #6
+  %0 = call i64 @nd_uint64_t() #6
+  %1 = icmp ult i64 %0, 10
+  call void @verifier.assume(i1 %1) #6
+  %2 = call i64 @nd_uint64_t() #6
+  %3 = icmp ugt i64 %2, 5
+  call void @verifier.assume(i1 %3) #6
+  %4 = call i64 @llvm.umin.i64(i64 noundef %0, i64 noundef %2) #6
+  %5 = icmp ugt i64 %4, 9
+  %.not.i = icmp ugt i64 %2, %0
+  %or.cond.i = select i1 %5, i1 %.not.i, i1 false
+  call void @verifier.assume(i1 %or.cond.i)
+  call void @seahorn.fail()
+  ret i32 42
+}
+
+attributes #0 = { "frame-pointer"="none" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #1 = { inaccessiblememonly nofree norecurse nounwind }
+attributes #2 = { mustprogress nofree nosync nounwind readnone speculatable willreturn }
+attributes #3 = { inaccessiblememonly nofree norecurse noreturn nounwind }
+attributes #4 = { inaccessiblememonly }
+attributes #5 = { nounwind uwtable "frame-pointer"="none" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #6 = { nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 7, !"PIC Level", i32 2}
+!2 = !{i32 7, !"PIE Level", i32 2}
+!3 = !{i32 7, !"uwtable", i32 1}
+!4 = !{!"Ubuntu clang version 14.0.0-1ubuntu1.1"}


### PR DESCRIPTION
When LLVM applies optimizations, such as enabling the `-O3` flag, it might introduce intrinsics like `@llvm.umax`. These intrinsics are currently unhandled under bvopsem2. This commit implements a simple version to lower these intrinsic using ITE.