### PR TITLE
fix(opsem): only consider ptr address for equality

### DIFF
--- a/lib/seahorn/BvOpSem2ExtraWideMemMgr.cc
+++ b/lib/seahorn/BvOpSem2ExtraWideMemMgr.cc
@@ -62,9 +62,12 @@ Expr ExtraWideMemManager<T>::isMetadataSet(MetadataKind kind,
 template <class T>
 Expr ExtraWideMemManager<T>::ptrEq(ExtraWideMemManager::PtrTy p1,
                                    ExtraWideMemManager::PtrTy p2) const {
+  // NOTE: we consider two pointers to be same if their address (base and ofset)
+  //       is the same. Size is ignored. This is done to have parity with memset
+  //       like operations that zero out main memory but do not touch shadow
+  //       memory.
   return mk<AND>(m_main.ptrEq(p1.getBase(), p2.getBase()),
-                 m_offset.ptrEq(p1.getOffset(), p2.getOffset()),
-                 m_size.ptrEq(p1.getSize(), p2.getSize()));
+                 m_offset.ptrEq(p1.getOffset(), p2.getOffset()));
 }
 template <class T>
 Expr ExtraWideMemManager<T>::castPtrSzToSlotSz(const Expr val) const {


### PR DESCRIPTION
In https://github.com/seahorn/seahorn/commit/2eb1ddb2b014bed0c710a588c9aa23f54e1a1fd6 we added consideration for allocation size in equality predicate. This does not match behaviour of memset operation that does not touch metadata part of a pointer stored in memory. Instead of now requiring such operations to affect shadow memory, we retrograde to using address to compare pointers. This is also compatible with how ISO C compares with NULL pointers (address == 0).

Further, this opens up a question of how to model pointer provenance in general. Currently a malloc does not reuse allocations/addresses so <base,offset,size> can stand for provenance. If we introduce re-allocation then this tuple will not suffice. However, that problem is out of scope.

This will fix `verify-c-common` failures in https://github.com/seahorn/verify-c-common/actions/runs/8057645165