### PR TITLE
feat: ignore compile commands file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@
 .ccls
 .ccls-root
 CMakeUserPresets.json
+compile_commands.json


### PR DESCRIPTION
add compile_commands.json file to .gitignore to make git ignore this file when reviewing changes