### PR TITLE
intrinsics for ownsem 

### DIFF
--- a/include/seahorn/Analysis/SeaBuiltinsInfo.hh
+++ b/include/seahorn/Analysis/SeaBuiltinsInfo.hh
@@ -31,6 +31,19 @@ enum class SeaBuiltinsOp {
   FREE,               /* sea.free */
   SET_SHADOWMEM,      /* sea.set_shadowmem */
   GET_SHADOWMEM,      /* sea.get_shadowmem */
+  MK_OWN,
+  MK_SHR,
+  BOR_MKBOR,
+  BOR_MKBOR_PART,
+  BOR_MEM2REG, /* sea.bor_mem2reg */
+  MOV_REG2MEM, /* sea.bor_reg2mem */
+  BOR_MKSUC,
+  BEGIN_UNIQUE,
+  END_UNIQUE,
+  DIE,
+  MOVE,
+  SET_FATPTR_SLOT,
+  GET_FATPTR_SLOT,
   UNKNOWN
 };
 
@@ -55,6 +68,20 @@ class SeaBuiltinsInfo {
   llvm::Function *mkFreeFn(llvm::Module &M);
   llvm::Function *mkSetShadowMem(llvm::Module &M);
   llvm::Function *mkGetShadowMem(llvm::Module &M);
+  llvm::Function *mkMkOwn(llvm::Module &M);
+  llvm::Function *mkMkShr(llvm::Module &M);
+  llvm::Function *mkBorMkBor(llvm::Module &M);
+  llvm::Function *mkBorMkBorPart(llvm::Module &M);
+  llvm::Function *mkBorMkSuc(llvm::Module &M);
+  llvm::Function *mkBorMem2Reg(llvm::Module &M);
+  llvm::Function *mkMovReg2Mem(llvm::Module &M);
+  llvm::Function *mkBeginUnique(llvm::Module &M);
+  llvm::Function *mkEndUnique(llvm::Module &M);
+  llvm::Function *mkDie(llvm::Module &M);
+  llvm::Function *mkMove(llvm::Module &M);
+  llvm::Function *mkBorOffset(llvm::Module &M);
+  llvm::Function *mkSetFatPtrSlot(llvm::Module &M);
+  llvm::Function *mkGetFatPtrSlot(llvm::Module &M);
 
 public:
   SeaBuiltinsOp getSeaBuiltinOp(const llvm::CallBase &cb) const;

--- a/include/seahorn/Bmc.hh
+++ b/include/seahorn/Bmc.hh
@@ -93,6 +93,9 @@ public:
     return m_smt_solver.getModel();
   }
 
+  /// get z3 solver stats.
+  z3::stats getStats() { return m_smt_solver.stats(); }
+
   /// Returns the BMC trace (if available)
   ZBmcTraceTy getTrace();
 

--- a/include/seahorn/Expr/Smt/Z3.hh
+++ b/include/seahorn/Expr/Smt/Z3.hh
@@ -618,6 +618,8 @@ public:
     return res;
   }
 
+  z3::stats stats() { return solver.statistics(); }
+
   template <typename Range> boost::tribool solveAssuming(const Range &lits) {
     z3::ast_vector av(ctx);
     for (Expr a : lits)

--- a/include/seahorn/Transforms/Scalar/PromoteVerifierCalls.hh
+++ b/include/seahorn/Transforms/Scalar/PromoteVerifierCalls.hh
@@ -9,40 +9,53 @@
 #include "llvm/IR/Module.h"
 #include "llvm/Pass.h"
 
-namespace seahorn
-{
-  using namespace llvm;
-  
-  struct PromoteVerifierCalls : public ModulePass {
-    static char ID;
+namespace seahorn {
+using namespace llvm;
 
-    Function *m_assumeFn;
-    Function *m_assertFn;
-    Function *m_assertNotFn;
-    Function *m_synthAssumeFn;
-    Function *m_synthAssertFn;
-    Function *m_errorFn;
-    Function *m_failureFn; // to indicate failure. It can only appears in main.
-    Function *m_is_deref;
-    Function *m_assert_if;
-    Function *m_is_modified;
-    Function *m_reset_modified;
-    Function *m_is_read;
-    Function *m_reset_read;
-    Function *m_is_alloc;
-    Function *m_tracking_on;
-    Function *m_tracking_off;
-    Function *m_free;
-    Function *m_set_shadowmem;
-    Function *m_get_shadowmem;
+struct PromoteVerifierCalls : public ModulePass {
+  static char ID;
 
-    PromoteVerifierCalls() : ModulePass(ID) {}
+  Function *m_assumeFn;
+  Function *m_assertFn;
+  Function *m_assertNotFn;
+  Function *m_synthAssumeFn;
+  Function *m_synthAssertFn;
+  Function *m_errorFn;
+  Function *m_failureFn; // to indicate failure. It can only appears in main.
+  Function *m_is_deref;
+  Function *m_assert_if;
+  Function *m_is_modified;
+  Function *m_reset_modified;
+  Function *m_is_read;
+  Function *m_reset_read;
+  Function *m_is_alloc;
+  Function *m_tracking_on;
+  Function *m_tracking_off;
+  Function *m_free;
+  Function *m_set_shadowmem;
+  Function *m_get_shadowmem;
+  Function *m_mkOwn;
+  Function *m_mkShr;
+  Function *m_borMkBor;
+  Function *m_borMkSuc;
+  Function *m_begin_unique;
+  Function *m_end_unique;
+  Function *m_die;
+  Function *m_move;
+  Function *m_bor_mem2reg;
+  Function *m_mov_reg2mem;
+  Function *m_set_fatptr_slot;
+  Function *m_get_fatptr_slot;
 
-    bool runOnModule(Module &M) override;
-    bool runOnFunction(Function &F);
-    void getAnalysisUsage(AnalysisUsage &AU) const override;
-    virtual StringRef getPassName() const override { return "PromoteVerifierCalls"; }
-  };
-}
+  PromoteVerifierCalls() : ModulePass(ID) {}
+
+  bool runOnModule(Module &M) override;
+  bool runOnFunction(Function &F);
+  void getAnalysisUsage(AnalysisUsage &AU) const override;
+  virtual StringRef getPassName() const override {
+    return "PromoteVerifierCalls";
+  }
+};
+} // namespace seahorn
 
 #endif /* PROMOTEVERIFIERCALLS_H */

--- a/include/seahorn/ownsem.h
+++ b/include/seahorn/ownsem.h
@@ -1,0 +1,361 @@
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+#define cast_to(x, y) (decltype(x))(y)
+#else
+#define cast_to(x, y) (typeof(x))(y)
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern char *sea_begin_unique(char *);
+extern char *sea_end_unique(char *);
+extern char *__sea_set_extptr_slot0_hm(char *ptr, size_t val);
+extern size_t __sea_get_extptr_slot0_hm(char *ptr);
+extern char *__sea_set_extptr_slot1_hm(char *ptr, size_t val);
+extern size_t __sea_get_extptr_slot1_hm(char *ptr);
+extern char *sea_set_fatptr_slot(char *ptr, char slot, uint64_t val);
+extern uint64_t sea_get_fatptr_slot(char *ptr, char slot);
+extern char nd_char(void);
+extern uint64_t nd_uint64t(void);
+extern char *sea_bor_mkbor(char *);
+extern char *sea_bor_mksuc(char *);
+extern void sea_die(char *);
+extern char *sea_mkown(char *);
+extern char *sea_mkshr(char *);
+extern char *sea_bor_mem2reg(char *);
+extern char *sea_mov_reg2mem(char * /*dst_ptrtoptr*/, char * /*src_ptr*/);
+extern bool nd_bool(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+// Information to bit map
+#define HELD_BIT 0x2
+#define LENT_BIT 0x1
+#define OWN_BIT 0x0
+
+#define GET_BIT(x, loc) (((uint64_t)x & (1 << loc)) >> loc)
+
+#define SET_BIT(x, loc, boolean_value)                                         \
+  ((boolean_value) ? ((x) | ((uint64_t)1 << (loc)))                            \
+                   : ((x) & ~((uint64_t)1 << (loc))))
+
+#define GET_LENT(x) GET_BIT(x, LENT_BIT)
+#define SET_LENT(x, val) SET_BIT(x, LENT_BIT, val)
+
+#define GET_HELD(x) GET_BIT(x, HELD_BIT)
+#define SET_HELD(x, val) SET_BIT(x, HELD_BIT, val)
+
+/* FATPTR SLOT MAP
+ * slot0 -- carried val
+ * slot1 -- returned val at borrowed ptr
+ * slot2 -- borrow/ownership checking
+ **/
+#define CARRY_SLOT 0
+#define PROPHECY_SLOT 1
+#define OWNERSHIP_SLOT 2
+
+#ifdef OWNSEM_BORCHK
+#define borchk_assert(x) sassert(x)
+#define borchk_assume(x) assume(x)
+#else
+#define borchk_assert(x) ;
+#define borchk_assume(x) ;
+#endif
+
+#define SEA_SET_FATPTR_SLOT0(SRC, VAL)                                         \
+  do {                                                                         \
+    (SRC) =                                                                    \
+        cast_to(SRC, sea_set_fatptr_slot((char *)(SRC), 0, (uint64_t)VAL));    \
+  } while (0);
+
+#define SEA_SET_FATPTR_SLOT1(SRC, VAL)                                         \
+  do {                                                                         \
+    (SRC) =                                                                    \
+        cast_to(SRC, sea_set_fatptr_slot((char *)(SRC), 1, (uint64_t)VAL));    \
+  } while (0);
+
+#define SEA_SET_FATPTR_SLOT2(SRC, VAL)                                         \
+  do {                                                                         \
+    (SRC) =                                                                    \
+        cast_to(SRC, sea_set_fatptr_slot((char *)(SRC), 2, (uint64_t)VAL));    \
+  } while (0);
+
+#define SEA_SET_FATPTR_SLOT(SRC, SLOT, VAL)                                    \
+  do {                                                                         \
+    (SRC) =                                                                    \
+        cast_to(SRC, sea_set_fatptr_slot((char *)SRC, SLOT, (uint64_t)VAL));   \
+  } while (0);
+
+#define SEA_GET_FATPTR_SLOT0(SRC, VAL)                                         \
+  do {                                                                         \
+    (VAL) = cast_to(VAL, sea_get_fatptr_slot((char *)SRC, 0));                 \
+  } while (0);
+
+#define SEA_GET_FATPTR_SLOT1(SRC, VAL)                                         \
+  do {                                                                         \
+    (VAL) = cast_to(VAL, sea_get_fatptr_slot((char *)SRC, 1));                 \
+  } while (0);
+
+#define SEA_GET_FATPTR_SLOT2(SRC, VAL)                                         \
+  do {                                                                         \
+    (VAL) = cast_to(VAL, sea_get_fatptr_slot((char *)(SRC), 2));               \
+  } while (0);
+
+#define SEA_GET_FATPTR_SLOT(SRC, SLOT, VAL)                                    \
+  do {                                                                         \
+    (VAL) = cast_to(VAL, sea_get_fatptr_slot((char *)SRC, SLOT));              \
+  } while (0);
+
+#define SEA_GET_LENT(SRC, VAL)                                                 \
+  do {                                                                         \
+    uint64_t intmd;                                                            \
+    SEA_GET_FATPTR_SLOT2((char *)(SRC), intmd);                                \
+    (VAL) = GET_LENT(intmd);                                                   \
+  } while (0);
+
+#define SEA_SET_LENT(SRC, VAL)                                                 \
+  do {                                                                         \
+    uint64_t intmd;                                                            \
+    SEA_GET_FATPTR_SLOT2((SRC), intmd);                                        \
+    uint64_t new_intmd = SET_LENT(intmd, (bool)VAL);                           \
+    SEA_SET_FATPTR_SLOT2((SRC), new_intmd);                                    \
+  } while (0);
+
+#define SEA_GET_HELD(SRC, VAL)                                                 \
+  do {                                                                         \
+    uint64_t intmd;                                                            \
+    SEA_GET_FATPTR_SLOT2((SRC), intmd);                                        \
+    (VAL) = GET_HELD(intmd);                                                   \
+  } while (0);
+
+#define SEA_SET_HELD(SRC, VAL)                                                 \
+  do {                                                                         \
+    uint64_t intmd;                                                            \
+    SEA_GET_FATPTR_SLOT2((SRC), intmd);                                        \
+    uint64_t new_intmd = SET_HELD(intmd, (bool)VAL);                           \
+    SEA_SET_FATPTR_SLOT2((char *)(SRC), (uint64_t)new_intmd);                  \
+  } while (0);
+
+#define ENTANGLE_BIT(SRC, SRC_SLOT, SRC_SLOT_BIT, DST, DST_SLOT, DST_SLOT_BIT, \
+                     PROPHECY_VAR)                                             \
+  do {                                                                         \
+    uint64_t intmd_src;                                                        \
+    SEA_GET_FATPTR_SLOT(SRC, SRC_SLOT, intmd_src);                             \
+    uint64_t intmd_dst;                                                        \
+    SEA_GET_FATPTR_SLOT(DST, DST_SLOT, intmd_dst);                             \
+    uint64_t new_intmd_src = SET_BIT(intmd_src, SRC_SLOT_BIT, PROPHECY_VAR);   \
+    uint64_t new_intmd_dst = SET_BIT(intmd_dst, DST_SLOT_BIT, PROPHECY_VAR);   \
+    SEA_SET_FATPTR_SLOT(SRC, SRC_SLOT, new_intmd_src);                         \
+    SEA_SET_FATPTR_SLOT(DST, DST_SLOT, new_intmd_dst);                         \
+  } while (0);
+
+// NOTE: intrinsic
+#define SEA_MKOWN(SRC)                                                         \
+  do {                                                                         \
+    uint64_t nd_slot0 = nd_uint64t();                                          \
+    uint64_t nd_slot1 = nd_uint64t();                                          \
+    char *intmd0, *intmd1, *intmd2;                                            \
+    intmd0 = sea_mkown((char *)(SRC));                                         \
+    SEA_SET_FATPTR_SLOT0(intmd0, nd_slot0);                                    \
+    SEA_SET_FATPTR_SLOT1(intmd0, nd_slot1);                                    \
+    (SRC) = (typeof(SRC))intmd0;                                               \
+    /* Set lent field to false  */                                             \
+    SEA_SET_LENT(SRC, false);                                                  \
+  } while (0)
+
+#define SEA_MKOWN_FAST(SRC)                                                    \
+  do {                                                                         \
+    uint64_t nd_slot0 = nd_uint64t();                                          \
+    uint64_t nd_slot1 = nd_uint64t();                                          \
+    char *intmd0, *intmd1, *intmd2;                                            \
+    intmd0 = sea_mkown((char *)(SRC));                                         \
+    SEA_SET_FATPTR_SLOT0(intmd0, nd_slot0);                                    \
+    SEA_SET_FATPTR_SLOT1(intmd0, nd_slot1);                                    \
+    (SRC) = (typeof(SRC))intmd0;                                               \
+  } while (0)
+
+#define SEA_FK_MKOWN(SRC)                                                      \
+  do {                                                                         \
+    SRC = (typeof(SRC))sea_mkown((char *)(SRC));                               \
+  } while (0)
+
+// NOTE: intrinsic
+#define SEA_MKSHR(SRC)                                                         \
+  do {                                                                         \
+    (SRC) = (typeof(SRC))sea_mkshr((char *)(SRC));                             \
+  } while (0)
+
+// NOTE: intrinsic
+#define SEA_BEGIN_UNIQUE(SRC)                                                  \
+  do {                                                                         \
+    (SRC) = (typeof(SRC))sea_begin_unique((char *)(SRC));                      \
+  } while (0)
+
+// NOTE: intrinsic
+#define SEA_END_UNIQUE(SRC)                                                    \
+  do {                                                                         \
+    (SRC) = (typeof(SRC))sea_end_unique((char *)(SRC));                        \
+  } while (0)
+
+// NOTE: intrinsic
+#define SEA_BEGIN_UNIQUE_AND_LOAD_CACHE(SRC, VAL)                              \
+  do {                                                                         \
+    (SRC) = (typeof(SRC))sea_begin_unique((char *)SRC);                        \
+    SEA_SET_FATPTR_SLOT0((SRC), VAL);                                          \
+  } while (0)
+
+// TODO: make cache nd after unloading
+// NOTE: intrinsic
+#define SEA_UNLOAD_CACHE_AND_END_UNIQUE(SRC, DSTADDRESS, DSTLEN)               \
+  do {                                                                         \
+    char uniqval = __sea_get_extptr_slot0_hm((char *)SRC);                     \
+    (SRC) = (typeof(SRC))sea_end_unique((char *)(SRC));                        \
+    memset((char *)DSTADDRESS, uniqval, 1 /* FIXME: use DSTLEN */);            \
+  } while (0)
+
+// NOTE: intrinsic
+#define SEA_WRITE_CACHE(SRC, VAL)                                              \
+  do {                                                                         \
+    SEA_SET_FATPTR_SLOT0(SRC, (VAL));                                          \
+  } while (0)
+
+// NOTE: intrinsic
+#define SEA_READ_CACHE(VAL, SRC)                                               \
+  do {                                                                         \
+    SEA_GET_FATPTR_SLOT0((char *)SRC, VAL);                                    \
+  } while (0)
+
+// NOTE: intrinsic
+#define SEA_FK_BORROW(BOR, SRC)                                                \
+  do {                                                                         \
+    (BOR) = cast_to(BOR, sea_bor_mkbor((char *)SRC));                          \
+    (SRC) = cast_to(SRC, sea_bor_mksuc((char *)SRC));                          \
+  } while (0);
+
+#ifdef OWNSEM_BORCHK
+#define SEA_BORROW(BOR, SRC) SEA_BORROW_CHK(BOR, SRC)
+#else
+#define SEA_BORROW(BOR, SRC) SEA_BORROW_CHK(BOR, SRC)
+#endif
+
+#define SEA_BORROW_FAST(BOR, SRC)                                              \
+  do {                                                                         \
+    (BOR) = cast_to(BOR, sea_bor_mkbor((char *)SRC));                          \
+    (SRC) = cast_to(SRC, sea_bor_mksuc((char *)SRC));                          \
+    uint64_t brval;                                                            \
+    SEA_GET_FATPTR_SLOT0((SRC), brval);                                        \
+    SEA_SET_FATPTR_SLOT0((BOR), brval);                                        \
+    uint64_t ndval = nd_uint64t();                                             \
+    SEA_SET_FATPTR_SLOT1((BOR), ndval)                                         \
+    SEA_SET_FATPTR_SLOT0((SRC), ndval);                                        \
+  } while (0);
+
+#define SEA_BORROW_CHK(BOR, SRC)                                               \
+  do {                                                                         \
+    uint64_t src_own_data;                                                     \
+    SEA_GET_FATPTR_SLOT(SRC, OWNERSHIP_SLOT, src_own_data);                    \
+    bool is_lent = GET_LENT(src_own_data);                                     \
+    borchk_assert(!is_lent);                                                   \
+    (BOR) = cast_to(BOR, sea_bor_mkbor((char *)SRC));                          \
+    (SRC) = cast_to(SRC, sea_bor_mksuc((char *)SRC));                          \
+    uint64_t brval;                                                            \
+    SEA_GET_FATPTR_SLOT0((SRC), brval);                                        \
+    SEA_SET_FATPTR_SLOT0((BOR), brval);                                        \
+    uint64_t ndval = nd_uint64t();                                             \
+    SEA_SET_FATPTR_SLOT1((BOR), ndval)                                         \
+    SEA_SET_FATPTR_SLOT0((SRC), ndval);                                        \
+    /*borrow logic: choose action: */                                          \
+    /*borrow logic: SRC gives new loan or SRC transfers held loan  */          \
+    bool create_loan = nd_bool();                                              \
+    if (create_loan) {                                                         \
+      /* 1. create new loan  */                                                \
+      bool fresh_loan = nd_bool();                                             \
+      /* 2. entangle src lent bit and dst held bit */                          \
+      ENTANGLE_BIT(SRC, OWNERSHIP_SLOT, LENT_BIT, BOR, OWNERSHIP_SLOT,         \
+                   HELD_BIT, fresh_loan);                                      \
+    } else {                                                                   \
+      /*Transfer: Held loan already copied to BOR; */                          \
+      /*just set SRC held loan to false */                                     \
+      uint64_t own_data;                                                       \
+      SEA_GET_FATPTR_SLOT(SRC, OWNERSHIP_SLOT, own_data);                      \
+      uint64_t new_own_data = SET_HELD(own_data, false);                       \
+      SEA_SET_FATPTR_SLOT(SRC, OWNERSHIP_SLOT, new_own_data);                  \
+    }                                                                          \
+    /* Borrow lent bit should be false */                                      \
+    uint64_t bor_data;                                                         \
+    SEA_GET_FATPTR_SLOT(BOR, OWNERSHIP_SLOT, bor_data);                        \
+    uint64_t new_bor_data = SET_LENT(bor_data, false);                         \
+    SEA_SET_FATPTR_SLOT(BOR, OWNERSHIP_SLOT, new_bor_data);                    \
+  } while (0);
+
+#define SEA_MOVE2MEM(PTR_TO_SRC_PTR, SRC)                                      \
+  do {                                                                         \
+    (SRC) = (typeof(SRC))sea_mov_reg2mem((char *)SRC, (char *)PTR_TO_SRC_PTR); \
+    *(PTR_TO_SRC_PTR) = (typeof(SRC))(SRC);                                    \
+  } while (0);
+
+#ifdef OWNSEM_BORCHK
+#define SEA_DIE(SRC) SEA_DIE_CHK(SRC)
+#else
+#define SEA_DIE(SRC) SEA_DIE_FAST(SRC)
+#endif
+
+// NOTE: intrinsic
+#define SEA_DIE_FAST(SRC)                                                      \
+  do {                                                                         \
+    uint64_t nd_retval;                                                        \
+    SEA_GET_FATPTR_SLOT1((char *)(SRC), nd_retval);                            \
+    uint64_t cacheval;                                                         \
+    SEA_GET_FATPTR_SLOT0((char *)(SRC), cacheval);                             \
+    assume(nd_retval == cacheval);                                             \
+    sea_die((char *)(SRC));                                                    \
+  } while (0);
+
+// NOTE: intrinsic
+#define SEA_DIE_CHK(SRC)                                                       \
+  do {                                                                         \
+    uint64_t nd_retval;                                                        \
+    SEA_GET_FATPTR_SLOT1((char *)(SRC), nd_retval);                            \
+    uint64_t cacheval;                                                         \
+    SEA_GET_FATPTR_SLOT0((char *)(SRC), cacheval);                             \
+    assume(nd_retval == cacheval);                                             \
+    bool lent;                                                                 \
+    SEA_GET_LENT((char *)SRC, lent);                                           \
+    borchk_assert(lent == false);                                              \
+    bool held;                                                                 \
+    SEA_GET_HELD((char *)SRC, held);                                           \
+    borchk_assume(held == false);                                              \
+    sea_die((char *)(SRC));                                                    \
+  } while (0)
+
+// NOTE: intrinsic
+#define SEA_LOAD_CACHE_AND_BORROW(BOR, SRC, VAL)                               \
+  do {                                                                         \
+    char *intmd = __sea_set_extptr_slot0_hm((char *)(SRC), (VAL));             \
+    SEA_BORROW((BOR), intmd);                                                  \
+  } while (0)
+
+// NOTE: intrinsic
+#define SEA_BORROW_OFFSET(BOR_OFF, SRC, OFFSET)                                \
+  do {                                                                         \
+    char *boroff_intmd0;                                                       \
+    SEA_BORROW(boroff_intmd0, SRC);                                            \
+    (BOR_OFF) = ((typeof(BOR_OFF))(boroff_intmd0)) + OFFSET;                   \
+  } while (0)
+
+// NOTE: intrinsic
+#define SEA_BORROW_LOAD(BOR, PTR_TO_SRC_PTR)                                   \
+  do {                                                                         \
+    char *intmd_ptrptrto = sea_bor_mem2reg((char *)(PTR_TO_SRC_PTR));          \
+    typeof(BOR)(mem2reg_ptr) = *((typeof(PTR_TO_SRC_PTR))intmd_ptrptrto);      \
+    SEA_BORROW(BOR, mem2reg_ptr);                                              \
+    *(PTR_TO_SRC_PTR) = mem2reg_ptr;                                           \
+  } while (0)

--- a/include/seahorn/seahorn.h
+++ b/include/seahorn/seahorn.h
@@ -1,5 +1,8 @@
 #ifndef _SEAHORN__H_
 #define _SEAHORN__H_
+
+#include <seahorn/ownsem.h>
+
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -52,12 +55,18 @@ extern void sea_reset_modified(char *);
  * arg1 - A
  * arg2 - V
  */
-extern void sea_set_shadowmem(char, char *, char);
+extern void sea_set_shadowmem(char, char *, size_t);
 /* Get a value from shadow memory slot S at address A.
  * arg0 - S. Note that 0 is main memory and should not be used.
  * arg1 - A
  */
-extern char sea_get_shadowmem(char, char *);
+extern size_t sea_get_shadowmem(char, char *);
+#define TRACK_READ_MEM 0
+#define TRACK_WRITE_MEM 1
+#define TRACK_ALLOC_MEM 2
+#define TRACK_CUSTOM0_MEM 3
+#define TRACK_CUSTOM1_MEM 4
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/Transforms/Scalar/PromoteVerifierCalls.cc
+++ b/lib/Transforms/Scalar/PromoteVerifierCalls.cc
@@ -102,6 +102,18 @@ bool PromoteVerifierCalls::runOnModule(Module &M) {
   m_free = SBI.mkSeaBuiltinFn(SBIOp::FREE, M);
   m_set_shadowmem = SBI.mkSeaBuiltinFn(SBIOp::SET_SHADOWMEM, M);
   m_get_shadowmem = SBI.mkSeaBuiltinFn(SBIOp::GET_SHADOWMEM, M);
+  m_mkOwn = SBI.mkSeaBuiltinFn(SBIOp::MK_OWN, M);
+  m_mkShr = SBI.mkSeaBuiltinFn(SBIOp::MK_SHR, M);
+  m_borMkBor = SBI.mkSeaBuiltinFn(SBIOp::BOR_MKBOR, M);
+  m_borMkSuc = SBI.mkSeaBuiltinFn(SBIOp::BOR_MKSUC, M);
+  m_begin_unique = SBI.mkSeaBuiltinFn(SBIOp::BEGIN_UNIQUE, M);
+  m_end_unique = SBI.mkSeaBuiltinFn(SBIOp::END_UNIQUE, M);
+  m_die = SBI.mkSeaBuiltinFn(SBIOp::DIE, M);
+  m_move = SBI.mkSeaBuiltinFn(SBIOp::MOVE, M);
+  m_bor_mem2reg = SBI.mkSeaBuiltinFn(SBIOp::BOR_MEM2REG, M);
+  m_mov_reg2mem = SBI.mkSeaBuiltinFn(SBIOp::MOV_REG2MEM, M);
+  m_set_fatptr_slot = SBI.mkSeaBuiltinFn(SBIOp::SET_FATPTR_SLOT, M);
+  m_get_fatptr_slot = SBI.mkSeaBuiltinFn(SBIOp::GET_FATPTR_SLOT, M);
 
   // XXX DEPRECATED
   // Do not keep unused functions in llvm.used
@@ -170,6 +182,18 @@ bool PromoteVerifierCalls::runOnFunction(Function &F) {
       {"sea_free", {m_free, 1}},
       {"sea_set_shadowmem", {m_set_shadowmem, 3}},
       {"sea_get_shadowmem", {m_get_shadowmem, 2}},
+      {"sea_mkown", {m_mkOwn, 1}},
+      {"sea_mkshr", {m_mkShr, 1}},
+      {"sea_bor_mkbor", {m_borMkBor, 1}},
+      {"sea_bor_mksuc", {m_borMkSuc, 1}},
+      {"sea_begin_unique", {m_begin_unique, 1}},
+      {"sea_end_unique", {m_end_unique, 1}},
+      {"sea_die", {m_die, 1}},
+      {"sea_mov", {m_move, 1}},
+      {"sea_bor_mem2reg", {m_bor_mem2reg, 1}},
+      {"sea_mov_reg2mem", {m_mov_reg2mem, 2}},
+      {"sea_set_fatptr_slot", {m_set_fatptr_slot, 3}},
+      {"sea_get_fatptr_slot", {m_get_fatptr_slot, 2}},
   };
 
   auto replaceFn = [](Instruction &I, std::pair<Function *, unsigned> f,

--- a/lib/seahorn/BmcPass.cc
+++ b/lib/seahorn/BmcPass.cc
@@ -346,6 +346,23 @@ public:
       Stats::sset("Result", "TRUE");
 
     LOG(
+        "bmc_z3stats", z3::stats stats = bmc.getStats();
+        llvm::SmallString<1024> msg;
+        llvm::raw_svector_ostream out(msg); for (unsigned i = 0;
+                                                 i < stats.size(); ++i) {
+          out << "Z3_STAT " << stats.key(i) << ": ";
+          if (stats.is_uint(i)) {
+            out << stats.uint_value(i);
+          } else if (stats.is_double(i)) {
+            out << stats.double_value(i);
+          } else {
+            // Fallback for any unexpected type, though Z3 typically uses uint
+            // and double.
+            out << "Unknown value type";
+          }
+          out << "\n";
+        } errs() << out.str(););
+    LOG(
         "bmc_core",
         // producing bmc core is expensive. Enable only if specifically
         // requested

--- a/lib/seahorn/BvOpSem2Context.hh
+++ b/lib/seahorn/BvOpSem2Context.hh
@@ -26,6 +26,7 @@ enum class MetadataKind {
   WRITE = 1,
   ALLOC = 2,
   CUSTOM0 = 3,
+  CUSTOM1 = 4,
 };
 
 namespace MemoryFeatures {
@@ -768,6 +769,8 @@ public:
   virtual Expr getRawMem(Expr p) = 0;
 
   virtual size_t getNumOfMetadataSlots() = 0;
+
+  virtual Expr getAddressable(PtrTy p) const = 0;
 };
 
 OpSemMemManager *mkRawMemManager(Bv2OpSem &sem, Bv2OpSemContext &ctx,

--- a/lib/seahorn/BvOpSem2ExtraWideMemMgr.hh
+++ b/lib/seahorn/BvOpSem2ExtraWideMemMgr.hh
@@ -15,7 +15,7 @@
 namespace seahorn {
 namespace details {
 
-template <class T> class ExtraWideMemManager : public MemManagerCore {
+template <class T> class ExtraWideMemManagerCore : public MemManagerCore {
 
   /// \brief Base name for non-deterministic pointer
   Expr m_freshPtrName;
@@ -82,6 +82,7 @@ public:
 
     MemValTyImpl(RawMemValTy &&raw_val, Expr &&offset_val, Expr &&size_val) {
       assert(!strct::isStructVal(size_val));
+      auto a = {raw_val, offset_val, size_val};
       m_v = strct::mk(std::move(raw_val), std::move(offset_val),
                       std::move(size_val));
     }
@@ -89,6 +90,7 @@ public:
     MemValTyImpl(const RawPtrTy &raw_val, const Expr &offset_val,
                  const Expr &size_val) {
       assert(!strct::isStructVal(size_val));
+      auto a = {raw_val, offset_val, size_val};
       m_v = strct::mk(raw_val, offset_val, size_val);
     }
 
@@ -159,10 +161,10 @@ public:
   /// \brief A null pointer expression (cache)
   PtrTy m_nullPtr;
 
-  ExtraWideMemManager(Bv2OpSem &sem, Bv2OpSemContext &ctx, unsigned ptrSz,
-                      unsigned wordSz, bool useLambdas = false);
+  ExtraWideMemManagerCore(Bv2OpSem &sem, Bv2OpSemContext &ctx, unsigned ptrSz,
+                          unsigned wordSz, bool useLambdas = false);
 
-  ~ExtraWideMemManager() = default;
+  ~ExtraWideMemManagerCore() = default;
 
   Expr bytesToSlotExpr(unsigned bytes);
 
@@ -267,25 +269,26 @@ public:
 
   Expr isDereferenceable(PtrTy p, Expr byteSz);
 
-  typename ExtraWideMemManager<T>::RawMemValTy
-  setModified(ExtraWideMemManager::PtrTy ptr,
-              ExtraWideMemManager::MemValTy mem);
+  typename ExtraWideMemManagerCore<T>::RawMemValTy
+  setModified(ExtraWideMemManagerCore::PtrTy ptr,
+              ExtraWideMemManagerCore::MemValTy mem);
 
-  Expr isMetadataSet(MetadataKind kind, ExtraWideMemManager::PtrTy ptr,
-                     ExtraWideMemManager::MemValTy mem);
+  Expr isMetadataSet(MetadataKind kind, ExtraWideMemManagerCore::PtrTy ptr,
+                     ExtraWideMemManagerCore::MemValTy mem);
 
-  typename ExtraWideMemManager<T>::MemValTy
-  setMetadata(MetadataKind kind, ExtraWideMemManager::PtrTy ptr,
-              ExtraWideMemManager::MemValTy mem, Expr val);
+  typename ExtraWideMemManagerCore<T>::MemValTy
+  setMetadata(MetadataKind kind, ExtraWideMemManagerCore::PtrTy ptr,
+              ExtraWideMemManagerCore::MemValTy mem, Expr val);
 
-  typename ExtraWideMemManager<T>::MemValTy
-  memsetMetadata(MetadataKind kind, ExtraWideMemManager::PtrTy ptr,
-                 unsigned int len, ExtraWideMemManager::MemValTy memIn,
+  typename ExtraWideMemManagerCore<T>::MemValTy
+  memsetMetadata(MetadataKind kind, ExtraWideMemManagerCore::PtrTy ptr,
+                 unsigned int len, ExtraWideMemManagerCore::MemValTy memIn,
                  unsigned int val);
 
-  typename ExtraWideMemManager<T>::MemValTy
-  memsetMetadata(MetadataKind kind, ExtraWideMemManager::PtrTy ptr, Expr len,
-                 ExtraWideMemManager::MemValTy memIn, unsigned int val);
+  typename ExtraWideMemManagerCore<T>::MemValTy
+  memsetMetadata(MetadataKind kind, ExtraWideMemManagerCore::PtrTy ptr,
+                 Expr len, ExtraWideMemManagerCore::MemValTy memIn,
+                 unsigned int val);
 
   Expr getMetadata(MetadataKind kind, PtrTy ptr, MemValTy memIn,
                    unsigned int byteSz);
@@ -327,5 +330,13 @@ OpSemMemManager *mkTrackingExtraWideMemManager(Bv2OpSem &sem,
                                                Bv2OpSemContext &ctx,
                                                unsigned ptrSz, unsigned wordSz,
                                                bool useLambdas);
+// ExtraWide with Tracking MemManager
+using EWWTMemManager = OpSemMemManagerMixin<
+    ExtraWideMemManagerCore<OpSemMemManagerMixin<TrackingRawMemManager>>>;
+
+// ExtraWide with Tracking MemManager
+using EWWMemManager = OpSemMemManagerMixin<
+    ExtraWideMemManagerCore<OpSemMemManagerMixin<RawMemManagerCore>>>;
+
 } // namespace details
 } // namespace seahorn

--- a/lib/seahorn/BvOpSem2FatMemMgr.cc
+++ b/lib/seahorn/BvOpSem2FatMemMgr.cc
@@ -1,7 +1,8 @@
+#include "BvOpSem2FatMemMgr.hh"
 #include "BvOpSem2Context.hh"
-#include "BvOpSem2RawMemMgr.hh"
-
+#include "BvOpSem2ExtraWideMemMgr.hh"
 #include "BvOpSem2MemManagerMixin.hh"
+#include "BvOpSem2RawMemMgr.hh"
 
 #include "llvm/IR/GetElementPtrTypeIterator.h"
 #include "llvm/Support/Format.h"
@@ -11,600 +12,798 @@
 #include "seahorn/Support/SeaDebug.h"
 #include "seahorn/Support/SeaLog.hh"
 
+#include <boost/variant.hpp>
+
+static llvm::cl::opt<unsigned> FatMemSlots(
+    "horn-bv2-num-fat-slots",
+    llvm::cl::desc("Number of fat slots to initiate FatMemManager with"),
+    llvm::cl::init(3));
+
 namespace seahorn {
 namespace details {
 
-static const unsigned int g_slotBitWidth = 64;
-static const unsigned int g_slotByteWidth = g_slotBitWidth / 8;
+template <class T> unsigned FatMemManagerCore<T>::g_FatMemSlots;
 
-static const unsigned int g_maxFatSlots = 2;
-/// \brief provides Fat pointers and Fat memory to store them
-class FatMemManager : public MemManagerCore {
-public:
-  /// PtrTy representation for this manager
-  ///
-  /// Currently internal representation is just an Expr
-  struct PtrTyImpl {
-    Expr m_v;
-    PtrTyImpl(Expr &&e) : m_v(std::move(e)) {}
-    PtrTyImpl(const Expr &e) : m_v(e) {}
-
-    Expr v() const { return m_v; }
-    Expr toExpr() const { return v(); }
-    explicit operator Expr() const { return toExpr(); }
-  };
-
-  /// MemValTy representation for this manager
-  ///
-  /// Currently internal representation is just an Expr
-  struct MemValTyImpl {
-    Expr m_v;
-    MemValTyImpl(Expr &&e) : m_v(std::move(e)) {}
-    MemValTyImpl(const Expr &e) : m_v(e) {}
-
-    Expr v() const { return m_v; }
-    Expr toExpr() const { return v(); }
-    explicit operator Expr() const { return toExpr(); }
-    Expr getRaw() { return strct::extractVal(m_v, 0); }
-  };
-
-  using FatMemTag = MemoryFeatures::FatMem_tag;
-  using TrackingTag = int;
-  using WideMemTag = int;
-
-  /// Right now everything is an expression. In the future, we might have
-  /// other types for PtrTy, such as a tuple of expressions
-  using BasePtrTy = OpSemMemManager::PtrTy;
-  using RawPtrTy = OpSemMemManager::PtrTy;
-  using BaseMemValTy = OpSemMemManager::MemValTy;
-
-  using FatMemValTy = MemValTyImpl;
-  using FatPtrTy = PtrTyImpl;
-
-  using PtrTy = FatPtrTy;
-  using MemValTy = FatMemValTy;
-  using PtrSortTy = OpSemMemManager::PtrSortTy;
-  using MemSortTy = OpSemMemManager::MemSortTy;
-  using MemRegTy = OpSemMemManager::MemRegTy;
-
-  // TODO: change all slot0,1 methods to return these types for easier reading
-  using Slot0ValTy = Expr;
-  using Slot1ValTy = Expr;
-
-private:
-  /// \brief Memory manager for raw pointers
-  RawMemManager m_main;
-  RawMemManager m_slot0;
-  RawMemManager m_slot1;
-
-  /// \brief A null pointer expression (cache)
-  FatPtrTy m_nullPtr;
-
-  /// \brief Converts a raw ptr to fat ptr with default value for fat
-  FatPtrTy mkFatPtr(RawPtrTy rawPtr) const {
-    return strct::mk(rawPtr, m_ctx.alu().ui(0, g_slotBitWidth),
-                     m_ctx.alu().ui(1, g_slotBitWidth));
+/// \brief Converts a raw ptr to fat ptr with default value for fat
+template <class T>
+typename FatMemManagerCore<T>::PtrTy
+FatMemManagerCore<T>::mkFatPtr(MainPtrTy mainPtr) const {
+  llvm::SmallVector<AnyPtrTy, 8> ptrVals;
+  ptrVals.push_back(mainPtr);
+  // assign fresh (nd) values to fat slots
+  for (unsigned i = 0; i < g_FatMemSlots; i++) {
+    llvm::SmallString<100> tempStorage;
+    auto fullName = m_fatMemBaseName + "slot" + std::to_string(i);
+    auto fullNameExpr =
+        mkTerm<std::string>(fullName.toStringRef(tempStorage).str(), m_efac);
+    Expr freshSlotVal = op::variant::variant(m_id, fullNameExpr);
+    Expr slotBind =
+        bind::mkConst(freshSlotVal, m_ctx.alu().intTy(g_slotBitWidth));
+    m_id++;
+    ptrVals.push_back(slotBind);
   }
+  return PtrTy(ptrVals);
+}
 
-  /// \brief Converts a raw ptr to fat ptr with default value for fat
-  FatPtrTy mkFatPtr(RawPtrTy rawPtr, Slot0ValTy data0, Slot1ValTy data1) const {
-    // TODO: check if data0 and data1 bitwidth is <= max or always guaranteed?
-    return strct::mk(rawPtr, data0, data1);
+/// \brief Assembles a fat ptr from parts
+template <class T>
+typename FatMemManagerCore<T>::PtrTy
+FatMemManagerCore<T>::mkFatPtr(llvm::SmallVector<AnyPtrTy, 8> slots) const {
+  return PtrTy(slots);
+}
+
+/// \brief Update a given fat pointer with a "main" address value
+template <class T>
+typename FatMemManagerCore<T>::PtrTy
+FatMemManagerCore<T>::updateFatPtr(MainPtrTy mainPtr, PtrTy fat) const {
+  if (fat.v()->arity() == 1)
+    return mkFatPtr(mainPtr);
+
+  llvm::SmallVector<AnyPtrTy, 8> kids;
+  assert(fat.v()->arity() == g_FatMemSlots + 1);
+  kids.push_back(mainPtr);
+  for (unsigned i = 1; i <= g_FatMemSlots; i++) {
+    kids.push_back(fat.v()->arg(i));
   }
+  return PtrTy(strct::mk(kids));
+}
 
-  /// \brief Update a given fat pointer with a raw address value
-  FatPtrTy mkFatPtr(RawPtrTy rawPtr, FatPtrTy fat) const {
-    if (fat.v()->arity() == 1)
-      return mkFatPtr(rawPtr);
+/// \brief Extracts a "main" pointer out of a fat pointer
+template <class T>
+typename FatMemManagerCore<T>::MainPtrTy
+FatMemManagerCore<T>::mkMainPtr(PtrTy fatPtr) const {
+  assert(strct::isStructVal(fatPtr.v()));
+  return fatPtr.getMain();
+}
 
+/// \brief Extracts a "main" memory value from a fat memory value
+template <class T>
+typename FatMemManagerCore<T>::MainMemValTy
+FatMemManagerCore<T>::mkMainMem(MemValTy fatMem) const {
+  assert(strct::isStructVal(fatMem.v()));
+  return fatMem.getMain();
+}
+
+template <class T>
+typename FatMemManagerCore<T>::RawMemValTy
+FatMemManagerCore<T>::mkSlot0Mem(MemValTy fatMem) const {
+  assert(strct::isStructVal(fatMem.v()));
+  return fatMem.getSlot(1);
+}
+
+template <class T>
+typename FatMemManagerCore<T>::RawMemValTy
+FatMemManagerCore<T>::mkSlot1Mem(MemValTy fatMem) const {
+  assert(strct::isStructVal(fatMem.v()));
+  return fatMem.getSlot(2);
+}
+
+/// \brief Creates a fat memory value from raw memory with given values
+/// for fat
+template <class T>
+typename FatMemManagerCore<T>::MemValTy
+FatMemManagerCore<T>::mkFatMem(llvm::SmallVector<AnyMemValTy, 8> vals) const {
+  return MemValTy(vals);
+}
+
+template <class T>
+typename FatMemManagerCore<T>::PtrSortTy FatMemManagerCore<T>::ptrSort() const {
+  llvm::SmallVector<AnyPtrSortTy, 8> sorts;
+  sorts.push_back(m_main.ptrSort());
+  for (unsigned i = 0; i < g_FatMemSlots; i++) {
+    sorts.push_back(m_ctx.alu().intTy(g_slotBitWidth));
+  }
+  return PtrSortTy(sorts);
+}
+
+/// \brief Allocates memory on the stack and returns a pointer to it
+/// \param align is requested alignment. If 0, default alignment is used
+template <class T>
+typename FatMemManagerCore<T>::PtrTy
+FatMemManagerCore<T>::salloc(unsigned bytes, uint32_t align) {
+  auto e = m_main.salloc(bytes, align);
+  return mkFatPtr(e);
+}
+
+/// \brief Allocates memory on the stack and returns a pointer to it
+template <class T>
+typename FatMemManagerCore<T>::PtrTy
+FatMemManagerCore<T>::salloc(Expr elmts, unsigned typeSz, uint32_t align) {
+  auto e = m_main.salloc(elmts, typeSz, align);
+  return mkFatPtr(e);
+}
+
+/// \brief Returns a pointer value for a given stack allocation
+template <class T>
+typename FatMemManagerCore<T>::PtrTy
+FatMemManagerCore<T>::mkStackPtr(unsigned offset) {
+  return mkFatPtr(m_main.mkStackPtr(offset));
+}
+
+/// \brief Pointer to start of the heap
+/// \brief Returns a pointer value for a given stack allocation
+template <class T>
+typename FatMemManagerCore<T>::PtrTy FatMemManagerCore<T>::brk0Ptr() {
+  return mkFatPtr(m_main.brk0Ptr());
+}
+
+/// \brief Allocates memory on the heap and returns a pointer to it
+template <class T>
+typename FatMemManagerCore<T>::PtrTy
+FatMemManagerCore<T>::halloc(unsigned _bytes, uint32_t align) {
+  return mkFatPtr(m_main.halloc(_bytes, align));
+}
+
+/// \brief Allocates memory on the heap and returns pointer to it
+template <class T>
+typename FatMemManagerCore<T>::PtrTy
+FatMemManagerCore<T>::halloc(Expr bytes, uint32_t align) {
+  return mkFatPtr(m_main.halloc(bytes, align));
+}
+
+/// \brief Allocates memory in global (data/bss) segment for given global
+template <class T>
+typename FatMemManagerCore<T>::PtrTy
+FatMemManagerCore<T>::galloc(const GlobalVariable &gv, uint32_t align) {
+  for (auto memMgr : m_slots) {
+    memMgr.galloc(gv, align);
+  }
+  return mkFatPtr(m_main.galloc(gv, align));
+}
+
+/// \brief Allocates memory in code segment for the code of a given
+/// function
+template <class T>
+typename FatMemManagerCore<T>::PtrTy
+FatMemManagerCore<T>::falloc(const Function &fn) {
+  return mkFatPtr(m_main.falloc(fn));
+}
+
+/// \brief Returns a function pointer value for a given function
+template <class T>
+typename FatMemManagerCore<T>::PtrTy
+FatMemManagerCore<T>::getPtrToFunction(const Function &F) {
+  return mkFatPtr(m_main.getPtrToFunction(F));
+}
+
+/// \brief Returns a pointer to a global variable
+template <class T>
+typename FatMemManagerCore<T>::PtrTy
+FatMemManagerCore<T>::getPtrToGlobalVariable(const GlobalVariable &gv) {
+  return mkFatPtr(m_main.getPtrToGlobalVariable(gv));
+}
+
+/// \brief Initialize memory used by the global variable
+template <class T>
+void FatMemManagerCore<T>::initGlobalVariable(const GlobalVariable &gv) const {
+  m_main.initGlobalVariable(gv);
+}
+
+/// \brief Creates a non-deterministic pointer that is aligned
+///
+/// Top bits of the pointer are named by \p name and last \c log2(align)
+/// bits are set to zero
+template <class T>
+typename FatMemManagerCore<T>::PtrTy
+FatMemManagerCore<T>::mkAlignedPtr(Expr name, uint32_t align) const {
+  return mkFatPtr(m_main.mkAlignedPtr(name, align));
+}
+
+/// \brief Returns sort of a pointer register for an instruction
+template <class T>
+typename FatMemManagerCore<T>::PtrSortTy
+FatMemManagerCore<T>::mkPtrRegisterSort(const Instruction &inst) const {
+  llvm::SmallVector<AnyPtrSortTy, 8> sorts;
+  sorts.push_back(m_main.mkPtrRegisterSort(inst));
+  for (unsigned i = 0; i < g_FatMemSlots; i++) {
+    sorts.push_back(m_ctx.alu().intTy(g_slotBitWidth));
+  }
+  return PtrSortTy(sorts);
+}
+
+/// \brief Returns sort of a pointer register for a function pointer
+template <class T>
+typename FatMemManagerCore<T>::PtrSortTy
+FatMemManagerCore<T>::mkPtrRegisterSort(const Function &fn) const {
+  return ptrSort();
+}
+
+/// \brief Returns sort of a pointer register for a global pointer
+template <class T>
+typename FatMemManagerCore<T>::PtrSortTy
+FatMemManagerCore<T>::mkPtrRegisterSort(const GlobalVariable &gv) const {
+  return ptrSort();
+}
+
+/// \brief Returns sort of memory-holding register for an instruction
+template <class T>
+typename FatMemManagerCore<T>::MemSortTy
+FatMemManagerCore<T>::mkMemRegisterSort(const Instruction &inst) const {
+  llvm::SmallVector<AnyMemSortTy, 8> sorts;
+  sorts.push_back(m_main.mkMemRegisterSort(inst));
+  for (auto memMgr : m_slots) {
+    sorts.push_back(memMgr.mkMemRegisterSort(inst));
+  }
+  return MemSortTy(sorts);
+}
+
+/// \brief Returns a fresh aligned pointer value
+template <class T>
+typename FatMemManagerCore<T>::PtrTy FatMemManagerCore<T>::freshPtr() {
+  return mkFatPtr(m_main.freshPtr());
+}
+
+/// \brief Returns a null ptr
+template <class T>
+typename FatMemManagerCore<T>::PtrTy FatMemManagerCore<T>::nullPtr() const {
+  return mkFatPtr(m_main.nullPtr());
+}
+
+/// \brief Fixes the type of a havoced value to mach the representation
+/// used by mem repr.
+///
+/// \param sort
+/// \param val
+/// \return the coerced value.
+template <class T> Expr FatMemManagerCore<T>::coerce(Expr sort, Expr val) {
+  if (strct::isStructVal(val)) {
+    // recursively coerce struct-ty
     llvm::SmallVector<Expr, 8> kids;
-    kids.push_back(rawPtr);
-    for (unsigned i = 1, sz = fat.v()->arity(); i < sz; ++i) {
-      kids.push_back(fat.v()->arg(i));
-    }
+    assert(isOp<STRUCT_TY>(sort));
+    assert(sort->arity() == val->arity());
+    assert(sort->arity() == 1 + g_FatMemSlots);
+    kids.push_back(m_main.coerce(sort->arg(0), val->arg(0)));
+    for (unsigned i = 1, sz = val->arity(); i < sz; ++i)
+      kids.push_back(m_slots[i - 1].coerce(sort->arg(i), val->arg(i)));
     return strct::mk(kids);
   }
 
-  /// \brief Extracts a raw pointer out of a fat pointer
-  RawPtrTy mkRawPtr(FatPtrTy fatPtr) const {
-    assert(strct::isStructVal(fatPtr.v()));
-    return strct::extractVal(fatPtr.v(), 0);
+  return m_main.coerce(sort, val);
+}
+
+/// \brief Loads an integer of a given size from 'raw' memory register
+///
+/// \param[in] ptr pointer being accessed
+/// \param[in] mem memory value into which \p ptr points
+/// \param[in] byteSz size of the integer in bytes
+/// \param[in] align known alignment of \p ptr
+/// \return symbolic value of the read integer
+template <class T>
+Expr FatMemManagerCore<T>::loadIntFromMem(PtrTy ptr, MemValTy mem,
+                                          unsigned byteSz, uint64_t align) {
+  return m_main.loadIntFromMem(mkMainPtr(ptr), mkMainMem(mem), byteSz, align);
+}
+
+/// \brief Loads a pointer stored in memory
+/// \sa loadIntFromMem
+template <class T>
+typename FatMemManagerCore<T>::PtrTy
+FatMemManagerCore<T>::loadPtrFromMem(PtrTy ptr, MemValTy mem, unsigned byteSz,
+                                     uint64_t align) {
+  llvm::SmallVector<AnyPtrTy, 8> ptrVals;
+
+  MainPtrTy rawVal =
+      m_main.loadPtrFromMem(mkMainPtr(ptr), mkMainMem(mem), byteSz, align);
+  ptrVals.push_back(rawVal);
+  RawPtrTy rawPtr = getAddressable(ptr);
+  for (unsigned i = 1; i <= g_FatMemSlots; i++) {
+    auto slotVal = m_slots[i - 1].loadIntFromMem(rawPtr, mem.getSlot(i),
+                                                 g_slotByteWidth, align);
+    ptrVals.push_back(slotVal);
   }
+  return mkFatPtr(ptrVals);
+}
 
-  /// \brief Extracts a raw memory value from a fat memory value
-  BaseMemValTy mkRawMem(FatMemValTy fatMem) const {
-    assert(strct::isStructVal(fatMem.v()));
-    return strct::extractVal(fatMem.v(), 0);
+/// \brief Pointer addition with numeric offset
+template <class T>
+typename FatMemManagerCore<T>::PtrTy
+FatMemManagerCore<T>::ptrAdd(PtrTy ptr, int32_t _offset) const {
+  MainPtrTy mainPtr = m_main.ptrAdd(mkMainPtr(ptr), _offset);
+  return updateFatPtr(mainPtr, ptr);
+}
+
+/// \brief Pointer addition with symbolic offset
+template <class T>
+typename FatMemManagerCore<T>::PtrTy
+FatMemManagerCore<T>::ptrAdd(PtrTy ptr, Expr offset) const {
+  MainPtrTy mainPtr = m_main.ptrAdd(mkMainPtr(ptr), offset);
+  return updateFatPtr(mainPtr, ptr);
+}
+
+/// \brief Stores an integer into memory
+///
+/// Returns an expression describing the state of memory in \c memReadReg
+/// after the store
+/// \sa loadIntFromMem
+template <class T>
+typename FatMemManagerCore<T>::MemValTy
+FatMemManagerCore<T>::storeIntToMem(Expr _val, PtrTy ptr, MemValTy mem,
+                                    unsigned byteSz, uint64_t align) {
+  llvm::SmallVector<AnyMemValTy, 8> memVals;
+  assert(!strct::isStructVal(_val));
+  memVals.push_back(m_main.storeIntToMem(_val, mkMainPtr(ptr), mkMainMem(mem),
+                                         byteSz, align));
+  for (unsigned i = 1; i <= g_FatMemSlots; i++) {
+    memVals.push_back(mem.getSlot(i));
   }
+  return mkFatMem(memVals);
+}
 
-  BaseMemValTy mkSlot0Mem(FatMemValTy fatMem) const {
-    assert(strct::isStructVal(fatMem.v()));
-    return strct::extractVal(fatMem.v(), 1);
+/// \brief Stores a pointer into memory
+/// \sa storeIntToMem
+template <class T>
+typename FatMemManagerCore<T>::MemValTy
+FatMemManagerCore<T>::storePtrToMem(PtrTy val, PtrTy ptr, MemValTy mem,
+                                    unsigned byteSz, uint64_t align) {
+  llvm::SmallVector<AnyMemValTy, 8> memVals;
+
+  MainMemValTy main = m_main.storePtrToMem(mkMainPtr(val), mkMainPtr(ptr),
+                                           mkMainMem(mem), byteSz, align);
+  memVals.push_back(main);
+  RawPtrTy rawPtr = getAddressable(ptr);
+  for (unsigned i = 1; i <= g_FatMemSlots; i++) {
+    MainMemValTy slotVal = m_slots[i - 1].storeIntToMem(
+        val.getSlot(i), rawPtr, mem.getSlot(i), g_slotByteWidth, align);
+    memVals.push_back(slotVal);
   }
+  return mkFatMem(memVals);
+}
 
-  BaseMemValTy mkSlot1Mem(FatMemValTy fatMem) const {
-    assert(strct::isStructVal(fatMem.v()));
-    return strct::extractVal(fatMem.v(), 2);
-  }
+/// \brief Returns an expression corresponding to a load from memory
+///
+/// \param[in] ptr is the pointer being dereferenced
+/// \param[in] memReg is the memory register being read
+/// \param[in] ty is the type of value being loaded
+/// \param[in] align is the known alignment of the load
+template <class T>
+Expr FatMemManagerCore<T>::loadValueFromMem(PtrTy ptr, MemValTy mem,
+                                            const llvm::Type &ty,
+                                            uint64_t align) {
 
-  /// \brief Creates a fat memory value from raw memory with default value for
-  /// fat
-  FatMemValTy mkFatMem(BaseMemValTy rawMem, BaseMemValTy slot0Mem,
-                       BaseMemValTy slot1Mem) const {
-    return strct::mk(rawMem, slot0Mem, slot1Mem);
-  }
+  const unsigned byteSz =
+      m_sem.getTD().getTypeStoreSize(const_cast<llvm::Type *>(&ty));
+  // ExprFactory &efac = ptr.v()->efac();
 
-public:
-  FatMemManager(Bv2OpSem &sem, Bv2OpSemContext &ctx, unsigned ptrSz,
-                unsigned wordSz, bool useLambdas = false);
-
-  ~FatMemManager() = default;
-
-  PtrSortTy ptrSort() const {
-    return sort::structTy(m_main.ptrSort(), m_ctx.alu().intTy(g_slotBitWidth),
-                          m_ctx.alu().intTy(g_slotBitWidth));
-  }
-
-  /// \brief Allocates memory on the stack and returns a pointer to it
-  /// \param align is requested alignment. If 0, default alignment is used
-  FatPtrTy salloc(unsigned bytes, uint32_t align = 0) {
-    auto e = m_main.salloc(bytes, align);
-    m_slot0.salloc(bytes, align);
-    m_slot1.salloc(bytes, align);
-    return mkFatPtr(e);
-  }
-
-  /// \brief Allocates memory on the stack and returns a pointer to it
-  FatPtrTy salloc(Expr elmts, unsigned typeSz, uint32_t align = 0) {
-    auto e = m_main.salloc(elmts, typeSz, align);
-    m_slot0.salloc(elmts, typeSz, align);
-    m_slot1.salloc(elmts, typeSz, align);
-    return mkFatPtr(e);
-  }
-
-  /// \brief Returns a pointer value for a given stack allocation
-  FatPtrTy mkStackPtr(unsigned offset) {
-    return mkFatPtr(m_main.mkStackPtr(offset));
-  }
-
-  /// \brief Pointer to start of the heap
-  FatPtrTy brk0Ptr() { return mkFatPtr(m_main.brk0Ptr()); }
-
-  /// \brief Allocates memory on the heap and returns a pointer to it
-  FatPtrTy halloc(unsigned _bytes, uint32_t align = 0) {
-    m_slot0.halloc(_bytes, align);
-    m_slot1.halloc(_bytes, align);
-    return mkFatPtr(m_main.halloc(_bytes, align));
-  }
-
-  /// \brief Allocates memory on the heap and returns pointer to it
-  FatPtrTy halloc(Expr bytes, uint32_t align = 0) {
-    m_slot0.halloc(bytes, align);
-    m_slot1.halloc(bytes, align);
-    return mkFatPtr(m_main.halloc(bytes, align));
-  }
-
-  /// \brief Allocates memory in global (data/bss) segment for given global
-  FatPtrTy galloc(const GlobalVariable &gv, uint32_t align = 0) {
-    m_slot0.galloc(gv, align);
-    m_slot1.galloc(gv, align);
-    return mkFatPtr(m_main.galloc(gv, align));
-  }
-
-  /// \brief Allocates memory in code segment for the code of a given
-  /// function
-  FatPtrTy falloc(const Function &fn) {
-    m_slot0.falloc(fn);
-    m_slot1.falloc(fn);
-    return mkFatPtr(m_main.falloc(fn));
-  }
-
-  /// \brief Returns a function pointer value for a given function
-  FatPtrTy getPtrToFunction(const Function &F) {
-    m_slot0.getPtrToFunction(F);
-    m_slot1.getPtrToFunction(F);
-    return mkFatPtr(m_main.getPtrToFunction(F));
-  }
-
-  /// \brief Returns a pointer to a global variable
-  FatPtrTy getPtrToGlobalVariable(const GlobalVariable &gv) {
-    m_slot0.getPtrToGlobalVariable(gv);
-    m_slot1.getPtrToGlobalVariable(gv);
-    return mkFatPtr(m_main.getPtrToGlobalVariable(gv));
-  }
-
-  /// \brief Initialize memory used by the global variable
-  void initGlobalVariable(const GlobalVariable &gv) const {
-    m_main.initGlobalVariable(gv);
-    m_slot0.initGlobalVariable(gv);
-    m_slot1.initGlobalVariable(gv);
-  }
-
-  /// \brief Creates a non-deterministic pointer that is aligned
-  ///
-  /// Top bits of the pointer are named by \p name and last \c log2(align)
-  /// bits are set to zero
-  FatPtrTy mkAlignedPtr(Expr name, uint32_t align) const {
-    m_slot0.mkAlignedPtr(name, align);
-    m_slot1.mkAlignedPtr(name, align);
-    return mkFatPtr(m_main.mkAlignedPtr(name, align));
-  }
-
-  /// \brief Returns sort of a pointer register for an instruction
-  Expr mkPtrRegisterSort(const Instruction &inst) const {
-    return sort::structTy(m_main.mkPtrRegisterSort(inst),
-                          m_ctx.alu().intTy(g_slotBitWidth),
-                          m_ctx.alu().intTy(g_slotBitWidth));
-  }
-
-  /// \brief Returns sort of a pointer register for a function pointer
-  PtrSortTy mkPtrRegisterSort(const Function &fn) const { return ptrSort(); }
-
-  /// \brief Returns sort of a pointer register for a global pointer
-  Expr mkPtrRegisterSort(const GlobalVariable &gv) const { return ptrSort(); }
-
-  /// \brief Returns sort of memory-holding register for an instruction
-  Expr mkMemRegisterSort(const Instruction &inst) const {
-    return sort::structTy(m_main.mkMemRegisterSort(inst),
-                          m_slot0.mkMemRegisterSort(inst),
-                          m_slot1.mkMemRegisterSort(inst));
-  }
-
-  /// \brief Returns a fresh aligned pointer value
-  FatPtrTy freshPtr() { return mkFatPtr(m_main.freshPtr()); }
-
-  /// \brief Returns a null ptr
-  FatPtrTy nullPtr() const { return m_nullPtr; }
-
-  /// \brief Fixes the type of a havoced value to mach the representation used
-  /// by mem repr.
-  ///
-  /// \param sort
-  /// \param val
-  /// \return the coerced value.
-  Expr coerce(Expr sort, Expr val) {
-    if (strct::isStructVal(val)) {
-      // recursively coerce struct-ty
-      llvm::SmallVector<Expr, 8> kids;
-      assert(isOp<STRUCT_TY>(sort));
-      assert(sort->arity() == val->arity());
-      for (unsigned i = 0, sz = val->arity(); i < sz; ++i)
-        kids.push_back(coerce(sort->arg(i), val->arg(i)));
-      return strct::mk(kids);
-    }
-
-    return m_main.coerce(sort, val);
-  }
-
-  /// \brief Loads an integer of a given size from 'raw' memory register
-  ///
-  /// \param[in] ptr pointer being accessed
-  /// \param[in] mem memory value into which \p ptr points
-  /// \param[in] byteSz size of the integer in bytes
-  /// \param[in] align known alignment of \p ptr
-  /// \return symbolic value of the read integer
-  Expr loadIntFromMem(FatPtrTy ptr, FatMemValTy mem, unsigned byteSz,
-                      uint64_t align) {
-    return m_main.loadIntFromMem(mkRawPtr(ptr), mkRawMem(mem), byteSz, align);
-  }
-
-  /// \brief Loads a pointer stored in memory
-  /// \sa loadIntFromMem
-  FatPtrTy loadPtrFromMem(FatPtrTy ptr, FatMemValTy mem, unsigned byteSz,
-                          uint64_t align) {
-    BaseMemValTy rawVal =
-        m_main.loadPtrFromMem(mkRawPtr(ptr), mkRawMem(mem), byteSz, align);
-    BaseMemValTy slot0Val = m_slot0.loadIntFromMem(
-        mkRawPtr(ptr), mkSlot0Mem(mem), g_slotByteWidth, align);
-    BaseMemValTy slot1Val = m_slot1.loadIntFromMem(
-        mkRawPtr(ptr), mkSlot1Mem(mem), g_slotByteWidth, align);
-    return mkFatPtr(rawVal, slot0Val, slot1Val);
-  }
-
-  /// \brief Pointer addition with numeric offset
-  FatPtrTy ptrAdd(FatPtrTy ptr, int32_t _offset) const {
-    BasePtrTy rawPtr = m_main.ptrAdd(mkRawPtr(ptr), _offset);
-    return mkFatPtr(rawPtr, ptr);
-  }
-
-  /// \brief Pointer addition with symbolic offset
-  FatPtrTy ptrAdd(FatPtrTy ptr, Expr offset) const {
-    BasePtrTy rawPtr = m_main.ptrAdd(mkRawPtr(ptr), offset);
-    return mkFatPtr(rawPtr, ptr);
-  }
-
-  /// \brief Stores an integer into memory
-  ///
-  /// Returns an expression describing the state of memory in \c memReadReg
-  /// after the store
-  /// \sa loadIntFromMem
-  FatMemValTy storeIntToMem(Expr _val, FatPtrTy ptr, FatMemValTy mem,
-                            unsigned byteSz, uint64_t align) {
-    return mkFatMem(
-        m_main.storeIntToMem(_val, mkRawPtr(ptr), mkRawMem(mem), byteSz, align),
-        mkSlot0Mem(mem), mkSlot1Mem(mem));
-  }
-
-  /// \brief Stores a pointer into memory
-  /// \sa storeIntToMem
-  FatMemValTy storePtrToMem(FatPtrTy val, FatPtrTy ptr, FatMemValTy mem,
-                            unsigned byteSz, uint64_t align) {
-    BaseMemValTy main = m_main.storePtrToMem(mkRawPtr(val), mkRawPtr(ptr),
-                                             mkRawMem(mem), byteSz, align);
-    BaseMemValTy slot0 =
-        m_slot0.storeIntToMem(getFatData(val, 0), mkRawPtr(ptr),
-                              mkSlot0Mem(mem), g_slotByteWidth, align);
-    BaseMemValTy slot1 =
-        m_slot1.storeIntToMem(getFatData(val, 1), mkRawPtr(ptr),
-                              mkSlot1Mem(mem), g_slotByteWidth, align);
-    auto res = mkFatMem(main, slot0, slot1);
+  Expr res;
+  switch (ty.getTypeID()) {
+  case Type::IntegerTyID:
+    res = loadIntFromMem(ptr, mem, byteSz, align);
+    if (res && ty.getScalarSizeInBits() < byteSz * 8)
+      res = m_ctx.alu().doTrunc(res, ty.getScalarSizeInBits());
+    break;
+  case Type::FloatTyID:
+  case Type::DoubleTyID:
+  case Type::X86_FP80TyID:
+    errs() << "Error: load of float/double is not supported\n";
+    llvm_unreachable(nullptr);
+    break;
+  case Type::FixedVectorTyID:
+  case Type::ScalableVectorTyID:
+    errs() << "Error: load of fixed vectors is not supported\n";
+    llvm_unreachable(nullptr);
+    break;
+  case Type::PointerTyID:
+    res = loadPtrFromMem(ptr, mem, byteSz, align).v();
+    break;
+  case Type::StructTyID:
+    errs() << "loading form struct type " << ty << " is not supported";
     return res;
+  default:
+    SmallString<256> msg;
+    raw_svector_ostream out(msg);
+    out << "Loading from type: " << ty << " is not supported\n";
+    assert(false);
   }
+  return res;
+}
 
-  /// \brief Returns an expression corresponding to a load from memory
-  ///
-  /// \param[in] ptr is the pointer being dereferenced
-  /// \param[in] memReg is the memory register being read
-  /// \param[in] ty is the type of value being loaded
-  /// \param[in] align is the known alignment of the load
-  Expr loadValueFromMem(FatPtrTy ptr, FatMemValTy mem, const llvm::Type &ty,
-                        uint64_t align) {
+template <class T>
+typename FatMemManagerCore<T>::MemValTy
+FatMemManagerCore<T>::storeValueToMem(Expr _val, PtrTy ptr, MemValTy memIn,
+                                      const llvm::Type &ty, uint32_t align) {
+  assert(ptr.v());
+  Expr val = _val;
+  const unsigned byteSz =
+      m_sem.getTD().getTypeStoreSize(const_cast<llvm::Type *>(&ty));
 
-    const unsigned byteSz =
-        m_sem.getTD().getTypeStoreSize(const_cast<llvm::Type *>(&ty));
-    // ExprFactory &efac = ptr.v()->efac();
-
-    Expr res;
-    switch (ty.getTypeID()) {
-    case Type::IntegerTyID:
-      res = loadIntFromMem(ptr, mem, byteSz, align);
-      if (res && ty.getScalarSizeInBits() < byteSz * 8)
-        res = m_ctx.alu().doTrunc(res, ty.getScalarSizeInBits());
-      break;
-    case Type::FloatTyID:
-    case Type::DoubleTyID:
-    case Type::X86_FP80TyID:
-      errs() << "Error: load of float/double is not supported\n";
-      llvm_unreachable(nullptr);
-      break;
-    case Type::FixedVectorTyID:
-    case Type::ScalableVectorTyID:        
-      errs() << "Error: load of fixed vectors is not supported\n";
-      llvm_unreachable(nullptr);
-      break;
-    case Type::PointerTyID:
-      res = loadPtrFromMem(ptr, mem, byteSz, align).v();
-      break;
-    case Type::StructTyID:
-      errs() << "loading form struct type " << ty << " is not supported";
-      return res;
-    default:
-      SmallString<256> msg;
-      raw_svector_ostream out(msg);
-      out << "Loading from type: " << ty << " is not supported\n";
-      assert(false);
+  MemValTy res = MemValTy(Expr());
+  switch (ty.getTypeID()) {
+  case Type::IntegerTyID:
+    if (ty.getScalarSizeInBits() < byteSz * 8) {
+      val = m_ctx.alu().doZext(val, byteSz * 8, ty.getScalarSizeInBits());
     }
+    res = storeIntToMem(val, ptr, memIn, byteSz, align);
+    break;
+  case Type::FloatTyID:
+  case Type::DoubleTyID:
+  case Type::X86_FP80TyID:
+    errs() << "Error: store of float/double is not supported\n";
+    llvm_unreachable(nullptr);
+    break;
+  case Type::FixedVectorTyID:
+  case Type::ScalableVectorTyID:
+    errs() << "Error: store of vectors is not supported\n";
+    llvm_unreachable(nullptr);
+    break;
+  case Type::PointerTyID:
+    res = storePtrToMem(PtrTy(val), ptr, memIn, byteSz, align);
+    break;
+  case Type::StructTyID:
+    WARN << "Storing struct type " << ty << " is not supported\n";
     return res;
+  default:
+    SmallString<256> msg;
+    raw_svector_ostream out(msg);
+    out << "Loading from type: " << ty << " is not supported\n";
+    assert(false);
+    report_fatal_error(out.str());
   }
+  return res;
+}
 
-  FatMemValTy storeValueToMem(Expr _val, FatPtrTy ptr, FatMemValTy memIn,
-                              const llvm::Type &ty, uint32_t align) {
-    assert(ptr.v());
-    Expr val = _val;
-    const unsigned byteSz =
-        m_sem.getTD().getTypeStoreSize(const_cast<llvm::Type *>(&ty));
-    // ExprFactory &efac = ptr.v()->efac();
+/// \brief Executes symbolic memset with a concrete length
+template <class T>
+typename FatMemManagerCore<T>::MemValTy
+FatMemManagerCore<T>::MemSet(PtrTy ptr, Expr _val, unsigned len, MemValTy mem,
+                             uint32_t align) {
+  llvm::SmallVector<AnyMemValTy, 8> memVals;
+  memVals.push_back(
+      m_main.MemSet(mkMainPtr(ptr), _val, len, mkMainMem(mem), align));
+  for (unsigned i = 1; i <= g_FatMemSlots; i++) {
+    memVals.push_back(mem.getSlot(i));
+  }
+  return mkFatMem(memVals);
+}
 
-    FatMemValTy res(Expr(nullptr));
-    switch (ty.getTypeID()) {
-    case Type::IntegerTyID:
-      if (ty.getScalarSizeInBits() < byteSz * 8) {
-        val = m_ctx.alu().doZext(val, byteSz * 8, ty.getScalarSizeInBits());
-      }
-      res = storeIntToMem(val, ptr, memIn, byteSz, align);
-      break;
-    case Type::FloatTyID:
-    case Type::DoubleTyID:
-    case Type::X86_FP80TyID:
-      errs() << "Error: store of float/double is not supported\n";
-      llvm_unreachable(nullptr);
-      break;
-    case Type::FixedVectorTyID:
-    case Type::ScalableVectorTyID:        
-      errs() << "Error: store of vectors is not supported\n";
-      llvm_unreachable(nullptr);
-      break;
-    case Type::PointerTyID:
-      res = storePtrToMem(val, ptr, memIn, byteSz, align);
-      break;
-    case Type::StructTyID:
-      WARN << "Storing struct type " << ty << " is not supported\n";
-      return res;
-    default:
-      SmallString<256> msg;
-      raw_svector_ostream out(msg);
-      out << "Loading from type: " << ty << " is not supported\n";
-      assert(false);
-      report_fatal_error(out.str());
+template <class T>
+typename FatMemManagerCore<T>::MemValTy
+FatMemManagerCore<T>::MemSet(PtrTy ptr, Expr _val, Expr len, MemValTy mem,
+                             uint32_t align) {
+  llvm::SmallVector<AnyMemValTy, 8> memVals;
+  memVals.push_back(
+      m_main.MemSet(mkMainPtr(ptr), _val, len, mkMainMem(mem), align));
+  for (unsigned i = 1; i <= g_FatMemSlots; i++) {
+    memVals.push_back(mem.getSlot(i));
+  }
+  return mkFatMem(memVals);
+}
+
+/// \brief Executes symbolic memcpy with concrete length
+template <class T>
+typename FatMemManagerCore<T>::MemValTy
+FatMemManagerCore<T>::MemCpy(PtrTy dPtr, PtrTy sPtr, unsigned len,
+                             MemValTy memTrsfrRead, MemValTy memRead,
+                             uint32_t align) {
+  llvm::SmallVector<AnyMemValTy, 8> memVals;
+  memVals.push_back(m_main.MemCpy(mkMainPtr(dPtr), mkMainPtr(sPtr), len,
+                                  mkMainMem(memTrsfrRead), mkMainMem(memRead),
+                                  align));
+  RawPtrTy rawPtrDst = getAddressable(dPtr);
+  RawPtrTy rawPtrSrc = getAddressable(sPtr);
+  for (unsigned i = 1; i <= g_FatMemSlots; i++) {
+    memVals.push_back(m_slots[i - 1].MemCpy(rawPtrDst, rawPtrSrc, len,
+                                            memTrsfrRead.getSlot(i),
+                                            memRead.getSlot(i), align));
+  }
+  return mkFatMem(memVals);
+}
+
+/// \brief Executes symbolic memcpy with concrete length
+template <class T>
+typename FatMemManagerCore<T>::MemValTy
+FatMemManagerCore<T>::MemCpy(PtrTy dPtr, PtrTy sPtr, Expr len,
+                             MemValTy memTrsfrRead, MemValTy memRead,
+                             uint32_t align) {
+  llvm::SmallVector<AnyMemValTy, 8> memVals;
+  memVals.push_back(m_main.MemCpy(mkMainPtr(dPtr), mkMainPtr(sPtr), len,
+                                  mkMainMem(memTrsfrRead), mkMainMem(memRead),
+                                  align));
+  RawPtrTy rawPtrDst = getAddressable(dPtr);
+  RawPtrTy rawPtrSrc = getAddressable(sPtr);
+  for (unsigned i = 1; i <= g_FatMemSlots; i++) {
+    memVals.push_back(m_slots[i - 1].MemCpy(rawPtrDst, rawPtrSrc, len,
+                                            memTrsfrRead.getSlot(i),
+                                            memRead.getSlot(i), align));
+  }
+  return mkFatMem(memVals);
+}
+
+/// \brief Executes symbolic memcpy from physical memory with concrete
+/// length
+template <class T>
+typename FatMemManagerCore<T>::MemValTy
+FatMemManagerCore<T>::MemFill(PtrTy dPtr, char *sPtr, unsigned len,
+                              MemValTy mem, uint32_t align) {
+  llvm::SmallVector<AnyMemValTy, 8> memVals;
+  memVals.push_back(
+      m_main.MemFill(mkMainPtr(dPtr), sPtr, len, mkMainMem(mem), align));
+  for (unsigned i = 1; i <= g_FatMemSlots; i++) {
+    memVals.push_back(mem.getSlot(i));
+  }
+  return mkFatMem(memVals);
+}
+
+/// \brief Executes inttoptr conversion
+template <class T>
+typename FatMemManagerCore<T>::PtrTy
+FatMemManagerCore<T>::inttoptr(Expr intVal, const Type &intTy,
+                               const Type &ptrTy) const {
+  return mkFatPtr(m_main.inttoptr(intVal, intTy, ptrTy));
+}
+
+/// \brief Executes ptrtoint conversion. This only converts the raw ptr to
+/// int.
+template <class T>
+Expr FatMemManagerCore<T>::ptrtoint(PtrTy ptr, const Type &ptrTy,
+                                    const Type &intTy) const {
+  return m_main.ptrtoint(mkMainPtr(ptr), ptrTy, intTy);
+}
+
+template <class T> Expr FatMemManagerCore<T>::ptrUlt(PtrTy p1, PtrTy p2) const {
+  return m_main.ptrUlt(mkMainPtr(p1), mkMainPtr(p2));
+}
+
+template <class T> Expr FatMemManagerCore<T>::ptrSlt(PtrTy p1, PtrTy p2) const {
+  return m_main.ptrSlt(mkMainPtr(p1), mkMainPtr(p2));
+}
+template <class T> Expr FatMemManagerCore<T>::ptrUle(PtrTy p1, PtrTy p2) const {
+  return m_main.ptrUle(mkMainPtr(p1), mkMainPtr(p2));
+}
+template <class T> Expr FatMemManagerCore<T>::ptrSle(PtrTy p1, PtrTy p2) const {
+  return m_main.ptrSle(mkMainPtr(p1), mkMainPtr(p2));
+}
+template <class T> Expr FatMemManagerCore<T>::ptrUgt(PtrTy p1, PtrTy p2) const {
+  return m_main.ptrUgt(mkMainPtr(p1), mkMainPtr(p2));
+}
+template <class T> Expr FatMemManagerCore<T>::ptrSgt(PtrTy p1, PtrTy p2) const {
+  return m_main.ptrSgt(mkMainPtr(p1), mkMainPtr(p2));
+}
+template <class T> Expr FatMemManagerCore<T>::ptrUge(PtrTy p1, PtrTy p2) const {
+  return m_main.ptrUge(mkMainPtr(p1), mkMainPtr(p2));
+}
+template <class T> Expr FatMemManagerCore<T>::ptrSge(PtrTy p1, PtrTy p2) const {
+  return m_main.ptrSge(mkMainPtr(p1), mkMainPtr(p2));
+}
+
+/// \brief Checks if two pointers are equal.
+template <class T> Expr FatMemManagerCore<T>::ptrEq(PtrTy p1, PtrTy p2) const {
+  return m_main.ptrEq(mkMainPtr(p1), mkMainPtr(p2));
+}
+template <class T> Expr FatMemManagerCore<T>::ptrNe(PtrTy p1, PtrTy p2) const {
+  return m_main.ptrNe(mkMainPtr(p1), mkMainPtr(p2));
+}
+
+template <class T> Expr FatMemManagerCore<T>::ptrSub(PtrTy p1, PtrTy p2) const {
+  return m_main.ptrSub(mkMainPtr(p1), mkMainPtr(p2));
+}
+
+/// \brief Computes a pointer corresponding to the gep instruction
+template <class T>
+typename FatMemManagerCore<T>::PtrTy
+FatMemManagerCore<T>::gep(PtrTy ptr, gep_type_iterator it,
+                          gep_type_iterator end) const {
+  // Here the resultant pointer automatically gets the same slot(s) data
+  // as the original. Therefore we don't require the client to manually
+  // update slot(s) data after a gep call.
+  MainPtrTy mainPtr = m_main.gep(ptr.getMain(), it, end);
+  return updateFatPtr(mainPtr, ptr);
+}
+
+/// \brief Called when a function is entered for the first time
+template <class T>
+void FatMemManagerCore<T>::onFunctionEntry(const Function &fn) {
+  m_main.onFunctionEntry(fn);
+  for (auto memMgr : m_slots) {
+    memMgr.onFunctionEntry(fn);
+  }
+}
+
+/// \brief Called when a module entered for the first time
+template <class T> void FatMemManagerCore<T>::onModuleEntry(const Module &M) {
+  m_main.onModuleEntry(M);
+  for (unsigned i = 0; i < g_FatMemSlots; i++) {
+    m_slots[i].onModuleEntry(M);
+  }
+}
+
+/// \brief Debug helper
+template <class T> void FatMemManagerCore<T>::dumpGlobalsMap() {
+  m_main.dumpGlobalsMap();
+}
+
+template <class T>
+std::pair<char *, unsigned> FatMemManagerCore<T>::getGlobalVariableInitValue(
+    const llvm::GlobalVariable &gv) {
+  // TODO: do we need to make a union
+  return m_main.getGlobalVariableInitValue(gv);
+}
+
+template <class T>
+typename FatMemManagerCore<T>::MemValTy
+FatMemManagerCore<T>::zeroedMemory() const {
+  llvm::SmallVector<AnyMemValTy, 8> memVals;
+  memVals.push_back(m_main.zeroedMemory());
+  for (unsigned i = 1; i <= g_FatMemSlots; i++) {
+    memVals.push_back(m_slots[i - 1].zeroedMemory());
+  }
+  return mkFatMem(memVals);
+}
+
+/// \brief get fat data in ith fat slot.
+template <class T>
+Expr FatMemManagerCore<T>::getFatData(PtrTy p, unsigned SlotIdx) {
+  return p.getSlot(1 + SlotIdx);
+}
+
+template <class T>
+typename FatMemManagerCore<T>::PtrTy
+FatMemManagerCore<T>::setFatData(PtrTy p, unsigned slotIdx, Expr data) {
+  assert(slotIdx < g_FatMemSlots);
+  llvm::SmallVector<AnyPtrTy, 8> ptrVals;
+  ptrVals.push_back(p.getMain());
+  for (unsigned i = 1; i <= g_FatMemSlots; i++) {
+    if (slotIdx + 1 == i) {
+      ptrVals.push_back(data);
+    } else {
+      ptrVals.push_back(p.getSlot(i));
     }
-    return res;
   }
+  return mkFatPtr(ptrVals);
+}
 
-  /// \brief Executes symbolic memset with a concrete length
-  FatMemValTy MemSet(FatPtrTy ptr, Expr _val, unsigned len, FatMemValTy mem,
-                     uint32_t align) {
-    return mkFatMem(
-        m_main.MemSet(mkRawPtr(ptr), _val, len, mkRawMem(mem), align),
-        mkSlot0Mem(mem), mkSlot1Mem(mem));
-  }
+template <class T>
+typename FatMemManagerCore<T>::RawPtrTy
+FatMemManagerCore<T>::getAddressable(PtrTy p) const {
+  return m_main.getAddressable(p.getMain());
+}
 
-  FatMemValTy MemSet(FatPtrTy ptr, Expr _val, Expr len, FatMemValTy mem,
-                     uint32_t align) {
-    return mkFatMem(
-        m_main.MemSet(mkRawPtr(ptr), _val, len, mkRawMem(mem), align),
-        mkSlot0Mem(mem), mkSlot1Mem(mem));
-  }
+template <class T> bool FatMemManagerCore<T>::isPtrTyVal(Expr e) const {
+  // struct with raw ptr + fat slots
+  return e && strct::isStructVal(e) && e->arity() == (1 + g_FatMemSlots);
+}
 
-  /// \brief Executes symbolic memcpy with concrete length
-  FatMemValTy MemCpy(FatPtrTy dPtr, FatPtrTy sPtr, unsigned len,
-                     FatMemValTy memTrsfrRead, FatMemValTy memRead,
-                     uint32_t align) {
-    return mkFatMem(
-        m_main.MemCpy(mkRawPtr(dPtr), mkRawPtr(sPtr), len,
-                      mkRawMem(memTrsfrRead), mkRawMem(memRead), align),
-        m_slot0.MemCpy(mkRawPtr(dPtr), mkRawPtr(sPtr), len,
-                       mkSlot0Mem(memTrsfrRead), mkSlot0Mem(memRead), align),
-        m_slot1.MemCpy(mkRawPtr(dPtr), mkRawPtr(sPtr), len,
-                       mkSlot1Mem(memTrsfrRead), mkSlot1Mem(memRead), align));
-  }
+template <class T> bool FatMemManagerCore<T>::isMemVal(Expr e) const {
+  // struct with raw ptr + fat slots
+  return e && strct::isStructVal(e) && e->arity() == (1 + g_FatMemSlots);
+}
 
-  /// \brief Executes symbolic memcpy with concrete length
-  FatMemValTy MemCpy(FatPtrTy dPtr, FatPtrTy sPtr, Expr len,
-                     FatMemValTy memTrsfrRead, FatMemValTy memRead,
-                     uint32_t align) {
-    return mkFatMem(
-        m_main.MemCpy(mkRawPtr(dPtr), mkRawPtr(sPtr), len,
-                      mkRawMem(memTrsfrRead), mkRawMem(memRead), align),
-        m_slot0.MemCpy(mkRawPtr(dPtr), mkRawPtr(sPtr), len,
-                       mkSlot0Mem(memTrsfrRead), mkSlot0Mem(memRead), align),
-        m_slot1.MemCpy(mkRawPtr(dPtr), mkRawPtr(sPtr), len,
-                       mkSlot1Mem(memTrsfrRead), mkSlot1Mem(memRead), align));
+template <class T>
+Expr FatMemManagerCore<T>::isMetadataSet(MetadataKind kind, PtrTy ptr,
+                                         MemValTy mem) {
+  // The width of the value will be wordSz
+  Expr val = getMetadata(kind, ptr, mem, 1);
+  if (val == Expr()) {
+    return m_ctx.alu().getTrue();
   }
+  auto sentinel = m_ctx.alu().ui(1, getMetadataMemWordSzInBits());
+  return m_ctx.alu().doEq(val, sentinel, getMetadataMemWordSzInBits());
+}
 
-  /// \brief Executes symbolic memcpy from physical memory with concrete
-  /// length
-  FatMemValTy MemFill(FatPtrTy dPtr, char *sPtr, unsigned len, FatMemValTy mem,
-                      uint32_t align = 0) {
-    return mkFatMem(
-        m_main.MemFill(mkRawPtr(dPtr), sPtr, len, mkRawMem(mem), align),
-        mkSlot0Mem(mem), mkSlot1Mem(mem));
+template <class T>
+typename FatMemManagerCore<T>::MemValTy
+FatMemManagerCore<T>::memsetMetadata(MetadataKind kind, PtrTy ptr,
+                                     unsigned int len, MemValTy memIn,
+                                     unsigned int val) {
+  llvm::SmallVector<AnyMemValTy, 8> memVals;
+  memVals.push_back(
+      m_main.memsetMetadata(kind, ptr.getMain(), len, memIn.getMain(), val));
+  for (unsigned i = 1; i <= g_FatMemSlots; i++) {
+    memVals.push_back(memIn.getSlot(i));
   }
+  return mkFatMem(memVals);
+}
 
-  /// \brief Executes inttoptr conversion
-  FatPtrTy inttoptr(Expr intVal, const Type &intTy, const Type &ptrTy) const {
-    return mkFatPtr(m_main.inttoptr(intVal, intTy, ptrTy));
+template <class T>
+typename FatMemManagerCore<T>::MemValTy
+FatMemManagerCore<T>::memsetMetadata(MetadataKind kind, PtrTy ptr, Expr len,
+                                     MemValTy memIn, unsigned int val) {
+  llvm::SmallVector<AnyMemValTy, 8> memVals;
+  memVals.push_back(
+      m_main.memsetMetadata(kind, ptr.getMain(), len, memIn.getMain(), val));
+  for (unsigned i = 1; i <= g_FatMemSlots; i++) {
+    memVals.push_back(memIn.getSlot(i));
   }
+  return mkFatMem(memVals);
+}
 
-  /// \brief Executes ptrtoint conversion. This only converts the raw ptr to
-  /// int.
-  Expr ptrtoint(FatPtrTy ptr, const Type &ptrTy, const Type &intTy) const {
-    return m_main.ptrtoint(mkRawPtr(ptr), ptrTy, intTy);
-  }
+template <class T>
+Expr FatMemManagerCore<T>::getMetadata(MetadataKind kind, PtrTy ptr,
+                                       MemValTy memIn, unsigned int byteSz) {
+  return m_main.getMetadata(kind, ptr.getMain(), memIn.getMain(), byteSz);
+}
 
-  Expr ptrUlt(FatPtrTy p1, FatPtrTy p2) const {
-    return m_main.ptrUlt(mkRawPtr(p1), mkRawPtr(p2));
-  }
-  Expr ptrSlt(FatPtrTy p1, FatPtrTy p2) const {
-    return m_main.ptrSlt(mkRawPtr(p1), mkRawPtr(p2));
-  }
-  Expr ptrUle(FatPtrTy p1, FatPtrTy p2) const {
-    return m_main.ptrUle(mkRawPtr(p1), mkRawPtr(p2));
-  }
-  Expr ptrSle(FatPtrTy p1, FatPtrTy p2) const {
-    return m_main.ptrSle(mkRawPtr(p1), mkRawPtr(p2));
-  }
-  Expr ptrUgt(FatPtrTy p1, FatPtrTy p2) const {
-    return m_main.ptrUgt(mkRawPtr(p1), mkRawPtr(p2));
-  }
-  Expr ptrSgt(FatPtrTy p1, FatPtrTy p2) const {
-    return m_main.ptrSgt(mkRawPtr(p1), mkRawPtr(p2));
-  }
-  Expr ptrUge(FatPtrTy p1, FatPtrTy p2) const {
-    return m_main.ptrUge(mkRawPtr(p1), mkRawPtr(p2));
-  }
-  Expr ptrSge(FatPtrTy p1, FatPtrTy p2) const {
-    return m_main.ptrSge(mkRawPtr(p1), mkRawPtr(p2));
-  }
+template <class T>
+unsigned int FatMemManagerCore<T>::getMetadataMemWordSzInBits() {
+  return m_main.getMetadataMemWordSzInBits();
+}
 
-  /// \brief Checks if two pointers are equal.
-  Expr ptrEq(FatPtrTy p1, FatPtrTy p2) const {
-    return m_main.ptrEq(mkRawPtr(p1), mkRawPtr(p2));
+template <class T> size_t FatMemManagerCore<T>::getNumOfMetadataSlots() {
+  return m_main.getNumOfMetadataSlots();
+}
+
+template <class T>
+typename FatMemManagerCore<T>::MemValTy
+FatMemManagerCore<T>::setMetadata(MetadataKind kind, PtrTy ptr, MemValTy mem,
+                                  Expr val) {
+  if (!m_ctx.isTrackingOn() && kind != MetadataKind::ALLOC) {
+    LOG("opsem.memtrack.verbose",
+        WARN << "Ignoring setMetadata();Memory tracking is off"
+             << "\n";);
+    return mem;
   }
-  Expr ptrNe(FatPtrTy p1, FatPtrTy p2) const {
-    return m_main.ptrNe(mkRawPtr(p1), mkRawPtr(p2));
+  llvm::SmallVector<AnyMemValTy, 8> memVals;
+  auto mainOut = m_main.setMetadata(kind, ptr.getMain(), mem.getMain(), val);
+  memVals.push_back(mainOut);
+  for (unsigned i = 1; i <= g_FatMemSlots; i++) {
+    memVals.push_back(mem.getSlot(i));
   }
+  return mkFatMem(memVals);
+}
 
-  Expr ptrSub(FatPtrTy p1, FatPtrTy p2) const {
-    return m_main.ptrSub(mkRawPtr(p1), mkRawPtr(p2));
-  }
+template <class T>
+Expr FatMemManagerCore<T>::isDereferenceable(PtrTy p, Expr byteSz) {
+  return m_main.isDereferenceable(p.getMain(), byteSz);
+}
+// };
 
-  /// \brief Computes a pointer corresponding to the gep instruction
-  FatPtrTy gep(FatPtrTy ptr, gep_type_iterator it,
-               gep_type_iterator end) const {
-    // Here the resultant pointer automatically gets the same slot(s) data
-    // as the original. Therefore we don't require the client to manually
-    // update slot(s) data after a gep call.
-    BasePtrTy rawPtr = m_main.gep(mkRawPtr(ptr), it, end);
-    return mkFatPtr(rawPtr, ptr);
-  }
-
-  /// \brief Called when a function is entered for the first time
-  void onFunctionEntry(const Function &fn) {
-    m_main.onFunctionEntry(fn);
-    m_slot0.onFunctionEntry(fn);
-    m_slot1.onFunctionEntry(fn);
-  }
-
-  /// \brief Called when a module entered for the first time
-  void onModuleEntry(const Module &M) {
-    m_main.onModuleEntry(M);
-    m_slot0.onModuleEntry(M);
-    m_slot1.onModuleEntry(M);
-  }
-
-  /// \brief Debug helper
-  void dumpGlobalsMap() { m_main.dumpGlobalsMap(); }
-
-  std::pair<char *, unsigned>
-  getGlobalVariableInitValue(const llvm::GlobalVariable &gv) {
-    // TODO: do we need to make a union
-    return m_main.getGlobalVariableInitValue(gv);
-  }
-
-  FatMemValTy zeroedMemory() const {
-    return mkFatMem(m_main.zeroedMemory(), m_slot0.zeroedMemory(),
-                    m_slot1.zeroedMemory());
-  }
-
-  Expr getFatData(FatPtrTy p, unsigned SlotIdx) {
-    assert(strct::isStructVal(p.v()));
-    assert(SlotIdx < g_maxFatSlots);
-    return strct::extractVal(p.v(), 1 + SlotIdx);
-  }
-
-  FatPtrTy setFatData(FatPtrTy p, unsigned SlotIdx, Expr data) {
-    assert(strct::isStructVal(p.v()));
-    assert(SlotIdx < g_maxFatSlots);
-    return strct::insertVal(p.v(), 1 + SlotIdx, data);
-  }
-
-  RawPtrTy getAddressable(FatPtrTy p) const { return mkRawPtr(p); }
-
-  bool isPtrTyVal(Expr e) const {
-    // struct with raw ptr + fat slots
-    return e && strct::isStructVal(e) && e->arity() == (1 + g_maxFatSlots);
-  }
-
-  bool isMemVal(Expr e) const {
-    // struct with raw ptr + fat slots
-    return e && strct::isStructVal(e) && e->arity() == (1 + g_maxFatSlots);
-  }
-};
-
-FatMemManager::FatMemManager(Bv2OpSem &sem, Bv2OpSemContext &ctx,
-                             unsigned ptrSz, unsigned wordSz, bool useLambdas)
+template <class T>
+FatMemManagerCore<T>::FatMemManagerCore(Bv2OpSem &sem, Bv2OpSemContext &ctx,
+                                        unsigned ptrSz, unsigned wordSz,
+                                        bool useLambdas)
     : MemManagerCore(sem, ctx, ptrSz, wordSz,
-                     false /* this is a nop since we delegate to RawMemMgr */),
+                     false /* this is a nop since we delegate to T MemMgr */),
       m_main(sem, ctx, ptrSz, wordSz, useLambdas),
-      m_slot0(sem, ctx, ptrSz, g_slotByteWidth, useLambdas),
-      m_slot1(sem, ctx, ptrSz, g_slotByteWidth, useLambdas),
-      m_nullPtr(mkFatPtr(m_main.nullPtr())) {}
+      m_fatMemBaseName("sea.fatmem"),
+      m_slots(FatMemSlots,
+              RawMemManager(sem, ctx, ptrSz, g_slotByteWidth, useLambdas,
+                            /* ignoreAlignment =*/true)) {
+  g_FatMemSlots = FatMemSlots;
+}
 
 OpSemMemManager *mkFatMemManager(Bv2OpSem &sem, Bv2OpSemContext &ctx,
                                  unsigned ptrSz, unsigned wordSz,
                                  bool useLambdas) {
-  return new OpSemMemManagerMixin<FatMemManager>(sem, ctx, ptrSz, wordSz,
-                                                 useLambdas);
+  return new OpSemMemManagerMixin<FatMemManagerCore<RawMemManager>>(
+      sem, ctx, ptrSz, wordSz, useLambdas);
 }
+
+// FatMemManager with ExtraWide and Tracking components
+OpSemMemManager *mkFatEWWTManager(Bv2OpSem &sem, Bv2OpSemContext &ctx,
+                                  unsigned ptrSz, unsigned wordSz,
+                                  bool useLambdas) {
+  return new FatEWWTMemManager(sem, ctx, ptrSz, wordSz, useLambdas);
+}
+
+// FatMemManager with ExtraWide component
+OpSemMemManager *mkFatEWWManager(Bv2OpSem &sem, Bv2OpSemContext &ctx,
+                                 unsigned ptrSz, unsigned wordSz,
+                                 bool useLambdas) {
+  return new FatEWWMemManager(sem, ctx, ptrSz, wordSz, useLambdas);
+}
+
+template class FatMemManagerCore<RawMemManager>;
+template class OpSemMemManagerMixin<FatMemManagerCore<OpSemMemManagerMixin<
+    ExtraWideMemManagerCore<OpSemMemManagerMixin<TrackingRawMemManager>>>>>;
+
 } // namespace details
 } // namespace seahorn

--- a/lib/seahorn/BvOpSem2FatMemMgr.hh
+++ b/lib/seahorn/BvOpSem2FatMemMgr.hh
@@ -1,0 +1,465 @@
+#include "BvOpSem2Context.hh"
+#include "BvOpSem2ExtraWideMemMgr.hh"
+#include "BvOpSem2MemManagerMixin.hh"
+#include "BvOpSem2RawMemMgr.hh"
+
+#include "llvm/IR/GetElementPtrTypeIterator.h"
+#include "llvm/Support/Format.h"
+
+#include "seahorn/Expr/ExprLlvm.hh"
+#include "seahorn/Expr/ExprOpStruct.hh"
+#include "seahorn/Support/SeaDebug.h"
+#include "seahorn/Support/SeaLog.hh"
+
+#include <boost/variant.hpp>
+
+namespace seahorn {
+namespace details {
+
+static const unsigned int g_slotBitWidth = 64;
+static const unsigned int g_slotByteWidth = g_slotBitWidth / 8;
+
+// TODO: remove these vars
+// static const unsigned int g_undefSlot0 = 0xDEF0;
+// static const unsigned int g_undefSlot1 = 0xDEF1;
+
+/// \brief provides Fat pointers and Fat memory to store them
+template <class T> class FatMemManagerCore : public MemManagerCore {
+  static unsigned g_FatMemSlots;
+
+private:
+  /// \brief Memory manager for raw pointers
+  T m_main;
+  std::vector<RawMemManager> m_slots;
+
+public:
+  /// Right now everything is an expression. In the future, we might have
+  /// other types for PtrTy, such as a tuple of expressions
+  using MainPtrTy = typename T::PtrTy;
+  using RawPtrTy = OpSemMemManager::PtrTy;
+  using MainMemValTy = typename T::MemValTy;
+  using RawMemValTy = OpSemMemManager::MemValTy;
+  using AnyPtrTy = Expr;
+  using AnyMemValTy = Expr;
+
+  /// \brief Source of unique identifiers (currently inc. counter)
+  mutable unsigned m_id;
+
+  llvm::Twine m_fatMemBaseName;
+
+  /// PtrTy representation for this manager
+  ///
+  /// Currently internal representation is just an Expr
+  struct PtrTyImpl {
+    Expr m_v;
+
+    explicit PtrTyImpl(llvm::SmallVector<AnyPtrTy, 8> &&slots) {
+      assert(slots.size() == g_FatMemSlots + 1);
+      for (auto e : slots) {
+        assert(e);
+      }
+      m_v = strct::mk(std::move(slots));
+    }
+
+    explicit PtrTyImpl(llvm::SmallVector<AnyPtrTy, 8> &slots) {
+      assert(slots.size() == g_FatMemSlots + 1);
+      for (auto e : slots) {
+        assert(e);
+      }
+      m_v = strct::mk(slots);
+    }
+
+    explicit PtrTyImpl(const Expr &e) {
+      // Our base is a struct of three exprs
+      assert(strct::isStructVal(e));
+      assert(e->arity() == g_FatMemSlots + 1);
+      for (unsigned i = 0, sz = e->arity(); i < sz; i++) {
+        assert(e->arg(i));
+      }
+      m_v = e;
+    }
+
+    Expr v() const { return m_v; }
+    Expr toExpr() const { return v(); }
+    explicit operator Expr() const { return toExpr(); }
+
+    MainPtrTy getMain() { return strct::extractVal(m_v, 0); }
+
+    MainPtrTy getRaw() { return getMain(); }
+
+    Expr getSlot(unsigned idx) {
+      assert(idx < g_FatMemSlots + 1);
+      auto e = strct::extractVal(m_v, idx);
+      assert(e); // e is not null
+      return e;
+    }
+  };
+
+  struct MemValTyImpl {
+    Expr m_v;
+
+    explicit MemValTyImpl(llvm::SmallVector<AnyMemValTy, 8> &&vals) {
+      assert(vals.size() == g_FatMemSlots + 1);
+      for (auto e : vals) {
+        assert(e);
+      }
+      // TODO: add back isStructVal check
+      m_v = strct::mk(std::move(vals));
+    }
+
+    explicit MemValTyImpl(llvm::SmallVector<AnyMemValTy, 8> &vals) {
+      assert(vals.size() == g_FatMemSlots + 1);
+      for (auto e : vals) {
+        assert(e);
+      }
+
+      // TODO: add back isStructVal check
+      m_v = strct::mk(vals);
+    }
+
+    explicit MemValTyImpl(const Expr &e) {
+      // Our base is Expr() or a struct of three exprs
+      assert(!e || strct::isStructVal(e));
+      for (unsigned i = 0; i < g_FatMemSlots; i++) {
+        assert(!e || !strct::isStructVal(e->arg(i + 1)));
+      }
+      if (e) {
+        assert(e->arity() == g_FatMemSlots + 1);
+        for (unsigned i = 0, sz = e->arity(); i < sz; i++) {
+          assert(e->arg(i));
+        }
+      }
+      m_v = e;
+    }
+
+    Expr v() const { return m_v; }
+    Expr toExpr() const { return v(); }
+    explicit operator Expr() const { return toExpr(); }
+
+    MainMemValTy getMain() { return !m_v ? m_v : strct::extractVal(m_v, 0); }
+
+    MainMemValTy getRaw() { return getMain(); }
+
+    Expr getSlot(unsigned idx) {
+      assert(idx < g_FatMemSlots + 1);
+      auto e = strct::extractVal(m_v, idx);
+      assert(e); // e is not null
+      return e;
+    }
+  };
+
+  using FatMemTag = MemoryFeatures::FatMem_tag;
+  using TrackingTag = typename T::TrackingTag;
+  using WideMemTag = typename T::WideMemTag;
+
+  using MemValTy = MemValTyImpl;
+  using PtrTy = PtrTyImpl;
+
+  using MainPtrSortTy = typename T::PtrSortTy;
+  using MainMemSortTy = typename T::MemSortTy;
+  using MemRegTy = OpSemMemManager::MemRegTy;
+  using AnyPtrSortTy = Expr;
+  using AnyMemSortTy = Expr;
+
+  // TODO: change all slot0,1 methods to return these types for easier
+  // reading
+  using Slot0ValTy = Expr;
+  using Slot1ValTy = Expr;
+
+  struct PtrSortTyImpl {
+    Expr m_ptr_sort;
+
+    explicit PtrSortTyImpl(llvm::SmallVector<AnyPtrSortTy, 8> &&ptrSorts) {
+      assert(ptrSorts.size() == g_FatMemSlots + 1);
+      for (auto e : ptrSorts) {
+        assert(e);
+      }
+      m_ptr_sort = sort::structTy(std::move(ptrSorts));
+    }
+
+    explicit PtrSortTyImpl(llvm::SmallVector<AnyPtrSortTy, 8> &ptrSorts) {
+      assert(ptrSorts.size() == g_FatMemSlots + 1);
+      for (auto e : ptrSorts) {
+        assert(e);
+      }
+      m_ptr_sort = sort::structTy(std::move(ptrSorts));
+    }
+
+    Expr v() const { return m_ptr_sort; }
+    Expr toExpr() const { return v(); }
+    explicit operator Expr() const { return toExpr(); }
+
+    MainPtrSortTy getBaseSort() { return m_ptr_sort->arg(0); }
+  };
+
+  struct MemSortTyImpl {
+    Expr m_mem_sort;
+
+    explicit MemSortTyImpl(llvm::SmallVector<AnyMemSortTy, 8> &&memSorts) {
+      assert(memSorts.size() == g_FatMemSlots + 1);
+      for (auto e : memSorts) {
+        assert(e);
+      }
+      m_mem_sort = sort::structTy(std::move(memSorts));
+    }
+
+    explicit MemSortTyImpl(llvm::SmallVector<AnyMemSortTy, 8> &memSorts) {
+      assert(memSorts.size() == g_FatMemSlots + 1);
+      for (auto e : memSorts) {
+        assert(e);
+      }
+      m_mem_sort = sort::structTy(memSorts);
+    }
+
+    Expr v() const { return m_mem_sort; }
+    Expr toExpr() const { return v(); }
+    explicit operator Expr() const { return toExpr(); }
+  };
+
+  using PtrSortTy = PtrSortTyImpl;
+  using MemSortTy = MemSortTyImpl;
+
+  /// \brief Converts a raw ptr to fat ptr with default value for fat
+  PtrTy mkFatPtr(MainPtrTy mainPtr) const;
+
+  /// \brief Assembles a fat ptr from parts
+  PtrTy mkFatPtr(llvm::SmallVector<AnyPtrTy, 8> slots) const;
+
+  /// \brief Update a given fat pointer with a "main" address value
+  PtrTy updateFatPtr(MainPtrTy mainPtr, PtrTy fat) const;
+
+  /// \brief Extracts a "main" pointer out of a fat pointer
+  MainPtrTy mkMainPtr(PtrTy fatPtr) const;
+
+  /// \brief Extracts a "main" memory value from a fat memory value
+  MainMemValTy mkMainMem(MemValTy fatMem) const;
+
+  RawMemValTy mkSlot0Mem(MemValTy fatMem) const;
+
+  RawMemValTy mkSlot1Mem(MemValTy fatMem) const;
+
+  /// \brief Creates a fat memory value from raw memory with given values
+  /// for fat
+  MemValTy mkFatMem(llvm::SmallVector<AnyMemValTy, 8> vals) const;
+
+public:
+  FatMemManagerCore(Bv2OpSem &sem, Bv2OpSemContext &ctx, unsigned ptrSz,
+                    unsigned wordSz, bool useLambdas = false);
+
+  ~FatMemManagerCore() = default;
+
+  PtrSortTy ptrSort() const;
+
+  /// \brief Allocates memory on the stack and returns a pointer to it
+  /// \param align is requested alignment. If 0, default alignment is used
+  PtrTy salloc(unsigned bytes, uint32_t align);
+
+  /// \brief Allocates memory on the stack and returns a pointer to it
+  PtrTy salloc(Expr elmts, unsigned typeSz, uint32_t align);
+
+  /// \brief Returns a pointer value for a given stack allocation
+  PtrTy mkStackPtr(unsigned offset);
+
+  /// \brief Pointer to start of the heap
+  PtrTy brk0Ptr();
+
+  /// \brief Allocates memory on the heap and returns a pointer to it
+  PtrTy halloc(unsigned _bytes, uint32_t align);
+
+  /// \brief Allocates memory on the heap and returns pointer to it
+  PtrTy halloc(Expr bytes, uint32_t align);
+
+  /// \brief Allocates memory in global (data/bss) segment for given global
+  PtrTy galloc(const GlobalVariable &gv, uint32_t align);
+
+  /// \brief Allocates memory in code segment for the code of a given
+  /// function
+  PtrTy falloc(const Function &fn);
+
+  /// \brief Returns a function pointer value for a given function
+  PtrTy getPtrToFunction(const Function &F);
+
+  /// \brief Returns a pointer to a global variable
+  PtrTy getPtrToGlobalVariable(const GlobalVariable &gv);
+
+  /// \brief Initialize memory used by the global variable
+  void initGlobalVariable(const GlobalVariable &gv) const;
+
+  /// \brief Creates a non-deterministic pointer that is aligned
+  ///
+  /// Top bits of the pointer are named by \p name and last \c log2(align)
+  /// bits are set to zero
+  PtrTy mkAlignedPtr(Expr name, uint32_t align) const;
+
+  /// \brief Returns sort of a pointer register for an instruction
+  PtrSortTy mkPtrRegisterSort(const Instruction &inst) const;
+
+  /// \brief Returns sort of a pointer register for a function pointer
+  PtrSortTy mkPtrRegisterSort(const Function &fn) const;
+
+  /// \brief Returns sort of a pointer register for a global pointer
+  PtrSortTy mkPtrRegisterSort(const GlobalVariable &gv) const;
+
+  /// \brief Returns sort of memory-holding register for an instruction
+  MemSortTy mkMemRegisterSort(const Instruction &inst) const;
+
+  /// \brief Returns a fresh aligned pointer value
+  PtrTy freshPtr();
+
+  /// \brief Returns a null ptr
+  PtrTy nullPtr() const;
+
+  /// \brief Fixes the type of a havoced value to mach the representation
+  /// used by mem repr.
+  ///
+  /// \param sort
+  /// \param val
+  /// \return the coerced value.
+  Expr coerce(Expr sort, Expr val);
+
+  /// \brief Loads an integer of a given size from 'raw' memory register
+  ///
+  /// \param[in] ptr pointer being accessed
+  /// \param[in] mem memory value into which \p ptr points
+  /// \param[in] byteSz size of the integer in bytes
+  /// \param[in] align known alignment of \p ptr
+  /// \return symbolic value of the read integer
+  Expr loadIntFromMem(PtrTy ptr, MemValTy mem, unsigned byteSz, uint64_t align);
+
+  /// \brief Loads a pointer stored in memory
+  /// \sa loadIntFromMem
+  PtrTy loadPtrFromMem(PtrTy ptr, MemValTy mem, unsigned byteSz,
+                       uint64_t align);
+
+  /// \brief Pointer addition with numeric offset
+  PtrTy ptrAdd(PtrTy ptr, int32_t _offset) const;
+
+  /// \brief Pointer addition with symbolic offset
+  PtrTy ptrAdd(PtrTy ptr, Expr offset) const;
+
+  /// \brief Stores an integer into memory
+  ///
+  /// Returns an expression describing the state of memory in \c memReadReg
+  /// after the store
+  /// \sa loadIntFromMem
+  MemValTy storeIntToMem(Expr _val, PtrTy ptr, MemValTy mem, unsigned byteSz,
+                         uint64_t align);
+
+  /// \brief Stores a pointer into memory
+  /// \sa storeIntToMem
+  MemValTy storePtrToMem(PtrTy val, PtrTy ptr, MemValTy mem, unsigned byteSz,
+                         uint64_t align);
+
+  /// \brief Returns an expression corresponding to a load from memory
+  ///
+  /// \param[in] ptr is the pointer being dereferenced
+  /// \param[in] memReg is the memory register being read
+  /// \param[in] ty is the type of value being loaded
+  /// \param[in] align is the known alignment of the load
+  Expr loadValueFromMem(PtrTy ptr, MemValTy mem, const llvm::Type &ty,
+                        uint64_t align);
+
+  MemValTy storeValueToMem(Expr _val, PtrTy ptr, MemValTy memIn,
+                           const llvm::Type &ty, uint32_t align);
+
+  /// \brief Executes symbolic memset with a concrete length
+  MemValTy MemSet(PtrTy ptr, Expr _val, unsigned len, MemValTy mem,
+                  uint32_t align);
+
+  MemValTy MemSet(PtrTy ptr, Expr _val, Expr len, MemValTy mem, uint32_t align);
+
+  /// \brief Executes symbolic memcpy with concrete length
+  MemValTy MemCpy(PtrTy dPtr, PtrTy sPtr, unsigned len, MemValTy memTrsfrRead,
+                  MemValTy memRead, uint32_t align);
+
+  /// \brief Executes symbolic memcpy with concrete length
+  MemValTy MemCpy(PtrTy dPtr, PtrTy sPtr, Expr len, MemValTy memTrsfrRead,
+                  MemValTy memRead, uint32_t align);
+
+  /// \brief Executes symbolic memcpy from physical memory with concrete
+  /// length
+  MemValTy MemFill(PtrTy dPtr, char *sPtr, unsigned len, MemValTy mem,
+                   uint32_t align = 0);
+
+  /// \brief Executes inttoptr conversion
+  PtrTy inttoptr(Expr intVal, const Type &intTy, const Type &ptrTy) const;
+
+  /// \brief Executes ptrtoint conversion. This only converts the raw ptr to
+  /// int.
+  Expr ptrtoint(PtrTy ptr, const Type &ptrTy, const Type &intTy) const;
+
+  Expr ptrEq(PtrTy p1, PtrTy p2) const;
+  Expr ptrUlt(PtrTy p1, PtrTy p2) const;
+  Expr ptrSlt(PtrTy p1, PtrTy p2) const;
+  Expr ptrUle(PtrTy p1, PtrTy p2) const;
+  Expr ptrSle(PtrTy p1, PtrTy p2) const;
+  Expr ptrUgt(PtrTy p1, PtrTy p2) const;
+  Expr ptrSgt(PtrTy p1, PtrTy p2) const;
+  Expr ptrUge(PtrTy p1, PtrTy p2) const;
+  Expr ptrSge(PtrTy p1, PtrTy p2) const;
+  Expr ptrNe(PtrTy p1, PtrTy p2) const;
+  Expr ptrSub(PtrTy p1, PtrTy p2) const;
+
+  /// \brief Computes a pointer corresponding to the gep instruction
+  PtrTy gep(PtrTy ptr, gep_type_iterator it, gep_type_iterator end) const;
+
+  /// \brief Called when a function is entered for the first time
+  void onFunctionEntry(const Function &fn);
+
+  /// \brief Called when a module entered for the first time
+  void onModuleEntry(const Module &M);
+
+  /// \brief Debug helper
+  void dumpGlobalsMap();
+
+  std::pair<char *, unsigned>
+  getGlobalVariableInitValue(const llvm::GlobalVariable &gv);
+
+  MemValTy zeroedMemory() const;
+
+  /// \brief get fat data in ith fat slot.
+  Expr getFatData(PtrTy p, unsigned SlotIdx);
+
+  PtrTy setFatData(PtrTy p, unsigned slotIdx, Expr data);
+
+  RawPtrTy getAddressable(PtrTy p) const;
+
+  bool isPtrTyVal(Expr e) const;
+
+  bool isMemVal(Expr e) const;
+
+  Expr isMetadataSet(MetadataKind kind, PtrTy ptr, MemValTy mem);
+
+  MemValTy memsetMetadata(MetadataKind kind, PtrTy ptr, unsigned int len,
+                          MemValTy memIn, unsigned int val);
+
+  MemValTy memsetMetadata(MetadataKind kind, PtrTy ptr, Expr len,
+                          MemValTy memIn, unsigned int val);
+
+  Expr getMetadata(MetadataKind kind, PtrTy ptr, MemValTy memIn,
+                   unsigned int byteSz);
+
+  unsigned int getMetadataMemWordSzInBits();
+
+  size_t getNumOfMetadataSlots();
+  MemValTy setMetadata(MetadataKind kind, PtrTy ptr, MemValTy mem, Expr val);
+
+  Expr isDereferenceable(PtrTy p, Expr byteSz);
+};
+OpSemMemManager *mkFatMemManager(Bv2OpSem &sem, Bv2OpSemContext &ctx,
+                                 unsigned ptrSz, unsigned wordSz,
+                                 bool useLambdas);
+
+// FatMemManager with ExtraWide and Tracking components
+OpSemMemManager *mkFatEWWTManager(Bv2OpSem &sem, Bv2OpSemContext &ctx,
+                                  unsigned ptrSz, unsigned wordSz,
+                                  bool useLambdas);
+using FatEWWTMemManager =
+    OpSemMemManagerMixin<FatMemManagerCore<EWWTMemManager>>;
+// FatMemManager with ExtraWide and Tracking components
+OpSemMemManager *mkFatEWWManager(Bv2OpSem &sem, Bv2OpSemContext &ctx,
+                                 unsigned ptrSz, unsigned wordSz,
+                                 bool useLambdas);
+using FatEWWMemManager = OpSemMemManagerMixin<FatMemManagerCore<EWWMemManager>>;
+} // namespace details
+} // namespace seahorn

--- a/lib/seahorn/BvOpSem2MemManagerMixin.hh
+++ b/lib/seahorn/BvOpSem2MemManagerMixin.hh
@@ -39,7 +39,7 @@ protected:
 
 public:
   template <typename... Ts>
-  OpSemMemManagerMixin(Ts &&... Args)
+  OpSemMemManagerMixin(Ts &&...Args)
       : BaseT(std::forward<Ts>(Args)...),
         OpSemMemManager(base().sem(), base().ctx(), base().ptrSizeInBytes(),
                         base().wordSizeInBytes(), base().isIgnoreAlignment()) {}
@@ -444,6 +444,10 @@ public:
     if (!isMemVal(e))
       return Expr();
     return Expr(BaseMemValTy(e).getRaw());
+  }
+
+  Expr getAddressable(PtrTy ptr) const override {
+    return Expr(base().getAddressable(BasePtrTy(std::move(ptr))));
   }
 };
 } // namespace details

--- a/lib/seahorn/BvOpSem2MemRepr.cc
+++ b/lib/seahorn/BvOpSem2MemRepr.cc
@@ -433,10 +433,8 @@ Expr OpSemMemLambdaRepr::coerceArrayToLambda(Expr arrVal) {
   Expr name = bind::fname(arrVal);
   Expr rTy = bind::rangeTy(name);
   Expr idxTy = sort::arrayIndexTy(rTy);
-
   Expr bvAddr = bind::mkConst(mkTerm<std::string>("addr", m_efac), idxTy);
   Expr sel = op::array::select(arrVal, bvAddr);
-
   return bind::abs<LAMBDA>(as_std_array(bvAddr), sel);
 }
 

--- a/lib/seahorn/BvOpSem2RawMemMgr.cc
+++ b/lib/seahorn/BvOpSem2RawMemMgr.cc
@@ -100,6 +100,12 @@ RawMemManagerCore::RawMemManagerCore(Bv2OpSem &sem, Bv2OpSemContext &ctx,
     m_memRepr =
         std::make_unique<OpSemMemArrayRepr>(*this, ctx, MemCpyUnrollCount);
 }
+// TODO: don't hardcode args, instead expose useLambdas, ignoreAlignment
+//       in memmgr api
+RawMemManagerCore::RawMemManagerCore(const RawMemManagerCore &orig)
+    : RawMemManager::RawMemManagerCore(
+          orig.sem(), orig.ctx(), orig.ptrSizeInBytes(), orig.wordSizeInBytes(),
+          true /* useLambdas */, /* ignoreAlignment =*/true) {}
 
 /// \brief Creates a non-deterministic pointer that is aligned
 ///
@@ -834,7 +840,7 @@ OpSemAllocator &RawMemManagerCore::getMAllocator() const {
 }
 bool RawMemManagerCore::ignoreAlignment() const { return m_ignoreAlignment; }
 
-PtrTy RawMemManagerCore::getAddressable(PtrTy p) { return p; }
+PtrTy RawMemManagerCore::getAddressable(PtrTy p) const { return p; }
 
 // An empty destructor is needed because the class uses unique_ptr of
 // forward declared types.

--- a/lib/seahorn/BvOpSem2RawMemMgr.hh
+++ b/lib/seahorn/BvOpSem2RawMemMgr.hh
@@ -35,6 +35,8 @@ public:
   RawMemManagerCore(Bv2OpSem &sem, Bv2OpSemContext &ctx, unsigned ptrSz,
                     unsigned wordSz, bool useLambdas, bool ignoreAlignment);
 
+  RawMemManagerCore(const RawMemManagerCore &orig);
+
   ~RawMemManagerCore();
 
   OpSemAllocator &getMAllocator() const;
@@ -356,7 +358,7 @@ public:
 
   bool isMemVal(Expr e);
 
-  PtrTy getAddressable(PtrTy p);
+  PtrTy getAddressable(PtrTy p) const;
 
   Bv2OpSem &sem() const { return m_sem; }
   Bv2OpSemContext &ctx() const { return m_ctx; }

--- a/lib/seahorn/BvOpSem2TrackingRawMemMgr.hh
+++ b/lib/seahorn/BvOpSem2TrackingRawMemMgr.hh
@@ -30,7 +30,8 @@ struct TrackingMemoryTuple {
                            (RawMemManager, m_r_metadata),
                            (RawMemManager, m_w_metadata),
                            (RawMemManager, m_a_metadata),
-                           (RawMemManager, m_c0_metadata));
+                           (RawMemManager, m_c0_metadata),
+                           (RawMemManager, m_c1_metadata));
 
   /// \brief A helper function to get number of memory elements in tuple
   static constexpr auto GetTupleSize() {

--- a/py/sea/commands.py
+++ b/py/sea/commands.py
@@ -1205,7 +1205,11 @@ class Seahorn(sea.LimitedCmd):
                         help='Eval branch sentinel instrinsic',
                         default=False,
                         action='store_true')
-
+        ap.add_argument('--own-sem',
+                        dest='enable_own_sem',
+                        help='Enable Ownership semantics for BvOpSem2',
+                        default=False,
+                        action='store_true')
         return ap
 
     def run (self, args, extra):
@@ -1228,7 +1232,8 @@ class Seahorn(sea.LimitedCmd):
                 argv.append('--horn-shadow-mem-alloc-is-def')
         if args.crab:
             argv.append ('--horn-crab')
-
+        if args.enable_own_sem:
+            argv.append('--horn-bv2-own-sem')
         if self.enable_boogie:
             argv.append ('--boogie')
             # the translation uses crab to add invariants: disable crab warnings

--- a/sea-rt/seahorn.cpp
+++ b/sea-rt/seahorn.cpp
@@ -1,23 +1,25 @@
 #include "seahorn/seahorn.h"
-#include <stdarg.h>
 #include <cstdint>
 #include <cstdio>
+#include <stdarg.h>
 #undef NDEBUG
 #include <cassert>
 #include <cstdlib>
 #include <cstring>
-#include <map>
 #include <functional>
+#include <map>
 #include <stddef.h>
 
+#ifdef __cplusplus
 extern "C" {
+#endif
 
-void sealog (const char *format, ...) {
-    va_list args;
-    va_start(args, format);
-    if (std::getenv("SEAHORN_RT_VERBOSE"))
-        vprintf(format, args);
-    va_end(args);
+void sealog(const char *format, ...) {
+  va_list args;
+  va_start(args, format);
+  if (std::getenv("SEAHORN_RT_VERBOSE"))
+    vprintf(format, args);
+  va_end(args);
 }
 
 void __VERIFIER_error() {
@@ -25,13 +27,9 @@ void __VERIFIER_error() {
   exit(1);
 }
 
-void __VERIFIER_assume(int x) {
-  assert(x);
-}
+void __VERIFIER_assume(int x) { assert(x); }
 
-void __SEA_assume(bool x) {
-  assert(x);
-}
+void __SEA_assume(bool x) { assert(x); }
 
 bool __seahorn_get_value_i1(int ctr, bool *g_arr, int g_arr_sz) {
   sealog("[sea] __seahorn_get_value_i1(%d, %d)\n", ctr, g_arr_sz);
@@ -43,28 +41,25 @@ bool __seahorn_get_value_i1(int ctr, bool *g_arr, int g_arr_sz) {
   }
 }
 
-#define get_value_helper(ctype, llvmtype)                               \
-  ctype __seahorn_get_value_ ## llvmtype (int ctr, ctype *g_arr, int g_arr_sz) { \
-    sealog("[sea] __seahorn_get_value_(" #llvmtype ", %d, %d)\n", ctr, g_arr_sz); \
-    if (ctr >= g_arr_sz) {						\
-      sealog("\tout-of-bounds index\n");				\
-      return 0;								\
-    }									\
-    else { 								\
-      return g_arr[ctr];						\
-    }									\
+#define get_value_helper(ctype, llvmtype)                                      \
+  ctype __seahorn_get_value_##llvmtype(int ctr, ctype *g_arr, int g_arr_sz) {  \
+    sealog("[sea] __seahorn_get_value_(" #llvmtype ", %d, %d)\n", ctr,         \
+           g_arr_sz);                                                          \
+    if (ctr >= g_arr_sz) {                                                     \
+      sealog("\tout-of-bounds index\n");                                       \
+      return 0;                                                                \
+    } else {                                                                   \
+      return g_arr[ctr];                                                       \
+    }                                                                          \
   }
 
-#define get_value_int(bits) get_value_helper(int ## bits ## _t, i ## bits)
+#define get_value_int(bits) get_value_helper(int##bits##_t, i##bits)
 
-get_value_int(64)
-get_value_int(32)
-get_value_int(16)
-get_value_int(8)
+get_value_int(64) get_value_int(32) get_value_int(16) get_value_int(8)
 
-get_value_helper(intptr_t, ptr_internal)
+    get_value_helper(intptr_t, ptr_internal)
 
-const int MEM_REGION_SIZE_GUESS = 4000;
+        const int MEM_REGION_SIZE_GUESS = 4000;
 const int TYPE_GUESS = sizeof(int);
 
 std::map<intptr_t, intptr_t, std::greater<intptr_t>> absptrmap;
@@ -77,86 +72,81 @@ static uint16_t ptr_base; // 16 bit common base of stack allocated ptrs
 static bool ptr_base_set = false;
 
 // Hook for gdb-like tools: do nothing here.
-void* __emv(void* p) {
-  return p;
+void *__emv(void *p) { return p; }
+
+/*intptr_t __seahorn_get_value_ptr(int ctr, intptr_t *g_arr, int g_arr_sz, int
+ebits) { static std::unordered_map<intptr_t, intptr_t> absptrmap; intptr_t
+absptr = __seahorn_get_value_ptr_internal(ctr, g_arr, g_arr_sz);
+
+auto concptrfind = absptrmap.find(absptr);
+intptr_t concptr;
+if (concptrfind == absptrmap.end()) {
+  concptr = (intptr_t) calloc(MEM_REGION_SIZE_GUESS, ebits == 0 ? TYPE_GUESS :
+ebits); absptrmap.insert({absptr, concptr}); } else { concptr =
+concptrfind->second;
 }
-  
-  /*intptr_t __seahorn_get_value_ptr(int ctr, intptr_t *g_arr, int g_arr_sz, int ebits) {
-  static std::unordered_map<intptr_t, intptr_t> absptrmap;
+
+printf("Returning %#lx for abstract pointer %#lx\n", concptr, absptr);
+
+return concptr;
+}*/
+
+intptr_t __seahorn_get_value_ptr(int ctr, intptr_t *g_arr, int g_arr_sz,
+                                 int ebits) {
   intptr_t absptr = __seahorn_get_value_ptr_internal(ctr, g_arr, g_arr_sz);
 
-  auto concptrfind = absptrmap.find(absptr);
-  intptr_t concptr;
-  if (concptrfind == absptrmap.end()) {
-    concptr = (intptr_t) calloc(MEM_REGION_SIZE_GUESS, ebits == 0 ? TYPE_GUESS : ebits);
-    absptrmap.insert({absptr, concptr});
-  } else {
-    concptr = concptrfind->second;
-  }
+  size_t sz = MEM_REGION_SIZE_GUESS * (ebits == 0 ? TYPE_GUESS : ebits);
 
-  printf("Returning %#lx for abstract pointer %#lx\n", concptr, absptr);
+  absptrmap[absptr] = absptr + sz;
 
-  return concptr;
-  }*/
+  sealog("[sea] returning a pointer to an abstract region [%#lx, %#lx]\n",
+         absptr, absptrmap.at(absptr));
 
-  intptr_t __seahorn_get_value_ptr(int ctr, intptr_t *g_arr, int g_arr_sz, int ebits) {
-    intptr_t absptr = __seahorn_get_value_ptr_internal(ctr, g_arr, g_arr_sz);
+  return absptr;
+}
 
-    size_t sz = MEM_REGION_SIZE_GUESS * (ebits == 0 ? TYPE_GUESS : ebits);
+bool is_dummy_address(void *addr) {
 
-    absptrmap[absptr] = absptr + sz;
+  intptr_t ip = intptr_t(addr);
+  auto it = absptrmap.lower_bound(ip + 1);
+  if (it == absptrmap.end())
+    return false;
+  intptr_t lb = it->first;
+  intptr_t ub = it->second;
 
-    sealog("[sea] returning a pointer to an abstract region [%#lx, %#lx]\n", absptr, absptrmap.at(absptr));
+  return (ip >= lb && ip < ub);
+}
 
-    return absptr;
-  }
-
-  bool is_dummy_address (void *addr) {
-
-    intptr_t ip = intptr_t (addr);
-    auto it = absptrmap.lower_bound (ip+1);
-    if (it == absptrmap.end()) return false;
-    intptr_t lb = it->first;
-    intptr_t ub = it->second;
-
-    return (ip >= lb && ip < ub);
-  }
-
-  bool is_legal_address (void *addr) {
-    return (! is_dummy_address (addr) &&
-	    (size_t(addr) >= 0x100000 &&
-	     size_t(addr) <= 0xFFFFFFFFFFFF));
-  }
+bool is_legal_address(void *addr) {
+  return (!is_dummy_address(addr) &&
+          (size_t(addr) >= 0x100000 && size_t(addr) <= 0xFFFFFFFFFFFF));
+}
 
 /** Dummy implementation of memory wrapping functions */
-void __seahorn_mem_alloc(void* start, void* end, int64_t val, size_t sz)
-{}
+void __seahorn_mem_alloc(void *start, void *end, int64_t val, size_t sz) {}
 
-void __seahorn_mem_init (void* addr, int64_t val, size_t sz)
-{}
+void __seahorn_mem_init(void *addr, int64_t val, size_t sz) {}
 
-void __seahorn_mem_store (void *src, void *dst, size_t sz)
-{
+void __seahorn_mem_store(void *src, void *dst, size_t sz) {
   sealog("[sea] __seahorn_mem_store from %p to %p\n", src, dst);
-  if (is_legal_address (dst) && is_legal_address(src)) {
-  /* if dst is a legal address */
+  if (is_legal_address(dst) && is_legal_address(src)) {
+    /* if dst is a legal address */
     sealog("\tmemory write ");
-    memcpy (dst, src, sz);
+    memcpy(dst, src, sz);
     sealog("done\n");
   }
   /* else if dst is illegal, do nothing */
-  else{
+  else {
     sealog("\tignoring write to illegal memory address\n");
   }
 }
 
-void __seahorn_mem_load (void *dst, void *src, size_t sz)
-{
+void __seahorn_mem_load(void *dst, void *src, size_t sz) {
   sealog("[sea] __seahorn_mem_load from %p to %p\n", src, dst);
-  if (is_legal_address (src) && is_legal_address(dst)) {
-  /* if src is a legal address */
+  if (is_legal_address(src) && is_legal_address(dst)) {
+    /* if src is a legal address */
     sealog("\tmemory read ");
-    memcpy (dst, src, sz);
+    memcpy(dst, src, sz);
     sealog("done\n");
   }
   /* else, if src is illegal, return a dummy value */
@@ -173,48 +163,48 @@ void klee_make_symbolic(void *v, size_t sz, char *fname) {
 
 void klee_assume(int b) {
   sealog("[sea] calling klee_assume\n");
-  __VERIFIER_assume (b);
+  __VERIFIER_assume(b);
 }
 
-void __assert_fail (const char * assertion, const char * file,
-		    unsigned int line, const char * function) {
-  printf("[sea] exiting with a call to __assert_fail %s\n",assertion);
+void __assert_fail(const char *assertion, const char *file, unsigned int line,
+                   const char *function) {
+  printf("[sea] exiting with a call to __assert_fail %s\n", assertion);
   exit(1);
 }
 
 // draft
-void* __sea_set_extptr_slot0_fp(void* ptr, size_t base) {
+char *__sea_set_extptr_slot0_fp(char *ptr, size_t base) {
   if (!ptr_base_set) {
     ptr_base_set = true;
     ptr_base = (uint16_t)((size_t)ptr >> 48);
   }
   size_t base_bits = (size_t)base & 0xff;
   size_t packed = (base_bits << 56) | (size_t)ptr;
-  return (void*)packed;
+  return (char *)packed;
 }
 
 // draft
-void* __sea_set_extptr_slot1_fp(void* ptr, size_t size) {
+char *__sea_set_extptr_slot1_fp(char *ptr, size_t size) {
   if (!ptr_base_set) {
     ptr_base_set = true;
     ptr_base = (uint16_t)((size_t)ptr >> 48);
   }
   assert(size < 512);
   size_t packed = (size << 48) | (size_t)ptr;
-  return (void*)packed;
+  return (char *)packed;
 }
 
 // draft
-void* __sea_recover_pointer_fp(void* cooked) {
-  size_t cleared = (size_t) cooked & 0xffffffffffff;
-  size_t recov = cleared | (size_t) ptr_base << 48;
-  return (void*) recov;
+void *__sea_recover_pointer_fp(void *cooked) {
+  size_t cleared = (size_t)cooked & 0xffffffffffff;
+  size_t recov = cleared | (size_t)ptr_base << 48;
+  return (void *)recov;
 }
 
 // draft
 size_t __sea_get_extptr_slot0_fp(void *ptr) {
   size_t raw = (size_t)ptr >> 56; // 8 bits stored only
-  void* recov = __sea_recover_pointer_fp(ptr);
+  void *recov = __sea_recover_pointer_fp(ptr);
   size_t recov_base = (size_t)recov & 0xffffffffffffff00;
   return recov_base | raw;
 }
@@ -226,38 +216,37 @@ size_t __sea_get_extptr_slot1_fp(void *ptr) {
 }
 
 // draft
-void* __sea_copy_extptr_slots_fp(void *dst, void*src) {
+char *__sea_copy_extptr_slots_fp(void *dst, void *src) {
   size_t src_info = (size_t)src & 0xffff000000000000;
   size_t dst_addr = (size_t)dst & 0xffffffffffff;
-  return (void*)(src_info | dst_addr);
+  return (char *)(src_info | dst_addr);
 }
 
-void* __sea_set_extptr_slot0_hm(void* ptr, size_t base) {
+char *__sea_set_extptr_slot0_hm(char *ptr, size_t base) {
   fatptrslot0[(size_t)ptr] = (size_t)base;
   return ptr;
 }
 
-void* __sea_set_extptr_slot1_hm(void *ptr, size_t size) {
+char *__sea_set_extptr_slot1_hm(char *ptr, size_t size) {
   fatptrslot1[(size_t)ptr] = (size_t)size;
   return ptr;
 }
 
-void* __sea_recover_pointer_hm(void* cooked) {
-  return cooked;
-}
+char *__sea_recover_pointer_hm(char *cooked) { return cooked; }
 
-size_t __sea_get_extptr_slot0_hm(void *ptr) {
+size_t __sea_get_extptr_slot0_hm(char *ptr) {
   assert(fatptrslot0.count((size_t)ptr) != 0);
   return (size_t)fatptrslot0[(size_t)ptr];
 }
 
-size_t __sea_get_extptr_slot1_hm(void *ptr) {
+size_t __sea_get_extptr_slot1_hm(char *ptr) {
   assert(fatptrslot1.count((size_t)ptr) != 0);
   return fatptrslot1[(size_t)ptr];
 }
 
-void* __sea_copy_extptr_slots_hm(void *dst, void *src) {
-  assert(fatptrslot0.count((size_t)src) != 0 && fatptrslot1.count((size_t)src) != 0);
+char *__sea_copy_extptr_slots_hm(char *dst, void *src) {
+  assert(fatptrslot0.count((size_t)src) != 0 &&
+         fatptrslot1.count((size_t)src) != 0);
   size_t dst_int = (size_t)dst;
   size_t src_int = (size_t)src;
   fatptrslot0[dst_int] = fatptrslot0[src_int];
@@ -265,4 +254,6 @@ void* __sea_copy_extptr_slots_hm(void *dst, void *src) {
   return dst;
 }
 
+#ifdef __cplusplus
 }
+#endif

--- a/test/opsem2/ownsem/borrow_load_borchk_fail_sat.01.c
+++ b/test/opsem2/ownsem/borrow_load_borchk_fail_sat.01.c
@@ -1,0 +1,51 @@
+//; RUN: %sea "%s" -g -S --own-sem 2>&1 | OutputCheck %s
+// CHECK: ^sat$
+#include "seahorn/seahorn.h"
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+extern char nd_char();
+extern void pretendEscapeToMemory(char *);
+extern __declspec(noalias) void sea_printf(const char *format, ...);
+
+static unsigned CLEAN = 0;
+static unsigned TAINT = 1;
+
+typedef struct handle_t {
+  uint32_t *own_uint32ptr;
+  bool valid;
+} Handle;
+
+int main() {
+  sea_tracking_on();
+  Handle *h0 = (Handle *)malloc(sizeof(Handle));
+
+  uint32_t *stuff = (uint32_t *)malloc(sizeof(uint32_t));
+  SEA_MKOWN(stuff);
+  *stuff = CLEAN;
+  h0->own_uint32ptr = stuff;
+  h0->valid = false;
+  pretendEscapeToMemory((char *)h0);
+  uint32_t *bor_ptr;
+
+  SEA_BORROW_LOAD(bor_ptr, &h0->own_uint32ptr);
+  uint32_t r;
+  SEA_READ_CACHE(r, (char *)bor_ptr);
+  sea_printf("Cache val after first load:%d\n", r);
+  SEA_WRITE_CACHE(bor_ptr, 1);
+  SEA_READ_CACHE(r, (char *)bor_ptr);
+  sea_printf("Cache val after first write:%d\n", r);
+  *bor_ptr = TAINT;
+
+  // NOTE: The following DIE is missing and hence the next BORROW_LOAD fails.
+  // SEA_DIE(bor_ptr);
+
+  uint32_t *bor_ptr2;
+  SEA_BORROW_LOAD(bor_ptr2, &h0->own_uint32ptr);
+  uint32_t bor_val;
+  SEA_READ_CACHE(bor_val, (char *)bor_ptr2);
+  sea_printf("Cache val after second load:%d\n", bor_val); 
+  sassert(bor_val == TAINT);
+  return 0;
+}

--- a/test/opsem2/ownsem/borrow_load_unsat.01.c
+++ b/test/opsem2/ownsem/borrow_load_unsat.01.c
@@ -1,0 +1,51 @@
+//; RUN: %sea "%s" -g -S --own-sem 2>&1 | OutputCheck %s
+// CHECK: ^unsat$
+#include "seahorn/seahorn.h"
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+extern char nd_char();
+extern void pretendEscapeToMemory(char *);
+extern __declspec(noalias) void sea_printf(const char *format, ...);
+
+static uint32_t CLEAN = 0;
+static uint32_t TAINT = 1;
+
+typedef struct handle_t {
+  uint32_t *own_uint32ptr;
+  bool valid;
+} Handle;
+
+int main() {
+  sea_tracking_on();
+  Handle *h0 = (Handle *)malloc(sizeof(Handle));
+
+  uint32_t *stuff = (uint32_t *)malloc(sizeof(uint32_t));
+  SEA_MKOWN(stuff);
+  *stuff = CLEAN;
+  SEA_MOVE2MEM(&h0->own_uint32ptr, stuff);
+  h0->valid = false;
+  pretendEscapeToMemory((char *)h0);
+  uint32_t *bor_ptr;
+
+  SEA_BORROW_LOAD(bor_ptr, &h0->own_uint32ptr);
+  uint32_t r;
+  SEA_READ_CACHE(r, (char *)bor_ptr);
+  sea_printf("Cache val after first load:%d\n", r);
+  SEA_WRITE_CACHE(bor_ptr, 1);
+  SEA_READ_CACHE(r, (char *)bor_ptr);
+  sea_printf("Cache val after first write:%d\n", r);
+  *bor_ptr = TAINT;
+
+  SEA_DIE(bor_ptr);
+
+  uint32_t *bor_ptr2;
+  SEA_BORROW_LOAD(bor_ptr2, &h0->own_uint32ptr);
+  uint32_t bor_val;
+  SEA_READ_CACHE(bor_val, (char *)bor_ptr2);
+  sea_printf("Cache val after second load:%d\n", bor_val); 
+  sassert(bor_val == TAINT);
+  return 0;
+}

--- a/test/opsem2/ownsem/borrow_split_unsat.01.c
+++ b/test/opsem2/ownsem/borrow_split_unsat.01.c
@@ -1,0 +1,73 @@
+//; RUN: %sea "%s" -g -S --own-sem 2>&1 | OutputCheck %s
+// CHECK: ^unsat$
+#include "seahorn/seahorn.h"
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdlib.h>
+
+extern char nd_char();
+
+typedef struct handle_t {
+  unsigned val;
+  bool valid;
+} Handle;
+
+int main() {
+  sea_tracking_on();
+
+  Handle *h0 = (Handle *)malloc(sizeof(Handle));
+  h0->val = 0;
+  h0->valid = false;
+
+  SEA_MKOWN(h0);
+
+  SEA_WRITE_CACHE(h0, false);
+
+  bool *h0b0_valid;
+  SEA_BORROW_OFFSET(h0b0_valid, h0, offsetof(Handle, valid));
+
+  // write to cache and mem
+  SEA_WRITE_CACHE(h0b0_valid, true);
+  *h0b0_valid = true;
+
+  SEA_DIE(h0b0_valid);
+  bool valToAssert;
+  char *r = (char *)h0;
+  SEA_READ_CACHE(valToAssert, r);
+  sassert(valToAssert == true);
+
+  // Handle *h1s, *h1o1, *h1o;
+  // Handle *h1b, *h1b1, *h1b2, *h1d;
+
+  bool cacheVal;
+  r = (char *)h0;
+  SEA_READ_CACHE(cacheVal, r);
+  h0->valid = cacheVal;
+  SEA_MKSHR(h0);
+  h0->val = 1;
+  h0->valid = false;
+
+  SEA_MKOWN(h0);
+  SEA_WRITE_CACHE(h0, h0->valid);
+  r = (char *)h0;
+  SEA_READ_CACHE(valToAssert, r);
+  sassert(valToAssert == false);
+  Handle *h1b;
+  SEA_BORROW(h1b, h0);
+  SEA_DIE(h1b);
+  bool *h1b_valid, *h2b_valid;
+  SEA_BORROW_OFFSET(h1b_valid, h0, offsetof(Handle, valid));
+  // When writing to memory, also write to cache.
+  SEA_WRITE_CACHE(h1b_valid, false);
+  *h1b_valid = false;
+
+  SEA_DIE(h1b_valid);
+  SEA_DIE(h1b);
+  // It is valid to read from cache instead of memory
+  // since h11u is unique;
+  bool v;
+  r = (char *)h0;
+  SEA_READ_CACHE(v, r);
+  sassert(v == false);
+  return 0;
+}

--- a/test/opsem2/ownsem/borrow_split_unsat.02.c
+++ b/test/opsem2/ownsem/borrow_split_unsat.02.c
@@ -1,0 +1,78 @@
+//; RUN: %sea "%s" -S --own-sem 2>&1 | OutputCheck %s
+//; RUN: %sea "%s" -S --own-sem --horn-vcgen-use-ite --horn-vcgen-only-dataflow --horn-bmc-coi --horn-gsa  2>&1 | OutputCheck %s
+// CHECK: ^unsat$
+#include "seahorn/seahorn.h"
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdlib.h>
+
+extern char nd_char(void);
+extern bool nd_bool(void);
+
+typedef struct handle_t {
+  unsigned val;
+  bool valid;
+} Handle;
+
+int main() {
+  sea_tracking_on();
+
+  Handle *h0 = (Handle *)malloc(sizeof(Handle));
+  h0->val = 0;
+  h0->valid = false;
+
+  SEA_MKOWN(h0);
+
+  SEA_WRITE_CACHE(h0, false);
+
+  bool *h0b0_valid;
+  SEA_BORROW_OFFSET(h0b0_valid, h0, offsetof(Handle, valid));
+
+  // write to cache and mem
+  SEA_WRITE_CACHE(h0b0_valid, true);
+  *h0b0_valid = true;
+
+  SEA_DIE(h0b0_valid);
+
+  bool valToAssert;
+  char *r = (char *)h0;
+  SEA_READ_CACHE(valToAssert, r);
+
+  sassert(valToAssert == true);
+  Handle *h1b;
+  if (nd_bool()) {
+    // non deterministically choose to have split-borrowed
+    // access on h1
+    bool cacheVal;
+    r = (char *)h0;
+    SEA_READ_CACHE(cacheVal, r);
+    h0->valid = cacheVal; // write cache to mem
+    SEA_MKSHR(h0);
+    h0->val = 1;
+    h0->valid = false;
+    SEA_MKOWN(h0);
+    SEA_WRITE_CACHE(h0, h0->valid);
+    r = (char *)h0;
+    SEA_READ_CACHE(valToAssert, r);
+    sassert(valToAssert == false);
+    SEA_BORROW(h1b, h0);
+  } else {
+    SEA_BORROW(h1b, h0);
+  }
+
+  bool *h1b_valid;
+  SEA_BORROW_OFFSET(h1b_valid, h1b, offsetof(Handle, valid));
+  // When writing to memory, also write to cache.
+  SEA_WRITE_CACHE(h1b_valid, false);
+  *h1b_valid = false;
+  SEA_DIE(h1b_valid);
+  SEA_DIE(h1b);
+  // It is valid to read from cache instead of memory
+  // since h11u is unique;
+  bool v;
+  r = (char *)h0;
+  SEA_READ_CACHE(v, r);
+  sassert(v == false);
+
+  return 0;
+}

--- a/test/opsem2/ownsem/borrow_unsat.01.baseline.c
+++ b/test/opsem2/ownsem/borrow_unsat.01.baseline.c
@@ -1,0 +1,47 @@
+//; RUN: %sea "%s" --own-sem 2>&1 | OutputCheck %s
+// CHECK: ^unsat$
+#include "seahorn/seahorn.h"
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdlib.h>
+
+extern char nd_char();
+extern void pretendEscapeToMemory(char *);
+
+typedef struct handle_t {
+  unsigned val;
+  bool valid;
+} Handle;
+
+int main() {
+  sea_tracking_on();
+
+  Handle *h0 = (Handle *)malloc(sizeof(Handle));
+  h0->val = 0;
+  h0->valid = false;
+
+  SEA_MKOWN(h0);
+
+  SEA_WRITE_CACHE(h0, false);
+
+  bool *h0b0_valid;
+  SEA_BORROW_OFFSET(h0b0_valid, h0, offsetof(Handle, valid));
+
+  pretendEscapeToMemory((char *)h0b0_valid);
+
+  // write to cache and mem
+  *h0b0_valid = true;
+
+  SEA_WRITE_CACHE(h0b0_valid, true);
+  SEA_DIE(h0b0_valid);
+  bool valToAssert;
+  SEA_READ_CACHE(valToAssert, (char *)h0);
+  // NOTE: Comment out one of the aaserts
+  // to see coi in action.
+  // In case we are asserting on cached
+  // value only, there should be fewer
+  // memory accesses.
+  sassert(valToAssert == true);
+  sassert(h0->valid);
+  return 0;
+}

--- a/test/opsem2/ownsem/borrow_unsat.01.c
+++ b/test/opsem2/ownsem/borrow_unsat.01.c
@@ -1,0 +1,41 @@
+//; RUN: %sea "%s" --own-sem -g -S 2>&1 | OutputCheck %s
+// CHECK: ^unsat$
+#include "seahorn/seahorn.h"
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdlib.h>
+
+extern char nd_char();
+extern void pretendEscapeToMemory(char *);
+
+typedef struct handle_t {
+  unsigned val;
+  bool valid;
+} Handle;
+
+int main() {
+  sea_tracking_on();
+  Handle *h0 = (Handle *)malloc(sizeof(Handle));
+  h0->val = 0;
+  h0->valid = false;
+
+  SEA_MKOWN(h0);
+
+  h0->valid = false;
+  SEA_WRITE_CACHE(h0, false);
+  bool *h0b0_valid;
+  SEA_BORROW_OFFSET(h0b0_valid, h0, offsetof(Handle, valid));
+
+  pretendEscapeToMemory((char *)h0b0_valid);
+
+  // write to cache and mem
+  SEA_WRITE_CACHE(h0b0_valid, true);
+  *h0b0_valid = true;
+
+  SEA_DIE(h0b0_valid);
+
+  bool valToAssert;
+  SEA_READ_CACHE(valToAssert, (char *)h0);
+  sassert(valToAssert == true);
+  return 0;
+}

--- a/test/opsem2/ownsem/borrow_unsat.02.c
+++ b/test/opsem2/ownsem/borrow_unsat.02.c
@@ -1,0 +1,58 @@
+//; RUN: %sea "%s" "-g" --own-sem 2>&1 | OutputCheck %s
+// CHECK: ^unsat$
+#include "seahorn/seahorn.h"
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdlib.h>
+
+extern char nd_char();
+
+typedef struct handle_t {
+  unsigned val;
+  bool valid;
+} Handle;
+
+int main() {
+  sea_tracking_on();
+
+  Handle *h0 = (Handle *)malloc(sizeof(Handle));
+  h0->val = 0;
+  h0->valid = false;
+
+  SEA_MKOWN(h0);
+  h0->valid = false;
+  SEA_WRITE_CACHE(h0, false);
+  // No need to set fatptr_slot1
+  // A correct non deterministic value is read from slot1
+  // SEA_SET_FATPTR_SLOT1(h0, h00, 0xA);
+  bool *h0b0_valid;
+  SEA_BORROW_OFFSET(h0b0_valid, h0, offsetof(Handle, valid));
+
+  // write to cache and mem
+  SEA_WRITE_CACHE(h0b0_valid, true);
+  *h0b0_valid = true;
+  SEA_DIE(h0b0_valid);
+  bool valToAssert;
+  char *r = (char *)h0;
+  SEA_READ_CACHE(valToAssert, r);
+  sassert(valToAssert == true);
+
+  Handle *h1b;
+  // Two level borrow
+  SEA_BORROW(h1b, h0);
+  bool *h1b_valid, *h2b_valid;
+  SEA_BORROW_OFFSET(h1b_valid, h1b, offsetof(Handle, valid));
+  // When writing to memory, also write to cache.
+  SEA_WRITE_CACHE(h1b_valid, false);
+  *h1b_valid = false;
+  SEA_DIE(h1b_valid);
+  SEA_DIE(h1b);
+  // It is valid to read from cache instead of memory
+  // since h11u is unique;
+  bool v;
+  char *hr = (char *)h0;
+  SEA_READ_CACHE(v, hr);
+  sassert(v == false);
+
+  return 0;
+}

--- a/test/opsem2/ownsem/many_buffers_ownsem_unsat.c
+++ b/test/opsem2/ownsem/many_buffers_ownsem_unsat.c
@@ -1,0 +1,70 @@
+// RUN: %sea -m64 -DOWNSEM_BORCHK -O3 --inline --no-lower-gv-init-struct --horn-bv2-tracking-mem --horn-unify-assumes=true --horn-gsa --no-fat-fns=bcmp,memcpy,assert_bytes_match,ensure_linked_list_is_allocated,sea_aws_linked_list_is_valid --dsa=sea-cs-t --devirt-functions=sea-dsa --bmc=opsem --horn-vcgen-use-ite --horn-vcgen-only-dataflow=true --horn-bmc-coi=true --sea-opsem-allocator=static --horn-explicit-sp0=false --horn-bv2-lambdas --horn-bv2-simplify=true --own-sem "%s"  2>&1 | OutputCheck %s
+// CHECK: ^unsat$
+
+#include "seahorn/seahorn.h"
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+extern void sea_set_shadowmem(char, char*, size_t);
+extern size_t sea_get_shadowmem(char, char*);
+extern void sea_tracking_on();
+extern void sea_tracking_off();
+extern bool nd_bool();
+extern size_t nd_size_t();
+#define ND __declspec(noalias)
+extern ND void memhavoc(void *ptr, size_t size);
+
+#define MAX_BUFS 30
+static size_t buffer_counter = 0;
+
+typedef struct buf {
+    char *data;
+    size_t len;    
+} Buffer;
+
+void inline process_buffer(char *buffer, size_t len ) {
+  memhavoc(buffer, len);
+  size_t counter = sea_get_shadowmem(TRACK_CUSTOM0_MEM, buffer);
+  size_t cache_counter;
+  SEA_READ_CACHE(cache_counter, buffer);
+  SEA_WRITE_CACHE(buffer, cache_counter + buffer_counter);
+  sea_set_shadowmem(TRACK_CUSTOM0_MEM, buffer, counter + buffer_counter);
+  buffer_counter = buffer_counter + 1;   
+  SEA_DIE(buffer);
+}
+
+int main(int argc, char **argv) {
+  sea_tracking_on();
+  Buffer bufs[MAX_BUFS];
+  for(int i =0;i < MAX_BUFS; i++) {
+    size_t buf_size = nd_size_t();
+    assume(buf_size < 4096);
+    bufs[i].data = (char *) malloc(buf_size);
+    SEA_MKOWN(bufs[i].data);
+    bufs[i].len = buf_size;
+    SEA_WRITE_CACHE(bufs[i].data, 1);
+    sea_set_shadowmem(TRACK_CUSTOM0_MEM, bufs[i].data, 1);
+  }  
+
+  size_t choice1 = nd_size_t();
+  size_t choice2 = nd_size_t();
+  assume(choice1 < MAX_BUFS);
+  assume(choice2 < MAX_BUFS);
+  assume(choice1 != choice2);
+  char *bor_data;
+  SEA_BORROW(bor_data, bufs[choice1].data);
+  process_buffer(bor_data, bufs[choice1].len);  
+  SEA_BORROW(bor_data, bufs[choice2].data);
+  process_buffer(bor_data, bufs[choice2].len); 
+  size_t cache_counter1, cache_counter2;
+  SEA_READ_CACHE(cache_counter1, bufs[choice1].data);
+  SEA_READ_CACHE(cache_counter2, bufs[choice2].data);
+  size_t counter1 = sea_get_shadowmem(TRACK_CUSTOM0_MEM, bufs[choice1].data);  
+  size_t counter2 = sea_get_shadowmem(TRACK_CUSTOM0_MEM, bufs[choice2].data);  
+  sassert(cache_counter1 + 1 == cache_counter2);
+  // sassert(counter1 + 1 == counter2);
+  // sassert(bufs[choice1].data[0] + 1  == bufs[choice2].data[0]);
+  sea_tracking_off();
+  return 0;
+}

--- a/test/opsem2/ownsem/own_borrow_copy.c
+++ b/test/opsem2/ownsem/own_borrow_copy.c
@@ -1,0 +1,34 @@
+//; RUN: %sea "%s" --own-sem 2>&1 | OutputCheck %s
+// CHECK: ^unsat$
+#include "seahorn/seahorn.h"
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdlib.h>
+
+extern bool nd_bool(void);
+extern char nd_char(void);
+extern void pretendEscapeToMemory(char *);
+
+int main() {
+  char *p = (char *)malloc(sizeof(char));
+  SEA_MKOWN(p);
+  char c = nd_char();
+  assume (c == 0);
+  SEA_WRITE_CACHE(p, c);
+  *p = c;
+  char *b;
+  SEA_BORROW(b, p);
+  if (nd_bool()) {
+    c = nd_char();
+    assume(c > 1);
+    SEA_WRITE_CACHE(b, c);
+    *b = c;
+    pretendEscapeToMemory(b);
+  }
+  SEA_DIE(b);
+  char r;
+  SEA_READ_CACHE(r, p);
+  sassert(r == 0 || r > 1);
+  SEA_DIE(p);
+  return 0;
+}

--- a/test/opsem2/ownsem/own_borrow_copy2.c
+++ b/test/opsem2/ownsem/own_borrow_copy2.c
@@ -1,0 +1,37 @@
+//; RUN: %sea "%s" -g -S --horn-bmc-tactic=smtfd  --own-sem 2>&1 | OutputCheck %s
+// CHECK: ^unsat$
+#include "seahorn/seahorn.h"
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdlib.h>
+
+extern bool nd_bool(void);
+extern char nd_char(void);
+extern void escapeToMemory(char *);
+
+int main() {
+  char *p = (char *)malloc(sizeof(char));
+  SEA_MKOWN(p);
+  char c = nd_char();
+  assume (c == 0);
+  SEA_WRITE_CACHE(p, c);
+  *p = c;
+  char *b;
+  SEA_BORROW(b, p);
+  if (nd_bool()) {
+    char *cp1;
+    SEA_BORROW(cp1, b);
+    c = nd_char();
+    assume(c > 2);
+    *cp1 = c;
+    escapeToMemory(cp1);
+    SEA_DIE(cp1);
+    SEA_WRITE_CACHE(b, *b);
+  }
+  SEA_DIE(b);
+  char r;
+  SEA_READ_CACHE(r, p);
+  sassert(r == 0 || r > 2);
+  SEA_DIE(p);
+  return 0;
+}

--- a/test/opsem2/ownsem/test_rc.c
+++ b/test/opsem2/ownsem/test_rc.c
@@ -1,0 +1,22 @@
+//; RUN: %sea "%s" --own-sem 2>&1 | OutputCheck %s
+// CHECK: ^unsat$
+#include "seahorn/seahorn.h"
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdlib.h>
+
+extern bool nd_bool(void);
+extern char nd_char(void);
+extern unsigned nd_unsigned(void);
+
+
+int main() {
+  unsigned x = nd_unsigned();
+  unsigned y = nd_unsigned();
+  unsigned rc = nd_unsigned();
+  assume (rc == 1 + x - y);
+  // sassert(rc == 1);
+  assume(y == x);
+  sassert(rc == 1);
+  return 0;
+}

--- a/test/opsem2/ownsem/unique_unsat.01.c
+++ b/test/opsem2/ownsem/unique_unsat.01.c
@@ -1,0 +1,19 @@
+//; RUN: %sea "%s" --own-sem 2>&1 | OutputCheck %s
+// CHECK: ^unsat$
+#include "seahorn/seahorn.h"
+#include <stdlib.h>
+
+extern char *sea_begin_unique(char *);
+extern char *sea_end_unique(char *);
+extern char nd_char();
+
+int main() {
+  sea_tracking_on();
+  char *a = malloc(1024);
+  SEA_BEGIN_UNIQUE(a);
+  *a = nd_char();
+  assume(*a < 5);
+  SEA_END_UNIQUE(a);
+  sassert(*a < 5);
+  return 0;
+}

--- a/test/opsem2/ownsem/unique_unsat.02.c
+++ b/test/opsem2/ownsem/unique_unsat.02.c
@@ -1,0 +1,37 @@
+//; RUN: %sea "%s" --own-sem --horn-vcgen-use-ite --horn-vcgen-only-dataflow
+//--horn-bmc-coi 2>&1 | OutputCheck %s
+// CHECK: ^unsat$
+#include "seahorn/seahorn.h"
+#include <stdbool.h>
+#include <stdlib.h>
+
+extern char nd_char();
+
+typedef struct handle_t {
+  unsigned val;
+  bool valid;
+} Handle;
+
+int main() {
+  sea_tracking_on();
+  Handle *h1 = (Handle *)malloc(sizeof(Handle));
+  Handle *h2 = (Handle *)malloc(sizeof(Handle));
+  h1->val = 0;
+  h1->valid = true;
+  h2->val = 1;
+  h2->valid = false;
+  SEA_BEGIN_UNIQUE_AND_LOAD_CACHE(h1, h1->valid);
+
+  // When writing to memory, also write to cache.
+  SEA_WRITE_CACHE(h1, false);
+  h1->valid = false;
+  // It is valid to read from cache instead of memory
+  // since h1 is unique;
+  bool v;
+  char *r = (char *)h1;
+  SEA_READ_CACHE(v, r);
+  sassert(v == false);
+  r = (char *)h1;
+  SEA_UNLOAD_CACHE_AND_END_UNIQUE(r, &h1->valid, 1);
+  return 0;
+}

--- a/test/opsem2/ownsem/unique_unsat.03.c
+++ b/test/opsem2/ownsem/unique_unsat.03.c
@@ -1,0 +1,58 @@
+//; RUN: %sea "%s" --own-sem 2>&1 | OutputCheck %s
+// CHECK: ^unsat$
+#include "seahorn/seahorn.h"
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdlib.h>
+
+extern char nd_char();
+
+typedef struct handle_t {
+  unsigned val;
+  bool valid;
+} Handle;
+
+int main() {
+  sea_tracking_on();
+
+  Handle *h0 = (Handle *)malloc(sizeof(Handle));
+  h0->val = 0;
+  h0->valid = false;
+
+  SEA_MKOWN(h0);
+
+  SEA_WRITE_CACHE(h0, false);
+
+  bool *h0b0_valid;
+  SEA_BORROW_OFFSET(h0b0_valid, h0, offsetof(Handle, valid));
+
+  // write to cache and mem
+  SEA_WRITE_CACHE(h0b0_valid, true);
+  *h0b0_valid = true;
+
+  SEA_DIE(h0b0_valid);
+  uint64_t valToAssert;
+  char *r = (char *)h0;
+  SEA_READ_CACHE(valToAssert, r);
+  sassert((bool)valToAssert == true);
+  Handle *h1b;
+  SEA_BORROW(h1b, h0);
+
+  bool *h1b_valid;
+  SEA_BORROW_OFFSET(h1b_valid, h1b, offsetof(Handle, valid));
+  // When writing to memory, also write to cache.
+  SEA_WRITE_CACHE(h1b_valid, false);
+  *h1b_valid = false;
+  // NOTE: this is the outstanding borrow so only it needs
+  // to die
+  SEA_DIE(h1b_valid);
+  SEA_DIE(h1b);
+
+  // It is valid to read from cache instead of memory
+  // since h11u is unique;
+  bool v;
+  SEA_READ_CACHE(v, (char *)h0);
+  sassert(v == false);
+
+  return 0;
+}

--- a/test/opsem2/trackingmem/many_buffers_unsat.c
+++ b/test/opsem2/trackingmem/many_buffers_unsat.c
@@ -1,0 +1,57 @@
+// RUN: %sea -O3 -m64 --inline --no-lower-gv-init-struct --horn-unify-assumes=true --horn-gsa --no-fat-fns=bcmp,memcpy,assert_bytes_match,ensure_linked_list_is_allocated,sea_aws_linked_list_is_valid --dsa=sea-cs-t --devirt-functions=sea-dsa --bmc=opsem --horn-vcgen-use-ite --horn-vcgen-only-dataflow=true --horn-bmc-coi=true --sea-opsem-allocator=static --horn-explicit-sp0=false --horn-bv2-lambdas --horn-bv2-simplify=true --horn-bv2-extra-widemem  --horn-bv2-tracking-mem "%s"  2>&1 | OutputCheck %s
+// CHECK: ^unsat$
+
+#include "seahorn/seahorn.h"
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+extern void sea_set_shadowmem(char, char*, size_t);
+extern size_t sea_get_shadowmem(char, char*);
+extern void sea_tracking_on();
+extern void sea_tracking_off();
+extern bool nd_bool();
+extern size_t nd_size_t();
+#define ND __declspec(noalias)
+extern ND void memhavoc(void *ptr, size_t size);
+
+#define MAX_BUFS 30
+static size_t buffer_counter = 0;
+
+typedef struct buf {
+    char *data;
+    size_t len;    
+} Buffer;
+
+void process_buffer(char *buffer, size_t len ){
+  memhavoc(buffer, len);
+  size_t counter = sea_get_shadowmem(TRACK_CUSTOM0_MEM, buffer);
+  sea_set_shadowmem(TRACK_CUSTOM0_MEM, buffer, counter + buffer_counter);
+  buffer_counter = buffer_counter + 1;   
+}
+
+int main(int argc, char **argv) {
+  sea_tracking_on();
+  Buffer bufs[MAX_BUFS];
+  for(int i =0;i < MAX_BUFS; i++) {
+    size_t buf_size = nd_size_t();
+    assume(buf_size < 4096);
+    bufs[i].data = (char *) malloc(buf_size);
+    bufs[i].len = buf_size;
+    sea_set_shadowmem(TRACK_CUSTOM0_MEM, bufs[i].data, 1);
+  }  
+
+  size_t choice1 = nd_size_t();
+  size_t choice2 = nd_size_t();
+  assume(choice1 < MAX_BUFS);
+  assume(choice2 < MAX_BUFS);
+  assume(choice1 != choice2);
+  process_buffer(bufs[choice1].data, bufs[choice1].len);  
+  process_buffer(bufs[choice2].data, bufs[choice2].len);  
+  size_t counter1 = sea_get_shadowmem(TRACK_CUSTOM0_MEM, bufs[choice1].data);  
+  size_t counter2 = sea_get_shadowmem(TRACK_CUSTOM0_MEM, bufs[choice2].data);  
+  sassert(counter1 + 1 == counter2);
+  // sassert(bufs[choice1].data[0] + 1  == bufs[choice2].data[0]);
+  sea_tracking_off();
+  return 0;
+}

--- a/test/opsem2/trackingmem/taint_tracking_sat.c
+++ b/test/opsem2/trackingmem/taint_tracking_sat.c
@@ -3,8 +3,8 @@
 
 #include "seahorn/seahorn.h"
 #include <stdbool.h>
-extern void sea_set_shadowmem(char, char*, char);
-extern char sea_get_shadowmem(char, char*);
+extern void sea_set_shadowmem(char, char*, size_t);
+extern size_t sea_get_shadowmem(char, char*);
 extern void sea_tracking_on();
 extern void sea_tracking_off();
 extern bool nd_bool();
@@ -13,14 +13,14 @@ int main(int argc, char **argv) {
   sea_tracking_on();
   int a = 5;
   bool c = nd_bool();
-  char m = 0;
+  size_t m = 0;
   if (c) {
     m = 10;
   } else {
     m = 20;
   }
   sea_set_shadowmem(3, (char *)&a, m);
-  char r = sea_get_shadowmem(3, (char *)&a);
+  size_t r = sea_get_shadowmem(3, (char *)&a);
   if (c) {
     sassert(r == 10);
   } else {

--- a/test/opsem2/trackingmem/taint_tracking_unsat.c
+++ b/test/opsem2/trackingmem/taint_tracking_unsat.c
@@ -3,8 +3,6 @@
 
 #include "seahorn/seahorn.h"
 #include <stdbool.h>
-extern void sea_set_shadowmem(char, char*, char);
-extern char sea_get_shadowmem(char, char*);
 extern void sea_tracking_on();
 extern void sea_tracking_off();
 extern bool nd_bool();
@@ -13,14 +11,14 @@ int main(int argc, char **argv) {
   sea_tracking_on();
   int a = 5;
   bool c = nd_bool();
-  char m = 0;
+  uint64_t m = 0;
   if (c) {
     m = 10;
   } else {
     m = 20;
   }
   sea_set_shadowmem(3, (char *)&a, m);
-  char r = sea_get_shadowmem(3, (char *)&a);
+  uint64_t r = sea_get_shadowmem(3, (char *)&a);
   if (c) {
     sassert(r == 10);
   } else {

--- a/test/opsem2/widemem/sym_alloc.c
+++ b/test/opsem2/widemem/sym_alloc.c
@@ -12,8 +12,8 @@
 #include <seahorn/seahorn.h>
 #include <stdlib.h>
 
-extern uint8_t nd_char();
-extern bool nd_bool();
+extern char nd_char(void);
+extern bool nd_bool(void);
 
 int main() {
   size_t szBytes1 = nd_char();


### PR DESCRIPTION
Details:
1. Process intrinsics for ownership using ownsem.h for high level semantics and set_fatptr_slot and get_fatptr_slot for low-level semantics. 1.1 Repurpose fatmemmgr for this. Specifically, allow user to set number of slots at runtime.
2. Upgrade shadowmem metadata to be 64-bits (instead of 8). Metadata can be multiword now if run in wordsize < 64 bits.
3. Typecheck expressions on write in debug  mode.
4. Expose solver internal stats to bmc.stat for reporting.