### PR TITLE
ci(docker): cache C++ builds with ccache across CI runs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,10 @@
 /build10
 /debug10
 /release10
+/build-dev15
+# ccache directory and third-party clones produced by the CI `docker run`
+# build in the mounted workspace; keep them out of the docker build context.
+/.ccache
+/sea-dsa
+/llvm-seahorn
+/clam

--- a/.github/workflows/seahorn-docker.yml
+++ b/.github/workflows/seahorn-docker.yml
@@ -39,10 +39,31 @@ jobs:
           ref: dev15  # only checkout dev15
       - name: Login to GitHub Container Registry
         run: echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-      - name: Build seahorn builder
-        run: docker build . --file docker/seahorn-builder.Dockerfile --build-arg BUILDPACK_IMAGE=ghcr.io/${{ github.repository_owner }}/buildpack-deps-seahorn --tag seahorn/seahorn-builder:jammy-llvm15
-      - name: Copy build out to /host
-        run: docker run -v $(pwd):/host seahorn/seahorn-builder:jammy-llvm15 /bin/sh -c "cp build/SeaHorn*.tar.gz /host/"
+      # Persist the ccache directory across runs so only changed translation
+      # units recompile. The nightly build on dev15 seeds the cache that PR
+      # builds restore from.
+      - name: Restore ccache
+        uses: actions/cache@v4
+        with:
+          path: .ccache
+          key: ccache-llvm15-${{ github.ref_name }}-${{ github.sha }}
+          restore-keys: |
+            ccache-llvm15-${{ github.ref_name }}-
+            ccache-llvm15-dev15-
+            ccache-llvm15-
+      - name: Build SeaHorn (ccache-backed)
+        run: |
+          docker run --rm \
+            -v "$(pwd)":/seahorn \
+            -v "$(pwd)/.ccache":/ccache \
+            -e CCACHE_DIR=/ccache \
+            -e BUILD_TYPE=RelWithDebInfo \
+            ghcr.io/${{ github.repository_owner }}/buildpack-deps-seahorn:jammy-llvm15 \
+            bash /seahorn/docker/build_seahorn.sh
+          cp build/SeaHorn*.tar.gz .
+          # ccache files are written by root in the container; make them
+          # readable to the runner user so actions/cache can pack them.
+          sudo chown -R "$(id -u):$(id -g)" .ccache
       - name: Build seahorn container
         run: docker build . --file docker/seahorn.Dockerfile --build-arg BUILDPACK_IMAGE=ghcr.io/${{ github.repository_owner }}/buildpack-deps-seahorn --tag seahorn_container
       - name: Run opsem tests

--- a/.github/workflows/test-seahorn-docker.yml
+++ b/.github/workflows/test-seahorn-docker.yml
@@ -28,11 +28,31 @@ jobs:
         uses: actions/checkout@v2
       - name: Login to GitHub Container Registry
         run: echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-      - name: Build seahorn builder
-        run: docker build . --file docker/seahorn-builder.Dockerfile --build-arg BUILDPACK_IMAGE=ghcr.io/${{ github.repository_owner }}/buildpack-deps-seahorn --tag seahorn/seahorn-builder:jammy-llvm15
-      - name: Copy build out to /host
-        run: docker run -v $(pwd):/host seahorn/seahorn-builder:jammy-llvm15 /bin/sh -c "cp build/SeaHorn*.tar.gz /host/"
-      - name: Build seahorn container  
+      # Persist the ccache directory across runs so only changed translation
+      # units recompile. PR builds restore the dev15 cache via restore-keys.
+      - name: Restore ccache
+        uses: actions/cache@v4
+        with:
+          path: .ccache
+          key: ccache-llvm15-${{ github.ref_name }}-${{ github.sha }}
+          restore-keys: |
+            ccache-llvm15-${{ github.ref_name }}-
+            ccache-llvm15-dev15-
+            ccache-llvm15-
+      - name: Build SeaHorn (ccache-backed)
+        run: |
+          docker run --rm \
+            -v "$(pwd)":/seahorn \
+            -v "$(pwd)/.ccache":/ccache \
+            -e CCACHE_DIR=/ccache \
+            -e BUILD_TYPE=RelWithDebInfo \
+            ghcr.io/${{ github.repository_owner }}/buildpack-deps-seahorn:jammy-llvm15 \
+            bash /seahorn/docker/build_seahorn.sh
+          cp build/SeaHorn*.tar.gz .
+          # ccache files are written by root in the container; make them
+          # readable to the runner user so actions/cache can pack them.
+          sudo chown -R "$(id -u):$(id -g)" .ccache
+      - name: Build seahorn container
         run: docker build . --file docker/seahorn.Dockerfile --build-arg BUILDPACK_IMAGE=ghcr.io/${{ github.repository_owner }}/buildpack-deps-seahorn --tag seahorn_container
       - name: Run opsem tests
         run: docker run -v $(pwd):/host seahorn_container /bin/bash -c "cd seahorn/share/seahorn && lit -a --time-tests --max-time=1200 test/opsem "

--- a/docker/build_seahorn.sh
+++ b/docker/build_seahorn.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+#
+# Build SeaHorn and produce the binary release tarball (SeaHorn-*.tar.gz).
+#
+# Single source of truth for the build commands, used in two ways:
+#   * baked into an image by docker/seahorn-builder.Dockerfile
+#     (COPY . /seahorn ; RUN bash docker/build_seahorn.sh), and
+#   * invoked via `docker run` in CI with the source tree and a persistent
+#     ccache directory mounted, so C/C++ compilation is incrementally cached
+#     across builds (ccache caches object files; ninja still re-links).
+#
+# Environment:
+#   SRC_DIR     SeaHorn source tree           (default: /seahorn)
+#   BUILD_TYPE  CMake build type              (default: RelWithDebInfo)
+#   CCACHE_DIR  ccache cache directory        (default: /ccache)
+#
+set -euo pipefail
+
+SRC_DIR=${SRC_DIR:-/seahorn}
+BUILD_TYPE=${BUILD_TYPE:-RelWithDebInfo}
+export CCACHE_DIR=${CCACHE_DIR:-/ccache}
+# Make cached files world-readable so the host runner (a different uid) can
+# pack the cache directory with actions/cache after a containerized build.
+export CCACHE_UMASK=${CCACHE_UMASK:-000}
+export CCACHE_MAXSIZE=${CCACHE_MAXSIZE:-5G}
+# The source path is stable (/seahorn) across runs, so absolute paths baked
+# into the cache key stay consistent and hit rates remain high.
+
+# The published base image (buildpack-deps-seahorn) may predate ccache being
+# added to its Dockerfile; install it on demand (same pattern as filecheck).
+if ! command -v ccache >/dev/null 2>&1; then
+  apt-get update -qq && apt-get install -yqq ccache
+fi
+# Regression tooling may be missing from a stale base image.
+pip3 install --quiet filecheck || true
+
+# When the source tree is bind-mounted in CI it is owned by the host runner
+# user, but this script runs as root in the container; tell git not to reject
+# the differing owner (otherwise the `extra` clone/version steps fail).
+git config --global --add safe.directory '*' || true
+
+cd "$SRC_DIR"
+# ccache provides incrementality, not the build directory: always start from a
+# clean tree and drop any third-party clones left by a previous run.
+rm -rf build debug release clam sea-dsa llvm-seahorn
+mkdir build
+cd build
+
+ccache --zero-stats >/dev/null 2>&1 || true
+
+cmake .. -GNinja \
+  -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
+  -DZ3_ROOT=/opt/z3-4.8.9 \
+  -DYICES2_HOME=/opt/yices-2.6.1 \
+  -DCMAKE_INSTALL_PREFIX=run \
+  -DCMAKE_CXX_COMPILER=clang++-15 \
+  -DCMAKE_C_COMPILER=clang-15 \
+  -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+  -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+  -DSEA_ENABLE_LLD=ON \
+  -DCPACK_GENERATOR="TGZ" \
+  -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+  -DWITH_CLAM=OFF
+
+# `extra` clones the third-party projects; re-run cmake to pick them up.
+cmake --build . --target extra
+cmake ..
+cmake --build . --target install
+cmake --build . --target units_z3
+cmake --build . --target units_yices2
+cmake --build . --target test_type_checker
+cmake --build . --target test_hex_dump
+cmake --build . --target package
+
+units/units_z3
+units/units_yices2
+units/units_type_checker
+
+echo "==== ccache statistics ===="
+ccache --show-stats || true

--- a/docker/buildpack-deps-seahorn.Dockerfile
+++ b/docker/buildpack-deps-seahorn.Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update && \
   apt-get install -yqq cmake cmake-data unzip \
       zlib1g-dev \
       ninja-build libgraphviz-dev \
+      ccache \
       libgmp-dev libmpfr-dev \
       libboost1.74-dev \
       python3-pip \

--- a/docker/seahorn-builder.Dockerfile
+++ b/docker/seahorn-builder.Dockerfile
@@ -9,43 +9,16 @@ ARG BUILDPACK_IMAGE=ghcr.io/seahorn/buildpack-deps-seahorn
 ARG BASE_IMAGE=jammy-llvm15
 FROM ${BUILDPACK_IMAGE}:${BASE_IMAGE}
 
-# Tests (also run for coverage in this image) use `filecheck` (the maintained
-# pip package that replaces OutputCheck); the pre-built base may predate this.
-RUN pip3 install filecheck
-
 # Assume that docker-build is ran in the top-level SeaHorn directory
 COPY . /seahorn
-# Re-create the build directory that might have been present in the source tree
-RUN rm -rf /seahorn/build /seahorn/debug /seahorn/release && \
-  mkdir /seahorn/build && \
-# Remove any third-party dependencies that build process clones
-  rm -rf /seahorn/clam /seahorn/sea-dsa /seahorn/llvm-seahorn
-WORKDIR /seahorn/build
 
 ARG BUILD_TYPE=RelWithDebInfo
 
-# Build configuration
-RUN cmake .. -GNinja \
-  -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
-  -DZ3_ROOT=/opt/z3-4.8.9 \
-  -DYICES2_HOME=/opt/yices-2.6.1 \
-  -DCMAKE_INSTALL_PREFIX=run \
-  -DCMAKE_CXX_COMPILER=clang++-15 \
-  -DCMAKE_C_COMPILER=clang-15 \
-  -DSEA_ENABLE_LLD=ON \
-  -DCPACK_GENERATOR="TGZ" \
-  -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-  -DWITH_CLAM=OFF && \
-  cmake --build . --target extra  && cmake .. && \
-  cmake --build . --target install && \
-  cmake --build . --target units_z3 && \
-  cmake --build . --target units_yices2 && \
-  cmake --build . --target test_type_checker && \
-  cmake --build . --target test_hex_dump && \
-  cmake --build . --target package && \
-  units/units_z3 && \
-  units/units_yices2 && \
-  units/units_type_checker
+# The build commands live in docker/build_seahorn.sh, shared with the CI
+# `docker run` build (which mounts a persistent ccache directory). Inside this
+# image there is no cache mount, so ccache simply has no prior entries to reuse.
+RUN BUILD_TYPE=${BUILD_TYPE} CCACHE_DIR=/seahorn/.ccache \
+  bash /seahorn/docker/build_seahorn.sh
 
 ENV PATH "/seahorn/build/run/bin:$PATH"
 WORKDIR /seahorn


### PR DESCRIPTION
Move the heavy SeaHorn compile out of `docker build` and into a `docker run` of the buildpack-deps base image with the source tree and a persistent ccache directory bind-mounted, so only changed translation units recompile across CI runs.

- Add docker/build_seahorn.sh as the single source of truth for the build, with ccache compiler launchers and stats; seahorn-builder .Dockerfile now calls it (no cache mount there, so it just builds).
- Add ccache to the buildpack-deps base image.
- Persist .ccache via actions/cache in the CI and Nightly workflows; PR builds seed from the dev15 cache via restore-keys.
- Ignore the ccache dir and third-party clones produced in the mounted workspace so they stay out of the slim image build context.