### PR TITLE
Port SeaHorn to LLVM 18

### DIFF
--- a/.github/workflows/buildpack-deps.yml
+++ b/.github/workflows/buildpack-deps.yml
@@ -29,10 +29,10 @@ jobs:
       - name: Check Out Repo
         uses: actions/checkout@v2
         with:
-          ref: dev17
+          ref: dev18
       - name: Login to GitHub Container Registry
         run: echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       - name: Build buildpack-deps image
-        run: docker build . --file docker/buildpack-deps-seahorn.Dockerfile --build-arg LLVM_VERSION=17 --tag ghcr.io/${{ github.repository_owner }}/buildpack-deps-seahorn:jammy-llvm17
+        run: docker build . --file docker/buildpack-deps-seahorn.Dockerfile --build-arg LLVM_VERSION=18 --tag ghcr.io/${{ github.repository_owner }}/buildpack-deps-seahorn:jammy-llvm18
       - name: Push buildpack-deps image
-        run: docker push ghcr.io/${{ github.repository_owner }}/buildpack-deps-seahorn:jammy-llvm17
+        run: docker push ghcr.io/${{ github.repository_owner }}/buildpack-deps-seahorn:jammy-llvm18

--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Setup environment
         run: |
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
-          sudo apt-get install -yqq clang-format-17
+          sudo apt-get install -yqq clang-format-18
       - name: Checkout
         run: |
           git clone https://github.com/${{ github.repository }}.git .
@@ -21,7 +21,7 @@ jobs:
       - name: Run clang-format
         run: |
           git diff ${{ github.base_ref }} -U0 --no-color -- '**/*.cpp' '**/*.cc' '**/*.h' '**/*.hh' \
-            | clang-format-diff-17 -p1 >not-formatted.diff 2>&1
+            | clang-format-diff-18 -p1 >not-formatted.diff 2>&1
       - name: Check formatting
         run: |
           if ! grep -q '[^[:space:]]' not-formatted.diff ; then
@@ -29,7 +29,7 @@ jobs:
           else
             echo "Code not formatted."
             echo "Please run clang-format-diff on your changes and push again:"
-            echo "    git diff ${{ github.base_ref }} -U0 --no-color | clang-format-diff-17 -p1 -i"
+            echo "    git diff ${{ github.base_ref }} -U0 --no-color | clang-format-diff-18 -p1 -i"
             echo ""
             echo "Tip: you can selectively disable clang-format checks. See https://clang.llvm.org/docs/ClangFormatStyleOptions.html#disabling-formatting-on-a-piece-of-code"
             echo ""

--- a/.github/workflows/test-seahorn-docker.yml
+++ b/.github/workflows/test-seahorn-docker.yml
@@ -4,11 +4,11 @@ name: CI
 
 # Controls when the action will run.
 on:
-  # dev17 branch copy: build and test with the LLVM 17 toolchain.
+  # dev18 branch copy: build and test with the LLVM 18 toolchain.
   push:
-    branches: dev17
+    branches: dev18
   pull_request:
-    branches: dev17
+    branches: dev18
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -29,16 +29,16 @@ jobs:
       - name: Login to GitHub Container Registry
         run: echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       # Persist the ccache directory across runs so only changed translation
-      # units recompile. PR builds restore the dev17 cache via restore-keys.
+      # units recompile. PR builds restore the dev18 cache via restore-keys.
       - name: Restore ccache
         uses: actions/cache@v4
         with:
           path: .ccache
-          key: ccache-llvm17-${{ github.ref_name }}-${{ github.sha }}
+          key: ccache-llvm18-${{ github.ref_name }}-${{ github.sha }}
           restore-keys: |
-            ccache-llvm17-${{ github.ref_name }}-
-            ccache-llvm17-dev17-
-            ccache-llvm17-
+            ccache-llvm18-${{ github.ref_name }}-
+            ccache-llvm18-dev18-
+            ccache-llvm18-
       - name: Build SeaHorn (ccache-backed)
         run: |
           docker run --rm \
@@ -46,15 +46,15 @@ jobs:
             -v "$(pwd)/.ccache":/ccache \
             -e CCACHE_DIR=/ccache \
             -e BUILD_TYPE=RelWithDebInfo \
-            -e LLVM_VERSION=17 \
-            ghcr.io/${{ github.repository_owner }}/buildpack-deps-seahorn:jammy-llvm17 \
+            -e LLVM_VERSION=18 \
+            ghcr.io/${{ github.repository_owner }}/buildpack-deps-seahorn:jammy-llvm18 \
             bash /seahorn/docker/build_seahorn.sh
           cp build/SeaHorn*.tar.gz .
           # ccache files are written by root in the container; make them
           # readable to the runner user so actions/cache can pack them.
           sudo chown -R "$(id -u):$(id -g)" .ccache
       - name: Build seahorn container
-        run: docker build . --file docker/seahorn.Dockerfile --build-arg BUILDPACK_IMAGE=ghcr.io/${{ github.repository_owner }}/buildpack-deps-seahorn --build-arg BASE_IMAGE=jammy-llvm17 --tag seahorn_container
+        run: docker build . --file docker/seahorn.Dockerfile --build-arg BUILDPACK_IMAGE=ghcr.io/${{ github.repository_owner }}/buildpack-deps-seahorn --build-arg BASE_IMAGE=jammy-llvm18 --tag seahorn_container
       - name: Run opsem tests
         run: docker run -v $(pwd):/host seahorn_container /bin/bash -c "cd seahorn/share/seahorn && lit -a --time-tests --max-time=1200 test/opsem "
       - name: Run opsem2 tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,9 +76,9 @@ if (GIT_FOUND)
     CACHE STRING "clam repo")
   
   add_custom_target (llvm-seahorn-git
-    ${GIT_EXECUTABLE} clone ${SEAHORN_LLVM_REPO} ${CMAKE_SOURCE_DIR}/llvm-seahorn -b dev17)
+    ${GIT_EXECUTABLE} clone ${SEAHORN_LLVM_REPO} ${CMAKE_SOURCE_DIR}/llvm-seahorn -b dev18)
   add_custom_target (sea-dsa-git
-    ${GIT_EXECUTABLE} clone ${SEA_DSA_REPO} ${CMAKE_SOURCE_DIR}/sea-dsa -b dev17)
+    ${GIT_EXECUTABLE} clone ${SEA_DSA_REPO} ${CMAKE_SOURCE_DIR}/sea-dsa -b dev18)
   # clam is not ported to LLVM 16 (WITH_CLAM=OFF); keep cloning its dev15
   # branch so the `extra` target still resolves.
   add_custom_target (clam-git
@@ -180,7 +180,7 @@ endif()
 # Pull in zstd's imported targets first so find_package(LLVM) can resolve it.
 find_package (zstd QUIET)
 
-find_package (LLVM 17 CONFIG)
+find_package (LLVM 18.1 CONFIG)
 if (NOT LLVM_FOUND)
   ExternalProject_Get_Property (llvm INSTALL_DIR)
   set (LLVM_ROOT ${INSTALL_DIR})

--- a/docker/build_seahorn.sh
+++ b/docker/build_seahorn.sh
@@ -18,8 +18,8 @@ set -euo pipefail
 
 SRC_DIR=${SRC_DIR:-/seahorn}
 BUILD_TYPE=${BUILD_TYPE:-RelWithDebInfo}
-# LLVM major version; the dev17 branch builds with clang/LLVM 17.
-LLVM_VERSION=${LLVM_VERSION:-17}
+# LLVM major version; the dev18 branch builds with clang/LLVM 18.
+LLVM_VERSION=${LLVM_VERSION:-18}
 export CCACHE_DIR=${CCACHE_DIR:-/ccache}
 # Make cached files world-readable so the host runner (a different uid) can
 # pack the cache directory with actions/cache after a containerized build.

--- a/docker/buildpack-deps-seahorn.Dockerfile
+++ b/docker/buildpack-deps-seahorn.Dockerfile
@@ -11,7 +11,7 @@ FROM buildpack-deps:$BASE_IMAGE
 # LLVM major version to install. Jammy's own archive stops at clang-15, so the
 # toolchain comes from apt.llvm.org (which also serves 15, so this works for
 # rebuilding the llvm15 image too).
-ARG LLVM_VERSION=17
+ARG LLVM_VERSION=18
 
 # Install dependencies
 ARG DEBIAN_FRONTEND=noninteractive

--- a/docker/seahorn-builder.Dockerfile
+++ b/docker/seahorn-builder.Dockerfile
@@ -3,10 +3,10 @@
 # Arguments:
 #  - BUILDPACK_IMAGE: registry/owner of the buildpack-deps base image
 #                     (published to GHCR by the buildpack-deps workflow)
-#  - BASE-IMAGE: jammy-llvm17
+#  - BASE-IMAGE: jammy-llvm18
 #  - BUILD_TYPE: Debug, RelWithDebInfo, Coverage
 ARG BUILDPACK_IMAGE=ghcr.io/seahorn/buildpack-deps-seahorn
-ARG BASE_IMAGE=jammy-llvm17
+ARG BASE_IMAGE=jammy-llvm18
 FROM ${BUILDPACK_IMAGE}:${BASE_IMAGE}
 
 # Assume that docker-build is ran in the top-level SeaHorn directory

--- a/docker/seahorn.Dockerfile
+++ b/docker/seahorn.Dockerfile
@@ -6,7 +6,7 @@
 #
 
 ARG BUILDPACK_IMAGE=ghcr.io/seahorn/buildpack-deps-seahorn
-ARG BASE_IMAGE=jammy-llvm17
+ARG BASE_IMAGE=jammy-llvm18
 FROM ${BUILDPACK_IMAGE}:${BASE_IMAGE}
 ENV SEAHORN=/home/usea/seahorn/bin/sea PATH="$PATH:/home/usea/seahorn/bin"
 USER root

--- a/include/seahorn/CexHarnessImpl.hh
+++ b/include/seahorn/CexHarnessImpl.hh
@@ -89,7 +89,7 @@ void dumpLLVMCex(BmcTraceWrapper<Trace> &trace, StringRef CexFile,
   }
   assert(!error_code);
   verifyModule(*Harness, &errs());
-  if (CexFile.endswith(".ll"))
+  if (CexFile.ends_with(".ll"))
     out.os() << *Harness;
   else
     WriteBitcodeToFile(*Harness, out.os());
@@ -219,7 +219,7 @@ createCexHarness(BmcTraceWrapper<Trace> &trace, const DataLayout &dl,
         // We want to ignore seahorn functions, but not nondet
         // functions created by strip-extern or dummyMainFunction
         if (CF->getName().find_first_of('.') != StringRef::npos &&
-            !CF->getName().startswith("verifier.nondet"))
+            !CF->getName().starts_with("verifier.nondet"))
           continue;
         if (!CF->isExternalLinkage(CF->getLinkage()))
           continue;
@@ -273,11 +273,11 @@ createCexHarness(BmcTraceWrapper<Trace> &trace, const DataLayout &dl,
       pRT = RT->getPointerTo();
     } else if (RT->isIntegerTy()) {
       TypeSize tsz = dl.getTypeStoreSizeInBits(RT);
-      auto bitsz = tsz.getFixedSize();
+      auto bitsz = tsz.getFixedValue();
       eRT = Type::getIntNTy(TheContext, bitsz);
       pRT = eRT->getPointerTo();
     } else {
-      pRT = Type::getInt8PtrTy(TheContext);
+      pRT = PointerType::getUnqual(TheContext);
     }
 
     ArrayType *AT = nullptr;
@@ -390,7 +390,7 @@ createCexHarness(BmcTraceWrapper<Trace> &trace, const DataLayout &dl,
   {
     Type *intTy = IntegerType::get(TheContext, 64);
     Type *intPtrTy = dl.getIntPtrType(TheContext, 0);
-    Type *i8PtrTy = Type::getInt8PtrTy(TheContext, 0);
+    Type *i8PtrTy = PointerType::getUnqual(TheContext);
 
     // Hook for gdb-like tools. Used to translate virtual addresses to
     // physical ones if that's the case. This is useful so we can

--- a/include/seahorn/Transforms/Instrumentation/ShadowMemDsa.hh
+++ b/include/seahorn/Transforms/Instrumentation/ShadowMemDsa.hh
@@ -77,7 +77,7 @@ inline bool isShadowMem(const Value &V, const Value **out) {
 
     if (auto *ci = dyn_cast<const CallInst>(val)) {
       if (const Function *fn = ci->getCalledFunction()) {
-        if (!fn->getName().startswith("shadow.mem"))
+        if (!fn->getName().starts_with("shadow.mem"))
           return false;
         if (out)
           *out = extractUniqueScalar(*ci);
@@ -89,7 +89,7 @@ inline bool isShadowMem(const Value &V, const Value **out) {
       for (unsigned i = 0; i < phi->getNumIncomingValues(); ++i)
         wl.push(phi->getIncomingValue(i));
     } else if (const SelectInst *gamma = dyn_cast<const SelectInst>(val)) {
-      if (gamma->getName().startswith("seahorn.gsa")) {
+      if (gamma->getName().starts_with("seahorn.gsa")) {
         wl.push(gamma->getTrueValue());
         wl.push(gamma->getFalseValue());
       } else

--- a/lib/Analysis/CanAccessMemory.cc
+++ b/lib/Analysis/CanAccessMemory.cc
@@ -26,9 +26,9 @@ bool CanAccessMemory::runOnModule(Module &M) {
       }
       if (const CallInst *CI = dyn_cast<CallInst>(&I)) {
         const Function *cf = CI->getCalledFunction();
-        if (cf && (cf->getName().startswith("llvm.memcpy") ||
-                   cf->getName().startswith("llvm.memmove") ||
-                   cf->getName().startswith("llvm.memset"))) {
+        if (cf && (cf->getName().starts_with("llvm.memcpy") ||
+                   cf->getName().starts_with("llvm.memmove") ||
+                   cf->getName().starts_with("llvm.memset"))) {
           m_must.insert(&F);
           break;
         }

--- a/lib/Analysis/SeaBuiltinsInfo.cc
+++ b/lib/Analysis/SeaBuiltinsInfo.cc
@@ -232,7 +232,7 @@ Function *SeaBuiltinsInfo::mkAssertAssumeFn(Module &M, SeaBuiltinsOp op) {
 Function *SeaBuiltinsInfo::mkIsModifiedFn(Module &M) {
   auto &C = M.getContext();
   auto FC = M.getOrInsertFunction(SEA_IS_MODIFIED, Type::getInt1Ty(C),
-                                  Type::getInt8PtrTy(C));
+                                  PointerType::getUnqual(C));
   auto *FN = dyn_cast<Function>(FC.getCallee());
   if (FN) {
     FN->setOnlyReadsMemory();
@@ -249,7 +249,7 @@ Function *SeaBuiltinsInfo::mkIsModifiedFn(Module &M) {
 Function *SeaBuiltinsInfo::mkResetModifiedFn(Module &M) {
   auto &C = M.getContext();
   auto FC = M.getOrInsertFunction(SEA_RESET_MODIFIED, Type::getVoidTy(C),
-                                  Type::getInt8PtrTy(C));
+                                  PointerType::getUnqual(C));
   auto *FN = dyn_cast<Function>(FC.getCallee());
   if (FN) {
     FN->setDoesNotThrow();
@@ -265,7 +265,7 @@ Function *SeaBuiltinsInfo::mkResetModifiedFn(Module &M) {
 Function *SeaBuiltinsInfo::mkIsReadFn(Module &M) {
   auto &C = M.getContext();
   auto FC = M.getOrInsertFunction(SEA_IS_READ, Type::getInt1Ty(C),
-                                  Type::getInt8PtrTy(C));
+                                  PointerType::getUnqual(C));
   auto *FN = dyn_cast<Function>(FC.getCallee());
   if (FN) {
     FN->setOnlyReadsMemory();
@@ -282,7 +282,7 @@ Function *SeaBuiltinsInfo::mkIsReadFn(Module &M) {
 Function *SeaBuiltinsInfo::mkResetReadFn(Module &M) {
   auto &C = M.getContext();
   auto FC = M.getOrInsertFunction(SEA_RESET_READ, Type::getVoidTy(C),
-                                  Type::getInt8PtrTy(C));
+                                  PointerType::getUnqual(C));
   auto *FN = dyn_cast<Function>(FC.getCallee());
   if (FN) {
     FN->setDoesNotThrow();
@@ -301,7 +301,7 @@ Function *SeaBuiltinsInfo::mkGetShadowMem(llvm::Module &M) {
   auto FC = M.getOrInsertFunction(SEA_GET_SHADOWMEM,
                                   IntPtrTy,             // return type
                                   Type::getInt8Ty(C),   // slot number 0..255
-                                  Type::getInt8PtrTy(C) // address int8_t*
+                                  PointerType::getUnqual(C) // address int8_t*
   );
   auto *FN = dyn_cast<Function>(FC.getCallee());
   if (FN) {
@@ -320,7 +320,7 @@ Function *SeaBuiltinsInfo::mkSetShadowMem(llvm::Module &M) {
   auto FC = M.getOrInsertFunction(SEA_SET_SHADOWMEM,
                                   Type::getVoidTy(C),    // return type
                                   Type::getInt8Ty(C),    // slot number 0..255
-                                  Type::getInt8PtrTy(C), // address int8_t*
+                                  PointerType::getUnqual(C), // address int8_t*
                                   IntPtrTy               // value to set
   );
   auto *FN = dyn_cast<Function>(FC.getCallee());
@@ -336,7 +336,7 @@ Function *SeaBuiltinsInfo::mkSetShadowMem(llvm::Module &M) {
 Function *SeaBuiltinsInfo::mkIsAllocFn(Module &M) {
   auto &C = M.getContext();
   auto FC = M.getOrInsertFunction(SEA_IS_ALLOC, Type::getInt1Ty(C),
-                                  Type::getInt8PtrTy(C));
+                                  PointerType::getUnqual(C));
   auto *FN = dyn_cast<Function>(FC.getCallee());
   if (FN) {
     FN->setOnlyReadsMemory();
@@ -354,7 +354,7 @@ Function *SeaBuiltinsInfo::mkIsDereferenceable(Module &M) {
   auto &C = M.getContext();
   auto *IntPtrTy = M.getDataLayout().getIntPtrType(C);
   auto FC = M.getOrInsertFunction(SEA_IS_DEREFERENCEABLE, Type::getInt1Ty(C),
-                                  Type::getInt8PtrTy(C), IntPtrTy);
+                                  PointerType::getUnqual(C), IntPtrTy);
   auto *FN = dyn_cast<Function>(FC.getCallee());
   if (FN) {
     FN->setOnlyAccessesInaccessibleMemory();
@@ -473,7 +473,7 @@ Function *SeaBuiltinsInfo::mkTrackingOffFn(Module &M) {
 Function *SeaBuiltinsInfo::mkFreeFn(Module &M) {
   auto &C = M.getContext();
   auto FC = M.getOrInsertFunction(SEA_FREE, Type::getVoidTy(C),
-                                  Type::getInt8PtrTy(C));
+                                  PointerType::getUnqual(C));
   auto *FN = dyn_cast<Function>(FC.getCallee());
   if (FN) {
     FN->setDoesNotThrow();
@@ -491,8 +491,8 @@ Function *SeaBuiltinsInfo::mkMkOwn(Module &M) {
   // This consumes a shared ptr and returns an owned ptr
   auto &C = M.getContext();
   auto FC =
-      M.getOrInsertFunction(SEA_MK_OWN, Type::getInt8PtrTy(C) /* return  */,
-                            Type::getInt8PtrTy(C) /* param */);
+      M.getOrInsertFunction(SEA_MK_OWN, PointerType::getUnqual(C) /* return  */,
+                            PointerType::getUnqual(C) /* param */);
   auto *FN = dyn_cast<Function>(FC.getCallee());
   if (FN) {
     FN->setDoesNotThrow();
@@ -508,8 +508,8 @@ Function *SeaBuiltinsInfo::mkMkShr(Module &M) {
   // This consumes a shared ptr and returns an owned ptr
   auto &C = M.getContext();
   auto FC =
-      M.getOrInsertFunction(SEA_MK_SHR, Type::getInt8PtrTy(C) /* return  */,
-                            Type::getInt8PtrTy(C) /* param */);
+      M.getOrInsertFunction(SEA_MK_SHR, PointerType::getUnqual(C) /* return  */,
+                            PointerType::getUnqual(C) /* param */);
   auto *FN = dyn_cast<Function>(FC.getCallee());
   if (FN) {
     FN->setDoesNotThrow();
@@ -525,8 +525,8 @@ Function *SeaBuiltinsInfo::mkBorMkBor(Module &M) {
   // This consumes an owned/borowed/uniqued ptr and returns a bowrrowed ptr
   auto &C = M.getContext();
   auto FC =
-      M.getOrInsertFunction(SEA_BOR_MKBOR, Type::getInt8PtrTy(C) /* return  */,
-                            Type::getInt8PtrTy(C) /* param */);
+      M.getOrInsertFunction(SEA_BOR_MKBOR, PointerType::getUnqual(C) /* return  */,
+                            PointerType::getUnqual(C) /* param */);
   auto *FN = dyn_cast<Function>(FC.getCallee());
   if (FN) {
     FN->setDoesNotThrow();
@@ -543,8 +543,8 @@ Function *SeaBuiltinsInfo::mkBorMkBorPart(Module &M) {
   auto &C = M.getContext();
   auto *IntPtrTy = M.getDataLayout().getIntPtrType(C);
   auto FC = M.getOrInsertFunction(
-      SEA_BOR_MKBOR_PART, Type::getInt8PtrTy(C) /* return  */,
-      Type::getInt8PtrTy(C) /* param */, IntPtrTy /* start inclusive */,
+      SEA_BOR_MKBOR_PART, PointerType::getUnqual(C) /* return  */,
+      PointerType::getUnqual(C) /* param */, IntPtrTy /* start inclusive */,
       IntPtrTy /* end exclusive */);
   auto *FN = dyn_cast<Function>(FC.getCallee());
   if (FN) {
@@ -565,8 +565,8 @@ Function *SeaBuiltinsInfo::mkBorMkSuc(Module &M) {
   // This ptr will not be used until ptr created by bor_mkbor dies.
   auto &C = M.getContext();
   auto FC =
-      M.getOrInsertFunction(SEA_BOR_MKSUC, Type::getInt8PtrTy(C) /* return  */,
-                            Type::getInt8PtrTy(C) /* param */);
+      M.getOrInsertFunction(SEA_BOR_MKSUC, PointerType::getUnqual(C) /* return  */,
+                            PointerType::getUnqual(C) /* param */);
   auto *FN = dyn_cast<Function>(FC.getCallee());
   if (FN) {
     FN->setDoesNotThrow();
@@ -583,8 +583,8 @@ Function *SeaBuiltinsInfo::mkBeginUnique(Module &M) {
   // A unique ptr cannot escape to memory
   auto &C = M.getContext();
   auto FC = M.getOrInsertFunction(SEA_BEGIN_UNIQUE,
-                                  Type::getInt8PtrTy(C) /* return  */,
-                                  Type::getInt8PtrTy(C) /* param */);
+                                  PointerType::getUnqual(C) /* return  */,
+                                  PointerType::getUnqual(C) /* param */);
   auto *FN = dyn_cast<Function>(FC.getCallee());
   if (FN) {
     FN->setDoesNotThrow();
@@ -600,8 +600,8 @@ Function *SeaBuiltinsInfo::mkEndUnique(Module &M) {
   // This consumes a unique ptr and returns a shared ptr
   auto &C = M.getContext();
   auto FC =
-      M.getOrInsertFunction(SEA_END_UNIQUE, Type::getInt8PtrTy(C) /* return  */,
-                            Type::getInt8PtrTy(C) /* param */);
+      M.getOrInsertFunction(SEA_END_UNIQUE, PointerType::getUnqual(C) /* return  */,
+                            PointerType::getUnqual(C) /* param */);
   auto *FN = dyn_cast<Function>(FC.getCallee());
   if (FN) {
     FN->setDoesNotThrow();
@@ -619,8 +619,8 @@ Function *SeaBuiltinsInfo::mkBorMem2Reg(Module &M) {
   // To mark a subsequent load as a borrow load.
   auto &C = M.getContext();
   auto FC =
-      M.getOrInsertFunction(SEA_BOR_MEM2REG, Type::getInt8PtrTy(C) /* return */,
-                            Type::getInt8PtrTy(C) /* param 0 -- input ptr */);
+      M.getOrInsertFunction(SEA_BOR_MEM2REG, PointerType::getUnqual(C) /* return */,
+                            PointerType::getUnqual(C) /* param 0 -- input ptr */);
   auto *FN = dyn_cast<Function>(FC.getCallee());
   if (FN) {
     FN->setDoesNotThrow();
@@ -636,9 +636,9 @@ Function *SeaBuiltinsInfo::mkMovReg2Mem(Module &M) {
   // memory.
   auto &C = M.getContext();
   auto FC = M.getOrInsertFunction(
-      SEA_MOV_REG2MEM, Type::getInt8PtrTy(C) /* return */,
-      Type::getInt8PtrTy(C) /* param 0 -- src ptr */,
-      Type::getInt8PtrTy(C) /* param 0 -- dst ptrttoptr */);
+      SEA_MOV_REG2MEM, PointerType::getUnqual(C) /* return */,
+      PointerType::getUnqual(C) /* param 0 -- src ptr */,
+      PointerType::getUnqual(C) /* param 0 -- dst ptrttoptr */);
   auto *FN = dyn_cast<Function>(FC.getCallee());
   if (FN) {
     FN->setDoesNotThrow();
@@ -654,7 +654,7 @@ Function *SeaBuiltinsInfo::mkDie(Module &M) {
   // This consumes a ptr and semantically marks it as dead.
   auto &C = M.getContext();
   auto FC = M.getOrInsertFunction(SEA_DIE, Type::getVoidTy(C) /* return  */,
-                                  Type::getInt8PtrTy(C) /* param */);
+                                  PointerType::getUnqual(C) /* param */);
   auto *FN = dyn_cast<Function>(FC.getCallee());
   if (FN) {
     FN->setDoesNotThrow();
@@ -669,8 +669,8 @@ Function *SeaBuiltinsInfo::mkDie(Module &M) {
 Function *SeaBuiltinsInfo::mkMove(Module &M) {
   // This consumes an owned/borowed/uniqued ptr and returns a bowrrowed ptr
   auto &C = M.getContext();
-  auto FC = M.getOrInsertFunction(SEA_MOVE, Type::getInt8PtrTy(C) /* return  */,
-                                  Type::getInt8PtrTy(C) /* param */);
+  auto FC = M.getOrInsertFunction(SEA_MOVE, PointerType::getUnqual(C) /* return  */,
+                                  PointerType::getUnqual(C) /* param */);
   auto *FN = dyn_cast<Function>(FC.getCallee());
   if (FN) {
     FN->setDoesNotThrow();
@@ -686,7 +686,7 @@ Function *SeaBuiltinsInfo::mkGetFatPtrSlot(llvm::Module &M) {
   auto &C = M.getContext();
   auto FC = M.getOrInsertFunction(SEA_GET_FATPTR_SLOT,
                                   Type::getInt64Ty(C),   // return type
-                                  Type::getInt8PtrTy(C), // address int8_t* //
+                                  PointerType::getUnqual(C), // address int8_t* //
                                   Type::getInt8Ty(C)     // slot number 0..255
 
   );
@@ -705,8 +705,8 @@ Function *SeaBuiltinsInfo::mkSetFatPtrSlot(llvm::Module &M) {
   auto &C = M.getContext();
   auto FC =
       M.getOrInsertFunction(SEA_SET_FATPTR_SLOT,
-                            Type::getInt8PtrTy(C), // return type is int8_t
-                            Type::getInt8PtrTy(C), // address int8_t*
+                            PointerType::getUnqual(C), // return type is int8_t
+                            PointerType::getUnqual(C), // address int8_t*
                             Type::getInt8Ty(C),    // slot number 0..255
                             Type::getInt64Ty(C)    // value to set
       );

--- a/lib/Analysis/SeaBuiltinsInfo.cc
+++ b/lib/Analysis/SeaBuiltinsInfo.cc
@@ -299,8 +299,8 @@ Function *SeaBuiltinsInfo::mkGetShadowMem(llvm::Module &M) {
   auto &C = M.getContext();
   auto *IntPtrTy = M.getDataLayout().getIntPtrType(C);
   auto FC = M.getOrInsertFunction(SEA_GET_SHADOWMEM,
-                                  IntPtrTy,             // return type
-                                  Type::getInt8Ty(C),   // slot number 0..255
+                                  IntPtrTy,           // return type
+                                  Type::getInt8Ty(C), // slot number 0..255
                                   PointerType::getUnqual(C) // address int8_t*
   );
   auto *FN = dyn_cast<Function>(FC.getCallee());
@@ -318,10 +318,10 @@ Function *SeaBuiltinsInfo::mkSetShadowMem(llvm::Module &M) {
   auto &C = M.getContext();
   auto *IntPtrTy = M.getDataLayout().getIntPtrType(C);
   auto FC = M.getOrInsertFunction(SEA_SET_SHADOWMEM,
-                                  Type::getVoidTy(C),    // return type
-                                  Type::getInt8Ty(C),    // slot number 0..255
+                                  Type::getVoidTy(C), // return type
+                                  Type::getInt8Ty(C), // slot number 0..255
                                   PointerType::getUnqual(C), // address int8_t*
-                                  IntPtrTy               // value to set
+                                  IntPtrTy                   // value to set
   );
   auto *FN = dyn_cast<Function>(FC.getCallee());
   if (FN) {
@@ -524,9 +524,9 @@ Function *SeaBuiltinsInfo::mkMkShr(Module &M) {
 Function *SeaBuiltinsInfo::mkBorMkBor(Module &M) {
   // This consumes an owned/borowed/uniqued ptr and returns a bowrrowed ptr
   auto &C = M.getContext();
-  auto FC =
-      M.getOrInsertFunction(SEA_BOR_MKBOR, PointerType::getUnqual(C) /* return  */,
-                            PointerType::getUnqual(C) /* param */);
+  auto FC = M.getOrInsertFunction(SEA_BOR_MKBOR,
+                                  PointerType::getUnqual(C) /* return  */,
+                                  PointerType::getUnqual(C) /* param */);
   auto *FN = dyn_cast<Function>(FC.getCallee());
   if (FN) {
     FN->setDoesNotThrow();
@@ -564,9 +564,9 @@ Function *SeaBuiltinsInfo::mkBorMkSuc(Module &M) {
   // This consumes an KIND (owned/borowed/uniqued) ptr and returns a KIND ptr.
   // This ptr will not be used until ptr created by bor_mkbor dies.
   auto &C = M.getContext();
-  auto FC =
-      M.getOrInsertFunction(SEA_BOR_MKSUC, PointerType::getUnqual(C) /* return  */,
-                            PointerType::getUnqual(C) /* param */);
+  auto FC = M.getOrInsertFunction(SEA_BOR_MKSUC,
+                                  PointerType::getUnqual(C) /* return  */,
+                                  PointerType::getUnqual(C) /* param */);
   auto *FN = dyn_cast<Function>(FC.getCallee());
   if (FN) {
     FN->setDoesNotThrow();
@@ -599,9 +599,9 @@ Function *SeaBuiltinsInfo::mkBeginUnique(Module &M) {
 Function *SeaBuiltinsInfo::mkEndUnique(Module &M) {
   // This consumes a unique ptr and returns a shared ptr
   auto &C = M.getContext();
-  auto FC =
-      M.getOrInsertFunction(SEA_END_UNIQUE, PointerType::getUnqual(C) /* return  */,
-                            PointerType::getUnqual(C) /* param */);
+  auto FC = M.getOrInsertFunction(SEA_END_UNIQUE,
+                                  PointerType::getUnqual(C) /* return  */,
+                                  PointerType::getUnqual(C) /* param */);
   auto *FN = dyn_cast<Function>(FC.getCallee());
   if (FN) {
     FN->setDoesNotThrow();
@@ -618,9 +618,9 @@ Function *SeaBuiltinsInfo::mkBorMem2Reg(Module &M) {
   // borrowed ptr.
   // To mark a subsequent load as a borrow load.
   auto &C = M.getContext();
-  auto FC =
-      M.getOrInsertFunction(SEA_BOR_MEM2REG, PointerType::getUnqual(C) /* return */,
-                            PointerType::getUnqual(C) /* param 0 -- input ptr */);
+  auto FC = M.getOrInsertFunction(
+      SEA_BOR_MEM2REG, PointerType::getUnqual(C) /* return */,
+      PointerType::getUnqual(C) /* param 0 -- input ptr */);
   auto *FN = dyn_cast<Function>(FC.getCallee());
   if (FN) {
     FN->setDoesNotThrow();
@@ -669,8 +669,9 @@ Function *SeaBuiltinsInfo::mkDie(Module &M) {
 Function *SeaBuiltinsInfo::mkMove(Module &M) {
   // This consumes an owned/borowed/uniqued ptr and returns a bowrrowed ptr
   auto &C = M.getContext();
-  auto FC = M.getOrInsertFunction(SEA_MOVE, PointerType::getUnqual(C) /* return  */,
-                                  PointerType::getUnqual(C) /* param */);
+  auto FC =
+      M.getOrInsertFunction(SEA_MOVE, PointerType::getUnqual(C) /* return  */,
+                            PointerType::getUnqual(C) /* param */);
   auto *FN = dyn_cast<Function>(FC.getCallee());
   if (FN) {
     FN->setDoesNotThrow();
@@ -684,12 +685,13 @@ Function *SeaBuiltinsInfo::mkMove(Module &M) {
 }
 Function *SeaBuiltinsInfo::mkGetFatPtrSlot(llvm::Module &M) {
   auto &C = M.getContext();
-  auto FC = M.getOrInsertFunction(SEA_GET_FATPTR_SLOT,
-                                  Type::getInt64Ty(C),   // return type
-                                  PointerType::getUnqual(C), // address int8_t* //
-                                  Type::getInt8Ty(C)     // slot number 0..255
+  auto FC =
+      M.getOrInsertFunction(SEA_GET_FATPTR_SLOT,
+                            Type::getInt64Ty(C),       // return type
+                            PointerType::getUnqual(C), // address int8_t* //
+                            Type::getInt8Ty(C)         // slot number 0..255
 
-  );
+      );
   auto *FN = dyn_cast<Function>(FC.getCallee());
   if (FN) {
     FN->setDoesNotAccessMemory();
@@ -707,8 +709,8 @@ Function *SeaBuiltinsInfo::mkSetFatPtrSlot(llvm::Module &M) {
       M.getOrInsertFunction(SEA_SET_FATPTR_SLOT,
                             PointerType::getUnqual(C), // return type is int8_t
                             PointerType::getUnqual(C), // address int8_t*
-                            Type::getInt8Ty(C),    // slot number 0..255
-                            Type::getInt64Ty(C)    // value to set
+                            Type::getInt8Ty(C),        // slot number 0..255
+                            Type::getInt64Ty(C)        // value to set
       );
   auto *FN = dyn_cast<Function>(FC.getCallee());
   if (FN) {

--- a/lib/Transforms/Instrumentation/FatBufferBoundsCheck.cc
+++ b/lib/Transforms/Instrumentation/FatBufferBoundsCheck.cc
@@ -201,11 +201,13 @@ bool FatBufferBoundsCheck::instrument(Value *Ptr, Value *InstVal,
   Value *NeededSizeVal = ConstantInt::get(IntPtrTy, NeededSize);
   LOG("fat-bnd-check", errs() << "Instrument " << *Ptr << " for "
                               << Twine(NeededSize) << " bytes\n");
-  SizeOffsetEvalType SizeOffset = ObjSizeEval->compute(Ptr);
+  // LLVM 18: compute() returns SizeOffsetValue (bothKnown/knownSize and
+  // Size/Offset live on the value, not the evaluator).
+  SizeOffsetValue SizeOffset = ObjSizeEval->compute(Ptr);
   Value *Or;
 
   if (UseFatSlots) {
-    auto *ArgPtr = Builder->CreateBitCast(Ptr, Builder->getInt8PtrTy());
+    auto *ArgPtr = Builder->CreateBitCast(Ptr, Builder->getPtrTy());
     Value *RecovPtr = Builder->CreateCall(m_recoverFatPtr, ArgPtr);
     RawPtr = Builder->CreateBitCast(RecovPtr, Ptr->getType());
     Builder->CreateCall(m_seaDsaAlias, {ArgPtr, RecovPtr});
@@ -213,7 +215,7 @@ bool FatBufferBoundsCheck::instrument(Value *Ptr, Value *InstVal,
     RawPtr = Ptr;
   }
 
-  if (!ObjSizeEval->bothKnown(SizeOffset)) {
+  if (!SizeOffset.bothKnown()) {
     if (auto *GV = dyn_cast<GlobalVariable>(Ptr)) {
       // stderr is usually external and ObjSizeEval refuses to determine its
       // size
@@ -243,15 +245,15 @@ bool FatBufferBoundsCheck::instrument(Value *Ptr, Value *InstVal,
         is_access_bad := is_underflow or is_overflow
       */
       Value *Start = Builder->CreateCall(
-          m_getFatSlot0, Builder->CreateBitCast(Ptr, Builder->getInt8PtrTy()));
+          m_getFatSlot0, Builder->CreateBitCast(Ptr, Builder->getPtrTy()));
       Value *Size = nullptr;
-      if (ObjSizeEval->knownSize(SizeOffset)) {
-        Size = SizeOffset.first;
+      if (SizeOffset.knownSize()) {
+        Size = SizeOffset.Size;
         ++ChecksKnownSize;
       } else {
         Size = Builder->CreateCall(
             m_getFatSlot1,
-            Builder->CreateBitCast(Ptr, Builder->getInt8PtrTy()));
+            Builder->CreateBitCast(Ptr, Builder->getPtrTy()));
       }
       assert(Size);
       Value *PtrAsInt = Builder->CreatePtrToInt(RawPtr, IntPtrTy);
@@ -268,7 +270,7 @@ bool FatBufferBoundsCheck::instrument(Value *Ptr, Value *InstVal,
                                   << Twine(NeededSize) << " bytes\n";);
       auto isDerefCall = Builder->CreateCall(
           m_seaIsDereferenceable,
-          {Builder->CreateBitCast(Ptr, Builder->getInt8PtrTy()),
+          {Builder->CreateBitCast(Ptr, Builder->getPtrTy()),
            NeededSizeVal});
       Or = Builder->CreateNot(isDerefCall);
     }
@@ -276,8 +278,8 @@ bool FatBufferBoundsCheck::instrument(Value *Ptr, Value *InstVal,
     // size and offest statically computed
     LOG("fat-bnd-check", errs() << "statically instrument " << *Ptr << " for "
                                 << Twine(NeededSize) << " bytes\n";);
-    Value *Size = SizeOffset.first;
-    Value *Offset = SizeOffset.second;
+    Value *Size = SizeOffset.Size;
+    Value *Offset = SizeOffset.Offset;
     ConstantInt *SizeCI = dyn_cast<ConstantInt>(Size);
 
     // three checks are required to ensure safety:
@@ -301,7 +303,7 @@ bool FatBufferBoundsCheck::instrument(Value *Ptr, Value *InstVal,
     LOG("fat-bnd-check", errs() << "isAlloc instrument " << *Ptr << "\n";);
     auto isAllocCall = Builder->CreateCall(
         m_seaIsAllocated,
-        {Builder->CreateBitCast(Ptr, Builder->getInt8PtrTy())});
+        {Builder->CreateBitCast(Ptr, Builder->getPtrTy())});
     Or = Builder->CreateOr(Or, Builder->CreateNot(isAllocCall));
   }
   emitBranchToTrap(Or);
@@ -334,11 +336,11 @@ bool FatBufferBoundsCheck::instrumentAlloca(AllocaInst *Ptr,
   // -- forward created calls. Arguments will be filled later
   // -- create a call to set slot0
   CallInst *withBase = Builder->CreateCall(
-      m_setFatSlot0, {Constant::getNullValue(Builder->getInt8PtrTy()),
+      m_setFatSlot0, {Constant::getNullValue(Builder->getPtrTy()),
                       ConstantInt::get(IntPtrTy, 0)});
   // -- create a call to set slot1
   CallInst *withSize = Builder->CreateCall(
-      m_setFatSlot1, {Constant::getNullValue(Builder->getInt8PtrTy()),
+      m_setFatSlot1, {Constant::getNullValue(Builder->getPtrTy()),
                       ConstantInt::get(IntPtrTy, 0)});
   // -- cast result of setting slot1 to same type as returned by alloca
   Value *NewPtr = Builder->CreateBitCast(withSize, AllocedTy->getPointerTo());
@@ -349,13 +351,13 @@ bool FatBufferBoundsCheck::instrumentAlloca(AllocaInst *Ptr,
 
   // set_fat_slot0(Ptr, Base)
   Builder->SetInsertPoint(withBase);
-  Value *argA = Builder->CreateBitCast(Ptr, Builder->getInt8PtrTy());
+  Value *argA = Builder->CreateBitCast(Ptr, Builder->getPtrTy());
   Value *argB = Builder->CreatePtrToInt(Ptr, IntPtrTy);
   withBase->setArgOperand(0, argA);
   withBase->setArgOperand(1, argB);
 
   // set_fat_slot1(Ptr, Size)
-  auto argC = Builder->CreateBitCast(withBase, Builder->getInt8PtrTy());
+  auto argC = Builder->CreateBitCast(withBase, Builder->getPtrTy());
   withSize->setArgOperand(0, argC);
   Builder->SetInsertPoint(withSize);
   auto size = DL.getTypeStoreSize(AllocedTy);
@@ -367,7 +369,7 @@ bool FatBufferBoundsCheck::instrumentAlloca(AllocaInst *Ptr,
   Builder->CreateCall(m_seaDsaAlias, {argA, argC});
   Builder->CreateCall(
       m_seaDsaAlias,
-      {argC, Builder->CreateBitCast(withSize, Builder->getInt8PtrTy())});
+      {argC, Builder->CreateBitCast(withSize, Builder->getPtrTy())});
 
   return true;
 }
@@ -384,7 +386,7 @@ bool FatBufferBoundsCheck::instrumentGep(GetElementPtrInst *Ptr,
   auto *BasePtr = Ptr->getPointerOperand();
 
   Builder->SetInsertPoint(Ptr);
-  auto *ArgBasePtr = Builder->CreateBitCast(BasePtr, Builder->getInt8PtrTy());
+  auto *ArgBasePtr = Builder->CreateBitCast(BasePtr, Builder->getPtrTy());
   Value *RecovPtr = Builder->CreateCall(m_recoverFatPtr, ArgBasePtr);
 
   Builder->CreateCall(m_seaDsaAlias, {ArgBasePtr, RecovPtr});
@@ -392,8 +394,8 @@ bool FatBufferBoundsCheck::instrumentGep(GetElementPtrInst *Ptr,
 
   Builder->SetInsertPoint(Ptr->getParent(), ++BasicBlock::iterator(Ptr));
   CallInst *SlotCopyCall = Builder->CreateCall(
-      m_copyFatSlots, {Constant::getNullValue(Builder->getInt8PtrTy()),
-                       Constant::getNullValue(Builder->getInt8PtrTy())});
+      m_copyFatSlots, {Constant::getNullValue(Builder->getPtrTy()),
+                       Constant::getNullValue(Builder->getPtrTy())});
   Value *Casted = Builder->CreateBitCast(SlotCopyCall, GepTy->getPointerTo());
   Ptr->replaceAllUsesWith(Casted);
   LOG("fat-bnd-check", errs()
@@ -401,8 +403,8 @@ bool FatBufferBoundsCheck::instrumentGep(GetElementPtrInst *Ptr,
                            << " with type " << *GepTy->getPointerTo() << "\n";);
 
   Builder->SetInsertPoint(SlotCopyCall);
-  auto *Arg0 = Builder->CreateBitCast(Ptr, Builder->getInt8PtrTy());
-  auto *Arg1 = Builder->CreateBitCast(BasePtr, Builder->getInt8PtrTy());
+  auto *Arg0 = Builder->CreateBitCast(Ptr, Builder->getPtrTy());
+  auto *Arg1 = Builder->CreateBitCast(BasePtr, Builder->getPtrTy());
   SlotCopyCall->setArgOperand(0, Arg0);
   SlotCopyCall->setArgOperand(1, Arg1);
 
@@ -452,7 +454,7 @@ bool FatBufferBoundsCheck::runImpl(Function &F, const TargetLibraryInfo &tli,
   if (UseFatSlots) {
     m_getFatSlot0 =
         cast<Function>(M->getOrInsertFunction(SEA_GET_FAT_SLOT0, IntPtrTy,
-                                              Type::getInt8PtrTy(C, 0))
+                                              PointerType::getUnqual(C))
                            .getCallee());
 
     m_getFatSlot0->setDoesNotThrow();
@@ -461,23 +463,23 @@ bool FatBufferBoundsCheck::runImpl(Function &F, const TargetLibraryInfo &tli,
 
     m_getFatSlot1 =
         cast<Function>(M->getOrInsertFunction(SEA_GET_FAT_SLOT1, IntPtrTy,
-                                              Type::getInt8PtrTy(C, 0))
+                                              PointerType::getUnqual(C))
                            .getCallee());
     m_getFatSlot1->setDoesNotThrow();
     m_getFatSlot1->setOnlyWritesMemory();
     m_getFatSlot1->addParamAttr(0, Attribute::NoCapture);
 
     m_setFatSlot0 = cast<Function>(
-        M->getOrInsertFunction(SEA_SET_FAT_SLOT0, Type::getInt8PtrTy(C, 0),
-                               Type::getInt8PtrTy(C, 0), IntPtrTy)
+        M->getOrInsertFunction(SEA_SET_FAT_SLOT0, PointerType::getUnqual(C),
+                               PointerType::getUnqual(C), IntPtrTy)
             .getCallee());
     m_setFatSlot0->setDoesNotThrow();
     m_setFatSlot0->setOnlyWritesMemory();
     // m_setFatSlot0->addParamAttr(0, Attribute::Returned);
 
     m_setFatSlot1 = cast<Function>(
-        M->getOrInsertFunction(SEA_SET_FAT_SLOT1, Type::getInt8PtrTy(C, 0),
-                               Type::getInt8PtrTy(C, 0), IntPtrTy)
+        M->getOrInsertFunction(SEA_SET_FAT_SLOT1, PointerType::getUnqual(C),
+                               PointerType::getUnqual(C), IntPtrTy)
             .getCallee());
     m_setFatSlot1->setDoesNotThrow();
     m_setFatSlot1->setOnlyWritesMemory();
@@ -485,8 +487,8 @@ bool FatBufferBoundsCheck::runImpl(Function &F, const TargetLibraryInfo &tli,
 
     m_copyFatSlots =
         cast<Function>(M->getOrInsertFunction(
-                            SEA_COPY_FAT_SLOTS, Type::getInt8PtrTy(C, 0),
-                            Type::getInt8PtrTy(C, 0), Type::getInt8PtrTy(C, 0))
+                            SEA_COPY_FAT_SLOTS, PointerType::getUnqual(C),
+                            PointerType::getUnqual(C), PointerType::getUnqual(C))
                            .getCallee());
     m_copyFatSlots->setDoesNotThrow();
     m_copyFatSlots->setOnlyWritesMemory();
@@ -494,8 +496,8 @@ bool FatBufferBoundsCheck::runImpl(Function &F, const TargetLibraryInfo &tli,
     m_copyFatSlots->addParamAttr(1, Attribute::NoCapture);
 
     m_recoverFatPtr = cast<Function>(
-        M->getOrInsertFunction(SEA_RECOVER_FAT_PTR, Type::getInt8PtrTy(C, 0),
-                               Type::getInt8PtrTy(C, 0))
+        M->getOrInsertFunction(SEA_RECOVER_FAT_PTR, PointerType::getUnqual(C),
+                               PointerType::getUnqual(C))
             .getCallee());
     m_recoverFatPtr->setDoesNotThrow();
     m_recoverFatPtr->setOnlyWritesMemory();
@@ -503,8 +505,8 @@ bool FatBufferBoundsCheck::runImpl(Function &F, const TargetLibraryInfo &tli,
 
     m_seaDsaAlias =
         cast<Function>(M->getOrInsertFunction(SEA_DSA_ALIAS, Type::getVoidTy(C),
-                                              Type::getInt8PtrTy(C, 0),
-                                              Type::getInt8PtrTy(C, 0))
+                                              PointerType::getUnqual(C),
+                                              PointerType::getUnqual(C))
                            .getCallee());
   }
 

--- a/lib/Transforms/Instrumentation/FatBufferBoundsCheck.cc
+++ b/lib/Transforms/Instrumentation/FatBufferBoundsCheck.cc
@@ -252,8 +252,7 @@ bool FatBufferBoundsCheck::instrument(Value *Ptr, Value *InstVal,
         ++ChecksKnownSize;
       } else {
         Size = Builder->CreateCall(
-            m_getFatSlot1,
-            Builder->CreateBitCast(Ptr, Builder->getPtrTy()));
+            m_getFatSlot1, Builder->CreateBitCast(Ptr, Builder->getPtrTy()));
       }
       assert(Size);
       Value *PtrAsInt = Builder->CreatePtrToInt(RawPtr, IntPtrTy);
@@ -270,8 +269,7 @@ bool FatBufferBoundsCheck::instrument(Value *Ptr, Value *InstVal,
                                   << Twine(NeededSize) << " bytes\n";);
       auto isDerefCall = Builder->CreateCall(
           m_seaIsDereferenceable,
-          {Builder->CreateBitCast(Ptr, Builder->getPtrTy()),
-           NeededSizeVal});
+          {Builder->CreateBitCast(Ptr, Builder->getPtrTy()), NeededSizeVal});
       Or = Builder->CreateNot(isDerefCall);
     }
   } else {
@@ -302,8 +300,7 @@ bool FatBufferBoundsCheck::instrument(Value *Ptr, Value *InstVal,
   if (addIsAllocCheck) {
     LOG("fat-bnd-check", errs() << "isAlloc instrument " << *Ptr << "\n";);
     auto isAllocCall = Builder->CreateCall(
-        m_seaIsAllocated,
-        {Builder->CreateBitCast(Ptr, Builder->getPtrTy())});
+        m_seaIsAllocated, {Builder->CreateBitCast(Ptr, Builder->getPtrTy())});
     Or = Builder->CreateOr(Or, Builder->CreateNot(isAllocCall));
   }
   emitBranchToTrap(Or);
@@ -485,11 +482,11 @@ bool FatBufferBoundsCheck::runImpl(Function &F, const TargetLibraryInfo &tli,
     m_setFatSlot1->setOnlyWritesMemory();
     // m_setFatSlot1->addParamAttr(0, Attribute::Returned);
 
-    m_copyFatSlots =
-        cast<Function>(M->getOrInsertFunction(
-                            SEA_COPY_FAT_SLOTS, PointerType::getUnqual(C),
-                            PointerType::getUnqual(C), PointerType::getUnqual(C))
-                           .getCallee());
+    m_copyFatSlots = cast<Function>(
+        M->getOrInsertFunction(SEA_COPY_FAT_SLOTS, PointerType::getUnqual(C),
+                               PointerType::getUnqual(C),
+                               PointerType::getUnqual(C))
+            .getCallee());
     m_copyFatSlots->setDoesNotThrow();
     m_copyFatSlots->setOnlyWritesMemory();
     // m_copyFatSlots->addParamAttr(0, Attribute::Returned);

--- a/lib/Transforms/Instrumentation/GeneratePartialFnPass.cc
+++ b/lib/Transforms/Instrumentation/GeneratePartialFnPass.cc
@@ -38,7 +38,7 @@ namespace seahorn {
 
 // Declared in GeneratePartialFnPass.h
 bool isInferable(const Function &F) {
-  return F.getName().startswith(PARTIAL_FN_STUB_PREFIX);
+  return F.getName().starts_with(PARTIAL_FN_STUB_PREFIX);
 }
 
 // Declared in GeneratePartialFnPass.h

--- a/lib/Transforms/Instrumentation/KleeInternalize.cc
+++ b/lib/Transforms/Instrumentation/KleeInternalize.cc
@@ -60,7 +60,7 @@ class KleeInternalize : public ModulePass {
     m_intptrTy = m_dl->getIntPtrType(C, 0);
 
     Type *voidTy = Type::getVoidTy(C);
-    Type *i8PtrTy = Type::getInt8PtrTy(C);
+    Type *i8PtrTy = PointerType::getUnqual(C);
     Type *i32Ty = Type::getInt32Ty(C);
 
     m_assertFailFn = M.getOrInsertFunction("__assert_fail", voidTy, i8PtrTy,
@@ -87,7 +87,7 @@ class KleeInternalize : public ModulePass {
   bool shouldInternalize(const GlobalValue &GV) {
     if (!GV.isDeclaration())
       return false;
-    if (GV.getName().startswith("llvm."))
+    if (GV.getName().starts_with("llvm."))
       return false;
 
     if (!m_tli)
@@ -132,7 +132,7 @@ class KleeInternalize : public ModulePass {
       // TODO: update callgraph with this call
       CallInst *mksym = Builder.CreateCall(
           m_kleeMkSymbolicFn,
-          {Builder.CreateBitCast(v, Builder.getInt8PtrTy()), sz,
+          {Builder.CreateBitCast(v, Builder.getPtrTy()), sz,
            Builder.CreateConstGEP2_32(fname->getValueType(), fname, 0, 0)});
 
       (void)mksym;

--- a/lib/Transforms/Instrumentation/NondetInit.cc
+++ b/lib/Transforms/Instrumentation/NondetInit.cc
@@ -156,7 +156,7 @@ public:
           if (f == NULL)
             continue;
 
-          if (f->getName().startswith("verifier.nondet")) {
+          if (f->getName().starts_with("verifier.nondet")) {
             toerase.push_front(ci);
             ++NumKilled;
           }

--- a/lib/Transforms/Instrumentation/RenameNondet.cc
+++ b/lib/Transforms/Instrumentation/RenameNondet.cc
@@ -46,7 +46,7 @@ class RenameNondet : public ModulePass {
   bool shouldRename(const GlobalValue &GV) {
     if (!GV.isDeclaration())
       return false;
-    if (GV.getName().startswith("llvm."))
+    if (GV.getName().starts_with("llvm."))
       return false;
 
     if (!m_tli)

--- a/lib/Transforms/Instrumentation/SimpleMemoryCheck.cc
+++ b/lib/Transforms/Instrumentation/SimpleMemoryCheck.cc
@@ -867,7 +867,8 @@ void SimpleMemoryCheck::emitMemoryInstInstrumentation(CheckContext &Candidate) {
 
   auto *BeginCandiate = IRB.CreateBitOrPointerCast(
       Candidate.Barrier, GetI8PtrTy(*m_Ctx), "begin_candidate");
-  auto *TrackedBegin = CreateLoad(IRB, IRB.getPtrTy(), m_trackedBegin, m_DL, "tracked_begin");
+  auto *TrackedBegin =
+      CreateLoad(IRB, IRB.getPtrTy(), m_trackedBegin, m_DL, "tracked_begin");
   auto *Cmp = IRB.CreateICmpEQ(TrackedBegin, BeginCandiate);
   auto *Active = IRB.CreateLoad(IRB.getInt1Ty(), m_trackingEnabled, "active_tracking");
   auto *And = IRB.CreateAnd(Active, Cmp, "unsafe_condition");
@@ -910,7 +911,8 @@ void SimpleMemoryCheck::emitAllocSiteInstrumentation(CheckContext &Candidate,
                                        "inactive_tracking");
     auto *NDVal = getNDVal(32, CSFn, IRB);
     auto *NDBool = IRB.CreateICmpEQ(NDVal, CreateIntCnst(NDVal->getType(), 0));
-    auto *TrackedEnd = CreateLoad(IRB, IRB.getPtrTy(), m_trackedEnd, m_DL, "loaded_end");
+    auto *TrackedEnd =
+        CreateLoad(IRB, IRB.getPtrTy(), m_trackedEnd, m_DL, "loaded_end");
     auto *And = dyn_cast<Instruction>(IRB.CreateAnd(NotActive, NDBool));
     assert(And);
 
@@ -931,7 +933,8 @@ void SimpleMemoryCheck::emitAllocSiteInstrumentation(CheckContext &Candidate,
     // Start tracking.
     IRB.SetInsertPoint(ThenBB->getFirstNonPHI());
     CreateStore(IRB, ConstantInt::getTrue(*m_Ctx), m_trackingEnabled, m_DL);
-    auto *TrackedBegin = CreateLoad(IRB, IRB.getPtrTy(), m_trackedBegin, m_DL, "loaded_begin");
+    auto *TrackedBegin =
+        CreateLoad(IRB, IRB.getPtrTy(), m_trackedBegin, m_DL, "loaded_begin");
     auto *AllocIsBegin =
         IRB.CreateICmpEQ(AllocI8, TrackedBegin, "alloc.is.begin");
     createAssume(AllocIsBegin, CSFn, IRB);
@@ -957,7 +960,8 @@ void SimpleMemoryCheck::emitAllocSiteInstrumentation(CheckContext &Candidate,
     IRB.SetInsertPoint(GetNextInst(OtherAllocInst));
     auto *OAI8 =
         IRB.CreateBitCast(OtherAllocInst, GetI8PtrTy(*m_Ctx), "other.alloc.i8");
-    auto *TrackedEnd = CreateLoad(IRB, IRB.getPtrTy(), m_trackedEnd, m_DL, "loaded_end");
+    auto *TrackedEnd =
+        CreateLoad(IRB, IRB.getPtrTy(), m_trackedEnd, m_DL, "loaded_end");
     auto *GT = IRB.CreateICmpSGT(OAI8, TrackedEnd);
     createAssume(GT, OtherAllocInst->getFunction(), IRB);
 

--- a/lib/Transforms/Instrumentation/SimpleMemoryCheck.cc
+++ b/lib/Transforms/Instrumentation/SimpleMemoryCheck.cc
@@ -379,11 +379,13 @@ std::optional<size_t> SimpleMemoryCheck::getAllocSize(Value *Ptr) {
   Opts.RoundToAlign = true;
   Opts.EvalMode = llvm::ObjectSizeOpts::Mode::Max;
   ObjectSizeOffsetVisitor OSOV(*m_DL, m_TLI, *m_Ctx, Opts);
+  // LLVM 18: compute() returns SizeOffsetAPInt (knownSize/Size members)
+  // instead of a pair queried through the visitor.
   auto OffsetAlign = OSOV.compute(Ptr);
-  if (!OSOV.knownSize(OffsetAlign))
+  if (!OffsetAlign.knownSize())
     return std::nullopt;
 
-  const int64_t I = OffsetAlign.first.getSExtValue();
+  const int64_t I = OffsetAlign.Size.getSExtValue();
   assert(I >= 0);
   return size_t(I);
 }
@@ -646,7 +648,7 @@ CheckContext SimpleMemoryCheck::getUnsafeCandidates(Instruction *Inst,
 
         // Discard vtables.
         //        if (auto *C = dyn_cast<Constant>(AS))
-        //          if (C->getName().startswith("_ZTVN"))
+        //          if (C->getName().starts_with("_ZTVN"))
         //            Interesting = false;
       }
     }
@@ -865,7 +867,7 @@ void SimpleMemoryCheck::emitMemoryInstInstrumentation(CheckContext &Candidate) {
 
   auto *BeginCandiate = IRB.CreateBitOrPointerCast(
       Candidate.Barrier, GetI8PtrTy(*m_Ctx), "begin_candidate");
-  auto *TrackedBegin = CreateLoad(IRB, IRB.getInt8PtrTy(), m_trackedBegin, m_DL, "tracked_begin");
+  auto *TrackedBegin = CreateLoad(IRB, IRB.getPtrTy(), m_trackedBegin, m_DL, "tracked_begin");
   auto *Cmp = IRB.CreateICmpEQ(TrackedBegin, BeginCandiate);
   auto *Active = IRB.CreateLoad(IRB.getInt1Ty(), m_trackingEnabled, "active_tracking");
   auto *And = IRB.CreateAnd(Active, Cmp, "unsafe_condition");
@@ -908,7 +910,7 @@ void SimpleMemoryCheck::emitAllocSiteInstrumentation(CheckContext &Candidate,
                                        "inactive_tracking");
     auto *NDVal = getNDVal(32, CSFn, IRB);
     auto *NDBool = IRB.CreateICmpEQ(NDVal, CreateIntCnst(NDVal->getType(), 0));
-    auto *TrackedEnd = CreateLoad(IRB, IRB.getInt8PtrTy(), m_trackedEnd, m_DL, "loaded_end");
+    auto *TrackedEnd = CreateLoad(IRB, IRB.getPtrTy(), m_trackedEnd, m_DL, "loaded_end");
     auto *And = dyn_cast<Instruction>(IRB.CreateAnd(NotActive, NDBool));
     assert(And);
 
@@ -929,7 +931,7 @@ void SimpleMemoryCheck::emitAllocSiteInstrumentation(CheckContext &Candidate,
     // Start tracking.
     IRB.SetInsertPoint(ThenBB->getFirstNonPHI());
     CreateStore(IRB, ConstantInt::getTrue(*m_Ctx), m_trackingEnabled, m_DL);
-    auto *TrackedBegin = CreateLoad(IRB, IRB.getInt8PtrTy(), m_trackedBegin, m_DL, "loaded_begin");
+    auto *TrackedBegin = CreateLoad(IRB, IRB.getPtrTy(), m_trackedBegin, m_DL, "loaded_begin");
     auto *AllocIsBegin =
         IRB.CreateICmpEQ(AllocI8, TrackedBegin, "alloc.is.begin");
     createAssume(AllocIsBegin, CSFn, IRB);
@@ -955,7 +957,7 @@ void SimpleMemoryCheck::emitAllocSiteInstrumentation(CheckContext &Candidate,
     IRB.SetInsertPoint(GetNextInst(OtherAllocInst));
     auto *OAI8 =
         IRB.CreateBitCast(OtherAllocInst, GetI8PtrTy(*m_Ctx), "other.alloc.i8");
-    auto *TrackedEnd = CreateLoad(IRB, IRB.getInt8PtrTy(), m_trackedEnd, m_DL, "loaded_end");
+    auto *TrackedEnd = CreateLoad(IRB, IRB.getPtrTy(), m_trackedEnd, m_DL, "loaded_end");
     auto *GT = IRB.CreateICmpSGT(OAI8, TrackedEnd);
     createAssume(GT, OtherAllocInst->getFunction(), IRB);
 
@@ -1041,9 +1043,9 @@ bool SimpleMemoryCheck::runImpl(
       continue;
 
     // Skip special functions.
-    if (F.getName().startswith("seahorn.") ||
-        F.getName().startswith("shadow.") ||
-        F.getName().startswith("verifier."))
+    if (F.getName().starts_with("seahorn.") ||
+        F.getName().starts_with("shadow.") ||
+        F.getName().starts_with("verifier."))
       continue;
 
     m_TLI = &getTLI(F);

--- a/lib/Transforms/Instrumentation/WrapMem.cc
+++ b/lib/Transforms/Instrumentation/WrapMem.cc
@@ -55,14 +55,14 @@ public:
        { memcpy (dst, src, sz); }
      */
     m_memLoad = M.getOrInsertFunction("__seahorn_mem_load", Type::getVoidTy(C),
-                                      Type::getInt8PtrTy(C, 0),
-                                      Type::getInt8PtrTy(C, 0), m_intPtrTy);
+                                      PointerType::getUnqual(C),
+                                      PointerType::getUnqual(C), m_intPtrTy);
     /* void __sea_mem_store (void *src, void *dst, size_t sz)
        { memcpy (dst, src, sz); }
     */
     m_memStore = M.getOrInsertFunction(
-        "__seahorn_mem_store", Type::getVoidTy(C), Type::getInt8PtrTy(C, 0),
-        Type::getInt8PtrTy(C, 0), m_intPtrTy);
+        "__seahorn_mem_store", Type::getVoidTy(C), PointerType::getUnqual(C),
+        PointerType::getUnqual(C), m_intPtrTy);
 
     if (Function *Main = M.getFunction("main")) {
       FunctionCallee memInit = M.getOrInsertFunction(
@@ -89,7 +89,7 @@ public:
 
     LLVMContext &C = F.getContext();
     IRBuilder<> B(C);
-    Type *i8PtrTy = B.getInt8PtrTy();
+    Type *i8PtrTy = B.getPtrTy();
     for (BasicBlock &bb : F)
       for (Instruction &inst : bb) {
         if (LoadInst *load = dyn_cast<LoadInst>(&inst)) {

--- a/lib/Transforms/Scalar/LowerAssert.cc
+++ b/lib/Transforms/Scalar/LowerAssert.cc
@@ -56,7 +56,7 @@ bool isAssertionHandler(Function *F) {
   // --- otherwise, we consider the function an assertion handler if
   //     the function does not return.
 
-  if (F->getName().startswith("__assert") && F->doesNotReturn())
+  if (F->getName().starts_with("__assert") && F->doesNotReturn())
     return true;
 
   return false;

--- a/lib/Transforms/Scalar/LowerGvInitializers.cc
+++ b/lib/Transforms/Scalar/LowerGvInitializers.cc
@@ -178,7 +178,7 @@ bool LowerGvInitializers::runOnModule(Module &M) {
   // Iterate over global variables
   for (GlobalVariable *gv : gvs) {
     // XXX: skip global variables used by seahorn for instrumentation
-    if (gv->getName().startswith("sea_"))
+    if (gv->getName().starts_with("sea_"))
       continue;
 
     // First we try to promote the global variable to a stack variable

--- a/lib/Transforms/Scalar/PromoteMemcpy.cc
+++ b/lib/Transforms/Scalar/PromoteMemcpy.cc
@@ -76,16 +76,9 @@ char PromoteMemcpy::ID = 0;
 
 StructType *PromoteMemcpy::recoverStructType(Value *SrcPtr, Value *DstPtr,
                                              uint64_t Size, Function &F) {
-  // -- Legacy typed pointers: the pointee type is available directly.
-  for (Value *P : {SrcPtr, DstPtr}) {
-    auto *PtrTy = cast<PointerType>(P->getType());
-    if (!PtrTy->isOpaque()) {
-      if (auto *ST =
-              dyn_cast<StructType>(PtrTy->getNonOpaquePointerElementType()))
-        if (m_DL->getTypeStoreSize(ST) == Size)
-          return ST;
-    }
-  }
+  // -- LLVM 18 removed typed pointers entirely (PointerType::isOpaque and
+  // -- getNonOpaquePointerElementType are gone), so the legacy direct-pointee
+  // -- recovery branch is gone with them.
 
   // -- Opaque pointers: the pointee type is gone. Recover it ONLY from a GEP
   // -- that indexes the very pointer copied by the memcpy, with a struct whose

--- a/lib/Transforms/Scalar/PromoteVerifierCalls.cc
+++ b/lib/Transforms/Scalar/PromoteVerifierCalls.cc
@@ -134,7 +134,7 @@ bool PromoteVerifierCalls::runOnModule(Module &M) {
     LLVMUsed->eraseFromParent();
   }
   // re-create llvm.used
-  Type *i8PTy = Type::getInt8PtrTy(M.getContext());
+  Type *i8PTy = PointerType::getUnqual(M.getContext());
   MergedVars.push_back(
       ConstantExpr::getBitCast(cast<llvm::Constant>(m_assumeFn), i8PTy));
   MergedVars.push_back(
@@ -240,7 +240,7 @@ bool PromoteVerifierCalls::runOnFunction(Function &F) {
     if (fn && !fn->empty() && IgnoreDefinedVerifierFunctions)
       continue;
 
-    if (fn && (fn->getName().startswith("sea_nd"))) {
+    if (fn && (fn->getName().starts_with("sea_nd"))) {
       IRBuilder<> Builder(F.getContext());
       Builder.SetInsertPoint(&I);
       CallInst *ci;

--- a/lib/Transforms/Utils/AbstractMemory.cc
+++ b/lib/Transforms/Utils/AbstractMemory.cc
@@ -546,7 +546,7 @@ public:
       LLVMUsed->eraseFromParent();
     }
 
-    Type *i8PTy = Type::getInt8PtrTy(M.getContext());
+    Type *i8PTy = PointerType::getUnqual(M.getContext());
     // for (auto &ndfn: m_ndfn)
     // 	MergedVars.push_back (ConstantExpr::getBitCast(ndfn, i8PTy));
     for (auto &kv : m_extfn)

--- a/lib/Transforms/Utils/DevirtFunctions.cc
+++ b/lib/Transforms/Utils/DevirtFunctions.cc
@@ -118,9 +118,9 @@ void CallSiteResolverByTypes::populateTypeAliasSets() {
       continue;
 
     // -- skip seahorn and verifier specific intrinsics
-    if (F.getName().startswith("seahorn."))
+    if (F.getName().starts_with("seahorn."))
       continue;
-    if (F.getName().startswith("verifier."))
+    if (F.getName().starts_with("verifier."))
       continue;
     // -- assume entry point is never called indirectly
     if (F.getName().equals("main"))

--- a/lib/Transforms/Utils/DummyMainFunction.cc
+++ b/lib/Transforms/Utils/DummyMainFunction.cc
@@ -135,7 +135,7 @@ public:
     //   LLVMUsed->eraseFromParent();
     // }
 
-    // Type *i8PTy = Type::getInt8PtrTy(ctx);
+    // Type *i8PTy = PointerType::getUnqual(ctx);
     // // Add uses for our data
     // //MergedVars.push_back (ConstantExpr::getBitCast(cast<llvm::Constant>(F),
     // i8PTy));

--- a/lib/Transforms/Utils/ExternalizeFunctions.cc
+++ b/lib/Transforms/Utils/ExternalizeFunctions.cc
@@ -93,7 +93,7 @@ public:
         // in C++ local names are mangled with _ZL prefix, as we make functions
         // external, also rename
         auto name = F.getName();
-        if (name.startswith("_ZL") && name.size() > 3) {
+        if (name.starts_with("_ZL") && name.size() > 3) {
           F.setName("_Z" + name.substr(3));
           LOG("extern",
               errs() << "Renaming: " << name << " to " << F.getName() << "\n";);

--- a/lib/seahorn/Bmc.cc
+++ b/lib/seahorn/Bmc.cc
@@ -38,7 +38,8 @@ BmcEngine::BmcEngine(OperationalSemantics &sem, EZ3 &zctx)
   z3n_set_param(":model.compact", false);
   if (BmcSmtTactic != "default") {
     z3n_set_param(":tactic.default_tactic", BmcSmtTactic.c_str());
-    if (BmcSmtTactic == "sat" || llvm::StringRef(BmcSmtTactic).ends_with("sat)"))
+    if (BmcSmtTactic == "sat" ||
+        llvm::StringRef(BmcSmtTactic).ends_with("sat)"))
       z3n_set_param(":sat.euf", true);
   }
 }

--- a/lib/seahorn/Bmc.cc
+++ b/lib/seahorn/Bmc.cc
@@ -38,7 +38,7 @@ BmcEngine::BmcEngine(OperationalSemantics &sem, EZ3 &zctx)
   z3n_set_param(":model.compact", false);
   if (BmcSmtTactic != "default") {
     z3n_set_param(":tactic.default_tactic", BmcSmtTactic.c_str());
-    if (BmcSmtTactic == "sat" || llvm::StringRef(BmcSmtTactic).endswith("sat)"))
+    if (BmcSmtTactic == "sat" || llvm::StringRef(BmcSmtTactic).ends_with("sat)"))
       z3n_set_param(":sat.euf", true);
   }
 }

--- a/lib/seahorn/BmcPass.cc
+++ b/lib/seahorn/BmcPass.cc
@@ -411,7 +411,7 @@ public:
         // dump to harness file
         StringRef CexFileRef(HornCexFile);
         if (CexFileRef != "") {
-          if (CexFileRef.endswith(".ll") || CexFileRef.endswith(".bc")) {
+          if (CexFileRef.ends_with(".ll") || CexFileRef.ends_with(".bc")) {
             auto const &tli = m_tliGetter(F);
             auto const &dl = F.getParent()->getDataLayout();
             if (BmcCexGen) {
@@ -475,7 +475,7 @@ public:
         trace.print(errs());
         StringRef CexFileRef(HornCexFile);
         if (CexFileRef != "") {
-          if (CexFileRef.endswith(".ll") || CexFileRef.endswith(".bc")) {
+          if (CexFileRef.ends_with(".ll") || CexFileRef.ends_with(".bc")) {
             auto const &tli = m_tliGetter(F);
             auto const &dl = F.getParent()->getDataLayout();
             if (BmcCexGen) {

--- a/lib/seahorn/BoogieWriter.cc
+++ b/lib/seahorn/BoogieWriter.cc
@@ -181,7 +181,7 @@ bool instruction_factory::is_tracked(const Type *ty) {
 
 bool instruction_factory::is_tracked(const Value &v) {
   // -- ignore any shadow variable created by seahorn
-  if (v.getName().startswith("shadow.mem"))
+  if (v.getName().starts_with("shadow.mem"))
     return false;
   return is_tracked(v.getType());
 }
@@ -637,7 +637,7 @@ public:
         m_bb += m_ifac.mk_error();
       } else {
         // -- ignore shadow memory functions created by seahorn
-        if (!callee->getName().startswith("shadow.mem"))
+        if (!callee->getName().starts_with("shadow.mem"))
           m_bb += m_ifac.mk_call(I);
       }
     }
@@ -939,7 +939,7 @@ public:
     for (Function &F : M) {
       m_tli = &getAnalysis<TargetLibraryInfoWrapperPass>().getTLI(F);
       // -- ignore shadow memory functions created by seahorn
-      if (F.getName().startswith("shadow.mem"))
+      if (F.getName().starts_with("shadow.mem"))
         continue;
       runOnFunction(F);
     }

--- a/lib/seahorn/BvOpSem.cc
+++ b/lib/seahorn/BvOpSem.cc
@@ -573,7 +573,7 @@ struct OpSemVisitor : public InstVisitor<OpSemVisitor>, OpSemBase {
       return;
     }
 
-    if (F.getName().startswith("verifier.assume")) {
+    if (F.getName().starts_with("verifier.assume")) {
       Expr c = lookup(*CB.getOperand(0));
       if (F.getName().equals("verifier.assume.not"))
         c = boolop::lneg(c);
@@ -597,7 +597,7 @@ struct OpSemVisitor : public InstVisitor<OpSemVisitor>, OpSemBase {
         side(m_outMem,
              op::array::constArray(bv::bvsort(ptrSz(), m_efac), nullBv));
       }
-    } else if (F.getName().startswith("smt.extract.")) {
+    } else if (F.getName().starts_with("smt.extract.")) {
 
       auto *arg0 = dyn_cast<ConstantInt>(CB.getOperand(0));
       auto *arg1 = dyn_cast<ConstantInt>(CB.getOperand(1));
@@ -664,7 +664,7 @@ struct OpSemVisitor : public InstVisitor<OpSemVisitor>, OpSemBase {
       m_fparams.push_back(falseE);
       m_fparams.push_back(falseE);
       m_fparams.push_back(falseE);
-    } else if (F.getName().startswith("shadow.mem") && m_sem.isTracked(I)) {
+    } else if (F.getName().starts_with("shadow.mem") && m_sem.isTracked(I)) {
       if (F.getName().equals("shadow.mem.init")) {
         m_s.havoc(symb(I));
         unsigned id = shadow_dsa::getShadowId(CB);
@@ -1234,7 +1234,7 @@ bool BvOpSem::isTracked(const Value &v) const {
     if (v.hasOneUse())
       if (const CallInst *ci = dyn_cast<const CallInst>(*v.user_begin()))
         if (const Function *fn = ci->getCalledFunction())
-          if (fn->getName().startswith("shadow.mem"))
+          if (fn->getName().starts_with("shadow.mem"))
             return false;
 
     return m_trackLvl >= PTR;

--- a/lib/seahorn/BvOpSem2.cc
+++ b/lib/seahorn/BvOpSem2.cc
@@ -624,7 +624,7 @@ public:
     // -- should be handled by visitIntrinsicInst
     assert(!f->isIntrinsic());
 
-    if (f->getName().startswith("verifier.assume")) {
+    if (f->getName().starts_with("verifier.assume")) {
       visitVerifierAssumeCall(CB);
       return;
     }
@@ -635,7 +635,7 @@ public:
     }
 
     if (f->getFunctionType()->getReturnType()->isVoidTy()) {
-      if (f->getName().startswith("_ZN4core3ptr56drop_in_place")) {
+      if (f->getName().starts_with("_ZN4core3ptr56drop_in_place")) {
         // core::ptr::drop_in_place is recursive
         WARN << "Skipping a non-inlineable call to: " << f->getName();
         return;
@@ -654,7 +654,7 @@ public:
       return;
     }
 
-    if (f->getName().startswith("shadow.mem")) {
+    if (f->getName().starts_with("shadow.mem")) {
       WARN << "missing metadata on shadow.mem functions. "
               "Probably using old ShadowMem pass. "
               "Some features might not work as expected";
@@ -723,7 +723,7 @@ public:
       // The ease of adding a new instrinsic outweighs the cost of looping --
       // since the number of entries is small and not likely to grow 2x
       hana::for_each(hana::keys(funDeclStartsWithVisitorMap), [&](auto key) {
-        if (candidate.startswith(key.c_str()) && !found) {
+        if (candidate.starts_with(key.c_str()) && !found) {
           auto fnPtr = funDeclStartsWithVisitorMap[key];
           (this->*fnPtr)(CB);
           found = true;
@@ -734,11 +734,11 @@ public:
     };
 
     if (f->isDeclaration()) {
-      if (f->arg_empty() && (f->getName().startswith("nd") ||
-                             f->getName().startswith("nondet.") ||
-                             f->getName().endswith("nondet") ||
-                             f->getName().startswith("verifier.nondet") ||
-                             f->getName().startswith("__VERIFIER_nondet")))
+      if (f->arg_empty() && (f->getName().starts_with("nd") ||
+                             f->getName().starts_with("nondet.") ||
+                             f->getName().ends_with("nondet") ||
+                             f->getName().starts_with("verifier.nondet") ||
+                             f->getName().starts_with("__VERIFIER_nondet")))
         visitNondetCall(CB);
       else if (visitFunDecl(f->getName())) {
         return;
@@ -764,7 +764,7 @@ public:
 
     auto *f = getCalledFunction(CB);
     Expr res;
-    if (f->getName().startswith("smt.extract.")) {
+    if (f->getName().starts_with("smt.extract.")) {
       auto *arg0 = dyn_cast<ConstantInt>(CB.getOperand(0));
       auto *arg1 = dyn_cast<ConstantInt>(CB.getOperand(1));
       auto *val = CB.getOperand(2);
@@ -774,7 +774,7 @@ public:
             m_ctx.alu().Extract({symVal, val->getType()->getScalarSizeInBits()},
                                 arg0->getZExtValue(), arg1->getZExtValue());
       }
-    } else if (f->getName().startswith("smt.concat.")) {
+    } else if (f->getName().starts_with("smt.concat.")) {
       LOG("opsem", WARN << "Not implemented yet";);
       assert(false);
     } else {
@@ -2665,9 +2665,9 @@ public:
         // XXX hard-coded. should be based on use
         // XXX some functions have their address taken for llvm.used
         if (fn.getName().equals("verifier.error") ||
-            fn.getName().startswith("verifier.assume") ||
+            fn.getName().starts_with("verifier.assume") ||
             fn.getName().equals("seahorn.fail") ||
-            fn.getName().startswith("shadow.mem"))
+            fn.getName().starts_with("shadow.mem"))
           continue;
         if (m_sem.isSkipped(fn))
           continue;
@@ -3509,7 +3509,7 @@ bool Bv2OpSem::isSkipped(const Value &v) const {
     if (v.hasOneUse())
       if (const CallInst *ci = dyn_cast<const CallInst>(*v.user_begin()))
         if (const Function *fn = ci->getCalledFunction())
-          if (fn->getName().startswith("shadow.mem"))
+          if (fn->getName().starts_with("shadow.mem"))
             return true;
     return m_trackLvl < PTR;
   }
@@ -3875,7 +3875,8 @@ const llvm::ConstantRange Bv2OpSem::getLVIInstRng(llvm::Instruction &I) {
     if (fn) {
       auto it = m_lvi_map->find(fn);
       if (it != m_lvi_map->end()) {
-        return it->second->getConstantRange(dyn_cast<Value>(&I), &I);
+        return it->second->getConstantRange(dyn_cast<Value>(&I), &I,
+                                            /*UndefAllowed=*/false);
       }
     }
   }

--- a/lib/seahorn/BvOpSem2Allocators.cc
+++ b/lib/seahorn/BvOpSem2Allocators.cc
@@ -244,9 +244,9 @@ public:
         // XXX hard-coded. should be based on use
         // XXX some functions have their address taken for llvm.used
         if (fn.getName().equals("verifier.error") ||
-            fn.getName().startswith("verifier.assume") ||
+            fn.getName().starts_with("verifier.assume") ||
             fn.getName().equals("seahorn.fail") ||
-            fn.getName().startswith("shadow.mem"))
+            fn.getName().starts_with("shadow.mem"))
           continue;
         OpSemAllocator::falloc(fn, m_mem.getAlignment(fn));
       }

--- a/lib/seahorn/CexExeGenerator.cc
+++ b/lib/seahorn/CexExeGenerator.cc
@@ -132,7 +132,7 @@ public:
     // We want to ignore seahorn functions, but not nondet
     // functions created by strip-extern or dummyMainFunction
     if (CF->getName().find_first_of('.') != StringRef::npos &&
-        !CF->getName().startswith("verifier.nondet"))
+        !CF->getName().starts_with("verifier.nondet"))
       return;
     if (!CF->isExternalLinkage(CF->getLinkage()))
       return;
@@ -180,7 +180,7 @@ void CexExeGenerator<Trace>::buildNonDetFunction(const Function *func,
 
   Type *RT = func->getReturnType();
   Type *pRT =
-      RT->isIntegerTy() ? RT->getPointerTo() : Type::getInt8PtrTy(m_context);
+      RT->isIntegerTy() ? RT->getPointerTo() : PointerType::getUnqual(m_context);
   ArrayType *AT = ArrayType::get(RT, values.size());
 
   // Convert Expr to LLVM constants
@@ -259,7 +259,7 @@ void CexExeGenerator<Trace>::buildMemhavoc(const Function *func,
     LOG("cex", WARN << "memhavoc has non-void return type. Skipping...\n";);
     return;
   }
-  Type *i8PtrTy = Type::getInt8PtrTy(m_context);
+  Type *i8PtrTy = PointerType::getUnqual(m_context);
   // Convert Expr to LLVM constants
   SmallVector<Constant *, 20> LLVMarray;
   // one nested array for segments
@@ -343,7 +343,7 @@ void CexExeGenerator<Trace>::saveCexModuleToFile(llvm::StringRef CexFile) {
   llvm::ToolOutputFile out(CexFile, error_code, sys::fs::OF_None);
   assert(!error_code);
   verifyModule(*m_harness, &errs());
-  if (CexFile.endswith(".ll"))
+  if (CexFile.ends_with(".ll"))
     out.os() << *m_harness;
   else
     WriteBitcodeToFile(*m_harness, out.os());
@@ -412,7 +412,7 @@ Constant *CexExeGenerator<Trace>::exprToMemSegment(Expr segment, Expr startAddr,
     blockWidth = sizeMpz.get_ui();
   } else {
     LOG("cex", ERR << "memhavoc: cannot get concrete size (" << *size << ")\n");
-    ArrayType *placeholderT = ArrayType::get(Type::getInt8PtrTy(m_context), 0);
+    ArrayType *placeholderT = ArrayType::get(PointerType::getUnqual(m_context), 0);
     return ConstantArray::get(placeholderT, LLVMValueSegment);
   }
 
@@ -424,7 +424,7 @@ Constant *CexExeGenerator<Trace>::exprToMemSegment(Expr segment, Expr startAddr,
   } else {
     LOG("cex", ERR << "memhavoc: cannot get concrete starting address: "
                    << *startAddr << "\n");
-    ArrayType *placeholderT = ArrayType::get(Type::getInt8PtrTy(m_context), 0);
+    ArrayType *placeholderT = ArrayType::get(PointerType::getUnqual(m_context), 0);
     return ConstantArray::get(placeholderT, LLVMValueSegment);
   }
 
@@ -432,7 +432,7 @@ Constant *CexExeGenerator<Trace>::exprToMemSegment(Expr segment, Expr startAddr,
   if (!m_map.isValid()) {
     LOG("cex",
         ERR << "memhavoc: cannot extract content from: " << *segment << "\n");
-    ArrayType *placeholderT = ArrayType::get(Type::getInt8PtrTy(m_context), 0);
+    ArrayType *placeholderT = ArrayType::get(PointerType::getUnqual(m_context), 0);
     return ConstantArray::get(placeholderT, LLVMValueSegment);
   }
   size_t elmWidth = m_map.getContentWidth();

--- a/lib/seahorn/CexExeGenerator.cc
+++ b/lib/seahorn/CexExeGenerator.cc
@@ -179,8 +179,8 @@ void CexExeGenerator<Trace>::buildNonDetFunction(const Function *func,
           .getCallee());
 
   Type *RT = func->getReturnType();
-  Type *pRT =
-      RT->isIntegerTy() ? RT->getPointerTo() : PointerType::getUnqual(m_context);
+  Type *pRT = RT->isIntegerTy() ? RT->getPointerTo()
+                                : PointerType::getUnqual(m_context);
   ArrayType *AT = ArrayType::get(RT, values.size());
 
   // Convert Expr to LLVM constants
@@ -412,7 +412,8 @@ Constant *CexExeGenerator<Trace>::exprToMemSegment(Expr segment, Expr startAddr,
     blockWidth = sizeMpz.get_ui();
   } else {
     LOG("cex", ERR << "memhavoc: cannot get concrete size (" << *size << ")\n");
-    ArrayType *placeholderT = ArrayType::get(PointerType::getUnqual(m_context), 0);
+    ArrayType *placeholderT =
+        ArrayType::get(PointerType::getUnqual(m_context), 0);
     return ConstantArray::get(placeholderT, LLVMValueSegment);
   }
 
@@ -424,7 +425,8 @@ Constant *CexExeGenerator<Trace>::exprToMemSegment(Expr segment, Expr startAddr,
   } else {
     LOG("cex", ERR << "memhavoc: cannot get concrete starting address: "
                    << *startAddr << "\n");
-    ArrayType *placeholderT = ArrayType::get(PointerType::getUnqual(m_context), 0);
+    ArrayType *placeholderT =
+        ArrayType::get(PointerType::getUnqual(m_context), 0);
     return ConstantArray::get(placeholderT, LLVMValueSegment);
   }
 
@@ -432,7 +434,8 @@ Constant *CexExeGenerator<Trace>::exprToMemSegment(Expr segment, Expr startAddr,
   if (!m_map.isValid()) {
     LOG("cex",
         ERR << "memhavoc: cannot extract content from: " << *segment << "\n");
-    ArrayType *placeholderT = ArrayType::get(PointerType::getUnqual(m_context), 0);
+    ArrayType *placeholderT =
+        ArrayType::get(PointerType::getUnqual(m_context), 0);
     return ConstantArray::get(placeholderT, LLVMValueSegment);
   }
   size_t elmWidth = m_map.getContentWidth();

--- a/lib/seahorn/CexHarness.cc
+++ b/lib/seahorn/CexHarness.cc
@@ -89,7 +89,7 @@ Constant *exprToMemSegment(Expr segment, Expr startAddr, Expr size,
   } else {
     LOG("cex",
         errs() << "memhavoc: cannot get concrete size (" << *size << ")\n");
-    ArrayType *placeholderT = ArrayType::get(Type::getInt8PtrTy(ctx), 0);
+    ArrayType *placeholderT = ArrayType::get(PointerType::getUnqual(ctx), 0);
     return ConstantArray::get(placeholderT, LLVMValueSegment);
   }
 
@@ -101,7 +101,7 @@ Constant *exprToMemSegment(Expr segment, Expr startAddr, Expr size,
   } else {
     LOG("cex", errs() << "memhavoc: cannot get concrete starting address: "
                       << *startAddr << "\n");
-    ArrayType *placeholderT = ArrayType::get(Type::getInt8PtrTy(ctx), 0);
+    ArrayType *placeholderT = ArrayType::get(PointerType::getUnqual(ctx), 0);
     return ConstantArray::get(placeholderT, LLVMValueSegment);
   }
   // use MemMap to extract mem segment info
@@ -111,7 +111,7 @@ Constant *exprToMemSegment(Expr segment, Expr startAddr, Expr size,
   if (!m_map.isValid() || elmWidth < IntegerType::MIN_INT_BITS) {
     LOG("cex_verbose", WARN << "memhavoc: invalid memory expression: "
                             << *m_map.getRawExpr() << "\n");
-    ArrayType *placeholderT = ArrayType::get(Type::getInt8PtrTy(ctx), 0);
+    ArrayType *placeholderT = ArrayType::get(PointerType::getUnqual(ctx), 0);
     return ConstantArray::get(placeholderT, LLVMValueSegment);
   }
   size_t blocks = std::ceil((float)blockWidth / (float)elmWidth);

--- a/lib/seahorn/HornCex.cc
+++ b/lib/seahorn/HornCex.cc
@@ -345,7 +345,7 @@ bool HornCex::runOnFunction(Module &M, Function &F) {
   }
 
   StringRef HornCexFileRef(HornCexFile);
-  if (HornCexFileRef.endswith(".ll") || HornCexFileRef.endswith(".bc")) {
+  if (HornCexFileRef.ends_with(".ll") || HornCexFileRef.ends_with(".bc")) {
     const DataLayout &dl = M.getDataLayout();
     std::unique_ptr<BmcTraceWrapper<ZBmcTraceTy>> traceW(
         new BmcTraceWrapper<ZBmcTraceTy>(trace));
@@ -353,7 +353,7 @@ bool HornCex::runOnFunction(Module &M, Function &F) {
       traceW.reset(new BmcTraceMemSim(*memSim));
     }
     dumpLLVMCex(*traceW, HornCexFileRef, dl, tli, F.getContext());
-  } else if (HornCexFileRef.endswith(".xml")) {
+  } else if (HornCexFileRef.ends_with(".xml")) {
     dumpSvCompCex(trace, HornCexFileRef);
   } else if (!HornCexFileRef.empty()) {
     errs() << "Unrecognized counter-example file suffix in " << HornCexFileRef
@@ -531,7 +531,7 @@ static void dumpLLVMBitcode(const Module &M, StringRef BcFile) {
   ToolOutputFile sliceOutput(BcFile, error_code, sys::fs::OF_None);
   assert(!error_code);
   verifyModule(M, &errs());
-  if (BcFile.endswith(".ll"))
+  if (BcFile.ends_with(".ll"))
     sliceOutput.os() << M;
   else
     WriteBitcodeToFile(M, sliceOutput.os());

--- a/lib/seahorn/UfoOpSem.cc
+++ b/lib/seahorn/UfoOpSem.cc
@@ -703,7 +703,7 @@ struct OpSemVisitor : public InstVisitor<OpSemVisitor>, OpSemBase {
       return;
     }
 
-    if (F.getName().startswith("verifier.assume")) {
+    if (F.getName().starts_with("verifier.assume")) {
       if (isa<UndefValue>(CB.getOperand(0))) {
         WARN << "`undef` in assumption: " << CB << " in BB: " << BB.getName()
              << "\n";
@@ -799,7 +799,7 @@ struct OpSemVisitor : public InstVisitor<OpSemVisitor>, OpSemBase {
       m_outRegions.clear();
       m_outValues.clear();
       m_regionValues.clear();
-    } else if (F.getName().startswith("shadow.mem")) {
+    } else if (F.getName().starts_with("shadow.mem")) {
       if (!m_sem.isTracked(CB))
         return;
 
@@ -1243,7 +1243,7 @@ bool UfoOpSem::isTracked(const Value &v) const {
     if (v.hasOneUse())
       if (const CallInst *ci = dyn_cast<const CallInst>(*v.user_begin()))
         if (const Function *fn = ci->getCalledFunction())
-          if (fn->getName().startswith("shadow.mem"))
+          if (fn->getName().starts_with("shadow.mem"))
             return false;
 
     return m_trackLvl >= PTR;

--- a/py/sea/commands.py
+++ b/py/sea/commands.py
@@ -78,7 +78,7 @@ class Clang(sea.LimitedCmd):
         def link_bc_files(bc_files, args):
             if len(bc_files) <= 1:
                 return 0
-            cmd_name = which(['llvm-link-mp-17', 'llvm-link-17', 'llvm-link'])
+            cmd_name = which(['llvm-link-mp-18', 'llvm-link-18', 'llvm-link'])
             if cmd_name is None: raise IOError ('llvm-link not found')
             self.linkCmd = sea.ExtCmd (cmd_name,'',quiet)
 
@@ -106,9 +106,9 @@ class Clang(sea.LimitedCmd):
             return link_bc_files(out_files, args)
 
         if self.plusplus:
-            cmd_name = which(['clang++-mp-17', 'clang++-17', 'clang++'])
+            cmd_name = which(['clang++-mp-18', 'clang++-18', 'clang++'])
         else:
-            cmd_name = which(['clang-mp-17', 'clang-17', 'clang'])
+            cmd_name = which(['clang-mp-18', 'clang-18', 'clang'])
 
         if cmd_name is None: raise IOError ('clang not found')
         self.clangCmd = sea.ExtCmd (cmd_name,'',quiet)
@@ -210,7 +210,7 @@ class LinkRt(sea.LimitedCmd):
 
     def run (self, args, extra):
 
-        cmd_name = which(['clang++-mp-17', 'clang++-17', 'clang++'])
+        cmd_name = which(['clang++-mp-18', 'clang++-18', 'clang++'])
 
         if cmd_name is None: raise IOError ('clang++ not found')
         self.clangCmd = sea.ExtCmd (cmd_name,'',quiet)

--- a/tools/seahorn/seahorn.cpp
+++ b/tools/seahorn/seahorn.cpp
@@ -298,7 +298,7 @@ int main(int argc, char **argv) {
   llvm::initializeScalarOpts(Registry);
   llvm::initializeIPO(Registry);
   llvm::initializeCallGraphWrapperPassPass(Registry);
-  llvm::initializeCallGraphPrinterLegacyPassPass(Registry);
+  // LLVM 18 removed the legacy CallGraphPrinter pass (new-PM only now).
   llvm::initializeCallGraphViewerPass(Registry);
   // XXX: not sure if needed anymore
   llvm::initializeGlobalsAAWrapperPassPass(Registry);


### PR DESCRIPTION

1. **`build(llvm18): require LLVM 18.1 and clone dev18 dependency
   branches`** — `find_package(LLVM 18.1)` (18 ships only as 18.1.x);
   in-tree dependency clones point at `dev18`.
2. **`fix(llvm18): port sources to LLVM 18 API removals`** — the
   substantive commit:
   - `StringRef::startswith/endswith` → `starts_with/ends_with`
     (~55 sites);
   - `Type::getInt8PtrTy` removed with typed pointers →
     `PointerType::getUnqual(ctx)` / `IRBuilder::getPtrTy()`
     (~85 sites; under opaque pointers all pointer types are equal, so
     these are type-identity-preserving rewrites);
   - `ObjectSizeOffsetVisitor::compute` returns `SizeOffsetAPInt` and
     `ObjectSizeOffsetEvaluator::compute` returns `SizeOffsetValue` —
     `knownSize()`/`bothKnown()` and `Size`/`Offset` now live on the
     returned value (SimpleMemoryCheck, FatBufferBoundsCheck);
   - `TypeSize::getFixedSize` → `getFixedValue`;
   - `LazyValueInfo::getConstantRange` lost its `UndefAllowed` default     
     — pass the previous default (`false`) explicitly;
   - `PointerType::isOpaque`/`getNonOpaquePointerElementType` removed:
     PromoteMemcpy's legacy typed-pointer recovery branch (dead since
     opaque pointers) is deleted, keeping the GEP-based recovery;
   - the legacy `CallGraphPrinter` pass was removed upstream; its
     initialization is dropped from the seahorn driver.
3. **`ci(llvm18): sea driver searches clang-18; CI on the LLVM 18
   toolchain`** — driver tool names; CI on dev18 with `jammy-llvm18`
   buildpack image, llvm18 ccache keys, clang-format-18.
4. **`style: apply clang-format to the llvm18 port changes`** — to
   fixpoint.

## How this was tested

Built clean against LLVM 18.1 (apt), with sea-dsa and llvm-seahorn on
their dev18 branches.

- `test/opsem2`: 42/42 (re-verified after the format commit).
  `test/opsem`: 125 passed + 1 expected failure.
- CHC suites at the dev16/dev17 baseline exactly: `test/simple` 9/10,
  `test/solve` 4 + 1 xfail + 1 fail (same two pre-existing failures,
  unrelated), `test/cex` 5/5.
- **verify-c-common** (228 proof jobs): see the run result posted with
  this PR.
- commitlint: 0 problems across all commits; clang-format to fixpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cy5J4Rx9YZSDUJp8wfRfqF