### PR TITLE
fix(smt): expand const-array selects for yices instead of lambdas

### DIFF
--- a/lib/seahorn/Smt/Yices2SolverImpl.cc
+++ b/lib/seahorn/Smt/Yices2SolverImpl.cc
@@ -2,11 +2,13 @@
 #include <gmp.h>
 #include "yices.h"
 
-#include "seahorn/Expr/Smt/Yices2SolverImpl.hh"
-#include "seahorn/Expr/Smt/Yices2ModelImpl.hh"
+#include "seahorn/Expr/ExprVisitor.hh"
 #include "seahorn/Expr/Smt/MarshalYices.hh"
+#include "seahorn/Expr/Smt/Yices2ModelImpl.hh"
+#include "seahorn/Expr/Smt/Yices2SolverImpl.hh"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/raw_ostream.h"
+#include <cstdlib>
 
 #include <vector>
 
@@ -66,8 +68,92 @@ yices_solver_impl::ycache_t& yices_solver_impl::get_cache(void){
   return d_cache;
 }
 
+namespace {
+/// -- true iff the array-term skeleton (stores and ites) has a const-array
+/// -- leaf, i.e. the term cannot be encoded for yices without a lambda
+bool hasConstArrayLeaf(Expr a) {
+  while (true) {
+    if (isOpX<CONST_ARRAY>(a))
+      return true;
+    if (isOpX<STORE>(a)) {
+      a = a->arg(0);
+      continue;
+    }
+    if (isOpX<ITE>(a))
+      return hasConstArrayLeaf(a->arg(1)) || hasConstArrayLeaf(a->arg(2));
+    return false;
+  }
+}
+
+/// -- push select(arr, idx) through the store/ite skeleton of arr:
+/// -- select-over-store becomes an index-equality ite, select-over-ite
+/// -- distributes into the branches, and select-over-const-array yields the
+/// -- default value. Leaves that are plain array terms keep a plain select.
+Expr expandSelectOverConstArray(Expr arr, Expr idx, ExprMap &memo) {
+  auto it = memo.find(arr);
+  if (it != memo.end())
+    return it->second;
+  Expr res;
+  if (isOpX<CONST_ARRAY>(arr))
+    res = arr->right();
+  else if (isOpX<STORE>(arr))
+    res = boolop::lite(mk<EQ>(idx, arr->arg(1)), arr->arg(2),
+                       expandSelectOverConstArray(arr->arg(0), idx, memo));
+  else if (isOpX<ITE>(arr))
+    res = boolop::lite(arr->arg(0),
+                       expandSelectOverConstArray(arr->arg(1), idx, memo),
+                       expandSelectOverConstArray(arr->arg(2), idx, memo));
+  else
+    res = op::array::select(arr, idx);
+  memo[arr] = res;
+  return res;
+}
+
+/// -- rewrite every select whose store/ite skeleton bottoms out in a
+/// -- const-array into an ite cascade. Yices contexts cannot assert lambda
+/// -- terms, which is the only encoding the marshaller has for const-arrays;
+/// -- selects over havoc'd (non-const) memories are left untouched.
+Expr rewriteConstArraySelects(Expr e, ExprMap &cache) {
+  if (e->arity() == 0)
+    return e;
+  auto it = cache.find(e);
+  if (it != cache.end())
+    return it->second;
+
+  ExprVector kids;
+  kids.reserve(e->arity());
+  bool changed = false;
+  for (auto b = e->args_begin(), be = e->args_end(); b != be; ++b) {
+    Expr kid = rewriteConstArraySelects(Expr(*b), cache);
+    changed |= (kid.get() != *b);
+    kids.push_back(kid);
+  }
+  Expr res = changed ? e->efac().mkNary(e->op(), kids.begin(), kids.end()) : e;
+  if (isOpX<SELECT>(res) && hasConstArrayLeaf(res->left())) {
+    ExprMap memo;
+    res = expandSelectOverConstArray(res->left(), res->right(), memo);
+  }
+  cache[e] = res;
+  return res;
+}
+} // namespace
 
 bool yices_solver_impl::add(expr::Expr exp){
+  ExprMap rw_cache;
+  exp = rewriteConstArraySelects(exp, rw_cache);
+  // -- debug aid: dump assertions in which a const-array survives the
+  // -- rewrite (yices cannot assert them; see rewriteConstArraySelects)
+  if (std::getenv("SEA_DEBUG_DUMP_CONST_ARRAY")) {
+    std::vector<Expr> matches;
+    expr::filter(
+        exp, [](Expr e) { return isOpX<CONST_ARRAY>(e); },
+        std::back_inserter(matches));
+    if (!matches.empty()) {
+      llvm::errs() << "=== assertion with CONST_ARRAY (" << matches.size()
+                   << ") ===\n"
+                   << *exp << "\n";
+    }
+  }
   term_t yt = marshal_yices::encode_term(exp, get_cache());
   if (yt == NULL_TERM){
     std::string str;  

--- a/units/units_yices2.cpp
+++ b/units/units_yices2.cpp
@@ -298,4 +298,60 @@ TEST_CASE("yices2-const-array.test") {
   CHECK(true);
 }
 
+TEST_CASE("yices2-const-array-store-select.test") {
+  // Regression test: a select over a store (or ite) chain whose base is a
+  // const-array must be solvable by yices. The marshaller can only encode a
+  // const-array as a lambda term; yices beta-reduces a direct
+  // select-over-const-array away, but a lambda under yices_update survives
+  // into the assertion and yices contexts reject lambda terms
+  // ("the context does not support lambda terms"). The yices bridge now
+  // expands such selects into ite cascades before encoding. This is the
+  // shape the tracking-mem metadata encoding produces
+  // (zero-initialized metadata memory with stores at symbolic addresses).
+  using namespace std;
+  using namespace expr;
+  using namespace seahorn;
+
+  expr::ExprFactory efac;
+
+  size_t SZ = 64;
+  Expr iTy = op::bv::bvsort(SZ, efac);
+  Expr p = op::bv::bvConst(mkTerm<string>("p", efac), SZ);
+  Expr q = op::bv::bvConst(mkTerm<string>("q", efac), SZ);
+  Expr zero = op::bv::bvnum(0, SZ, efac);
+  Expr one = op::bv::bvnum(1, SZ, efac);
+  Expr ca = op::array::constArray(iTy, zero);
+
+  // select(store(const-array(0), p, 1), q) with q != p is 0, never 1
+  Expr sel = op::array::select(op::array::store(ca, p, one), q);
+  Expr unsatE = mk<AND>(mk<EQ>(sel, one), mk<NEQ>(q, p));
+  // ... and without the disequality it is 1 exactly when q = p
+  Expr satE = mk<EQ>(sel, one);
+  // ite-of-arrays over const-array bases (the shadow-mem join shape)
+  Expr c = bind::boolConst(mkTerm<string>("c", efac));
+  Expr iteArr = boolop::lite(c, op::array::store(ca, p, one), ca);
+  Expr iteUnsatE =
+      mk<AND>(mk<EQ>(op::array::select(iteArr, q), one), mk<NEQ>(q, p));
+
+  seahorn::solver::yices_solver_impl yices_solver(efac);
+  seahorn::solver::Solver *ys = &yices_solver;
+
+  ys->push();
+  CHECK(ys->add(unsatE));
+  CHECK(ys->check() == seahorn::solver::SolverResult::UNSAT);
+  ys->pop();
+
+  ys->push();
+  CHECK(ys->add(satE));
+  CHECK(ys->check() == seahorn::solver::SolverResult::SAT);
+  ys->pop();
+
+  ys->push();
+  CHECK(ys->add(iteUnsatE));
+  CHECK(ys->check() == seahorn::solver::SolverResult::UNSAT);
+  ys->pop();
+
+  errs() << "FINISHED\n";
+}
+
 #endif


### PR DESCRIPTION
Yices contexts cannot assert lambda terms, and yices_lambda is the only encoding the marshaller has for const-arrays (yices2 issue 271). Since opaque pointers (LLVM 15), the tracking-mem metadata encoding leaves select-over-store/ite chains that bottom out in a const-array in the final formula, so every fat-memory test under --horn-bv2-tracking-mem with the yices solver aborted with 'the context does not support lambda terms'.

Rewrite such selects before encoding: push the select through the store/ite skeleton (select-over-store becomes an index-equality ite, select-over-ite distributes, const-array leaves yield their default value; plain array leaves keep a plain select). Memoized over the expression DAG; selects over havoc'd memories are untouched. Also add an env-gated debug dump (SEA_DEBUG_DUMP_CONST_ARRAY) for assertions where a const-array survives the rewrite.

This fixes the 13 *2_unsat_test failures in verify-c-common's cex + smt-y2 configuration and un-breaks the 11 tests blacklisted for the same root cause, some since LLVM 14.


Claude-Session: https://claude.ai/code/session_01Cy5J4Rx9YZSDUJp8wfRfqF