### PR TITLE
Fix/extrawide opaque ptr offset

### DIFF
--- a/lib/seahorn/BvOpSem2ExtraWideMemMgr.cc
+++ b/lib/seahorn/BvOpSem2ExtraWideMemMgr.cc
@@ -66,12 +66,14 @@ template <class T>
 Expr ExtraWideMemManagerCore<T>::ptrEq(
     ExtraWideMemManagerCore::PtrTy p1,
     ExtraWideMemManagerCore::PtrTy p2) const {
-  // NOTE: we consider two pointers to be same if their address (base and ofset)
-  //       is the same. Size is ignored. This is done to have parity with memset
-  //       like operations that zero out main memory but do not touch shadow
-  //       memory.
-  return mk<AND>(m_main.ptrEq(p1.getBase(), p2.getBase()),
-                 m_offset.ptrEq(p1.getOffset(), p2.getOffset()));
+  // Two pointers are equal iff they denote the same effective address
+  // (base + offset). Comparing base and offset componentwise is strictly
+  // stronger and hence WRONG: under LLVM 18 opaque pointers, the same address
+  // can be represented as e.g. (4,-1) via `gep i8 -1` and (3,0) via inttoptr,
+  // which componentwise compares unequal while denoting address 3. That also
+  // contradicts ptrNe (below), which already uses getAddressable, so the two
+  // could report both !(a==b) and !(a!=b). Mirror ptrNe.
+  return m_main.ptrEq(getAddressable(p1), getAddressable(p2));
 }
 template <class T>
 Expr ExtraWideMemManagerCore<T>::castPtrSzToSlotSz(const Expr val) const {

--- a/lib/seahorn/BvOpSem2ExtraWideMemMgr.cc
+++ b/lib/seahorn/BvOpSem2ExtraWideMemMgr.cc
@@ -401,6 +401,23 @@ ExtraWideMemManagerCore<T>::storeIntToMem(Expr _val,
     }
   }
   RawMemValTy rawIn = setModified(base, mem);
+  // Storing plain integer data means the cell no longer holds a pointer with a
+  // nonzero (base,offset). If it is later reloaded as a pointer, the correct
+  // value is inttoptr(data) = (data, 0). A stale offset from a prior pointer
+  // store to this location would otherwise leak: `load ptr` -> (data, stale)
+  // and ptrtoint -> data+stale (a spurious off-by-stale value).
+  //
+  // Only a pointer-sized store can be reloaded as a whole pointer and hit this,
+  // so restrict the (extra) offset-shadow clear to that case -- clearing on
+  // every narrower int store needlessly bloats memory-heavy VCs.
+  if (byteSz >= ptrSizeInBits() / 8) {
+    Expr zeroOffset = m_ctx.alu().ui(0UL, ptrSizeInBits());
+    return MemValTy(
+        m_main.storeIntToMem(_val, getAddressable(base), rawIn, byteSz, align),
+        m_offset.storeIntToMem(zeroOffset, getAddressable(base),
+                               mem.getOffset(), byteSz, align),
+        mem.getSize());
+  }
   return MemValTy(
       m_main.storeIntToMem(_val, getAddressable(base), rawIn, byteSz, align),
       mem.getOffset(), mem.getSize());

--- a/test/opsem2/widemem/ptr_eq_inttoptr_vs_gep.ll
+++ b/test/opsem2/widemem/ptr_eq_inttoptr_vs_gep.ll
@@ -1,0 +1,83 @@
+; RUN: %sea "%s" --horn-bv2-widemem 2>&1 | filecheck %s
+; RUN: %sea "%s" --horn-bv2-extra-widemem 2>&1 | filecheck %s
+; CHECK: {{^unsat$}}
+;
+; Regression test for ExtraWideMemManagerCore::ptrEq. Two pointers denoting the
+; same address via different (base,offset) representations -- (4,-1) from
+; `gep i8 -1` and (3,0) from inttoptr -- must compare EQUAL. The old
+; componentwise ptrEq reported `sat` under --horn-bv2-extra-widemem; the fix
+; (compare getAddressable(p1)==getAddressable(p2), mirroring ptrNe) makes both
+; RUN lines pass. Do not "fix" this test by changing CHECK to `sat`: the
+; equality holds and unsat is the correct verdict.
+
+; Two pointers to the SAME address, reached by two different routes:
+;
+;   start = inttoptr(3)                 -> ExtraWide triple (base=3, offset=0)
+;   end   = getelementptr(inttoptr(4), -1) -> ExtraWide triple (base=4, offset=-1)
+;
+; Both denote address 3, so `start == end` holds and this must be unsat.
+;
+; ExtraWideMemManagerCore::ptrEq compares the triple componentwise:
+;
+;   mk<AND>(m_main.ptrEq(p1.getBase(),   p2.getBase()),
+;           m_offset.ptrEq(p1.getOffset(), p2.getOffset()))
+;
+; i.e. base1 == base2 && offset1 == offset2, which is strictly stronger than
+; base1 + offset1 == base2 + offset2. Here it evaluates 3 == 4 && 0 == -1 ->
+; false, so the equality is (wrongly) refuted and the test reports `sat`.
+;
+; The two triples diverge because the managers build them differently:
+;   inttoptr(v) -> PtrTy(v, 0, ...)                 base is the integer, offset 0
+;   ptrAdd(p,k) -> PtrTy(p.getBase(), off+k, ...)   base preserved, offset moves
+;
+; WideMemManager::ptrEq compares a single raw value and is unaffected, which is
+; why the second RUN line passes while the first fails.
+;
+; This is a false alarm (imprecision), not unsoundness: SeaHorn refutes an
+; equality that actually holds, reporting a bug that is not there.
+;
+; Found via a Rust ZST iterator (verify-rust sea-vec test_zst). A zero-sized
+; type has no storage, so `start`/`end` are synthetic addresses used as counters
+; and exhaustion is pointer equality. Under LLVM 18, `start += 1` keeps its
+; uadd.with.overflow intrinsic (which blocks the inttoptr(ptrtoint(p)+c) -> gep
+; fold) while `end -= 1` loses its intrinsic to canonicalisation and does fold to
+; a gep -- so the two counters end up with different decompositions of the same
+; address. Under LLVM 14 both stayed inttoptr with offset 0 and the componentwise
+; comparison agreed with address comparison by luck.
+
+declare i64 @nd_int()
+declare void @__VERIFIER_assume(i32)
+declare void @__VERIFIER_error()
+
+define i32 @main() {
+entry:
+  ; Values come from nd_int + assume rather than literals so that the frontend
+  ; cannot constant-fold gep(inttoptr(4), -1) into inttoptr(3) -- that fold is
+  ; exactly what this test needs to keep apart.
+  %n = call i64 @nd_int()
+  %n.is4 = icmp eq i64 %n, 4
+  %n.is4.i32 = zext i1 %n.is4 to i32
+  call void @__VERIFIER_assume(i32 %n.is4.i32)
+
+  %m = call i64 @nd_int()
+  %m.is3 = icmp eq i64 %m, 3
+  %m.is3.i32 = zext i1 %m.is3 to i32
+  call void @__VERIFIER_assume(i32 %m.is3.i32)
+
+  ; end: base 4, offset -1  (address 3)
+  %end.base = inttoptr i64 %n to ptr
+  %end = getelementptr i8, ptr %end.base, i64 -1
+
+  ; start: base 3, offset 0 (address 3)
+  %start = inttoptr i64 %m to ptr
+
+  %eq = icmp eq ptr %start, %end
+  br i1 %eq, label %ok, label %err
+
+err:
+  call void @__VERIFIER_error()
+  unreachable
+
+ok:
+  ret i32 0
+}

--- a/test/opsem2/widemem/ptr_ne_inttoptr_vs_gep_missed_bug.ll
+++ b/test/opsem2/widemem/ptr_ne_inttoptr_vs_gep_missed_bug.ll
@@ -1,0 +1,83 @@
+; RUN: %sea "%s" --horn-bv2-widemem 2>&1 | filecheck %s
+; RUN: %sea "%s" --horn-bv2-extra-widemem 2>&1 | filecheck %s
+; CHECK: {{^sat$}}
+;
+; Companion to ptr_eq_inttoptr_vs_gep.ll, exercising the OTHER direction of the
+; same ExtraWideMemManagerCore::ptrEq defect -- and the more serious one.
+; Now fixed (getAddressable compare); both RUN lines report `sat` (the real
+; violation of `p != q` is found).
+;
+; Same two pointers, both denoting address 3 by different routes:
+;   start = inttoptr(3)                    -> triple (base=3, offset=0)
+;   end   = getelementptr(inttoptr(4), -1) -> triple (base=4, offset=-1)
+;
+; Here we assert `start != end`. That assertion is FALSE -- the pointers are
+; equal -- so a real violation exists and the correct verdict is `sat`.
+;
+;   widemem       -> sat    (correct: finds the violation)
+;   extra-widemem -> unsat  (WRONG: proves a disequality that does not hold,
+;                            and so MISSES a real assertion violation)
+;
+; That makes this defect a soundness hole, not merely an imprecision: it is not
+; only that extra-widemem raises false alarms on `p == q` (the companion test),
+; it also silently misses genuine bugs on `p != q`.
+;
+; This test also serves as the vacuity control for the companion: `sat` here
+; proves the path is reachable, so the companion's `unsat` under widemem is a
+; real proof rather than a vacuous one.
+;
+; NOTE: the exact route by which extra-widemem reaches `unsat` was not pinned
+; down. LLVM canonicalises `br (icmp ne a,b), ok, err` into
+; `br (icmp eq a,b), err, ok`, so this may well still go through ptrEq with
+; swapped successors rather than through ptrNe. Worth confirming before relying
+; on the mechanism; the wrong verdict itself is reproducible either way.
+;
+; Note also that ptrEq and ptrNe disagree about what pointer identity means:
+;
+;   ptrNe -> m_main.ptrNe(getAddressable(p1), getAddressable(p2))  // base+offset
+;   ptrEq -> mk<AND>(ptrEq(base1,base2), ptrEq(off1,off2))         // componentwise
+;
+; If both notions meet on the same pointers, SeaHorn can derive
+; !(p == q) && !(p != q) -- a contradiction, which makes paths spuriously
+; infeasible and is another way real bugs get pruned away.
+;
+; The fix mirrors ptrNe, reusing the getAddressable helper that already exists:
+;
+;   return m_main.ptrEq(getAddressable(p1), getAddressable(p2));
+
+declare i64 @nd_int()
+declare void @__VERIFIER_assume(i32)
+declare void @__VERIFIER_error()
+
+define i32 @main() {
+entry:
+  ; nd + assume rather than literals, so the frontend cannot constant-fold
+  ; gep(inttoptr(4), -1) into inttoptr(3) -- that fold is what must be avoided.
+  %n = call i64 @nd_int()
+  %n.is4 = icmp eq i64 %n, 4
+  %n.is4.i32 = zext i1 %n.is4 to i32
+  call void @__VERIFIER_assume(i32 %n.is4.i32)
+
+  %m = call i64 @nd_int()
+  %m.is3 = icmp eq i64 %m, 3
+  %m.is3.i32 = zext i1 %m.is3 to i32
+  call void @__VERIFIER_assume(i32 %m.is3.i32)
+
+  ; end: base 4, offset -1  (address 3)
+  %end.base = inttoptr i64 %n to ptr
+  %end = getelementptr i8, ptr %end.base, i64 -1
+
+  ; start: base 3, offset 0 (address 3)
+  %start = inttoptr i64 %m to ptr
+
+  ; start != end is FALSE, so this assertion must be violated -> sat.
+  %ne = icmp ne ptr %start, %end
+  br i1 %ne, label %ok, label %err
+
+err:
+  call void @__VERIFIER_error()
+  unreachable
+
+ok:
+  ret i32 0
+}


### PR DESCRIPTION
Fixing issues found in verify-rust llvm-15 to llvm-18 migration