### PR TITLE
Implement the ShadowMem (BvOpsem2) read metadata channel

### DIFF
--- a/include/seahorn/seahorn.h
+++ b/include/seahorn/seahorn.h
@@ -50,6 +50,18 @@ extern void sea_tracking_on(void);
 extern void sea_tracking_off(void);
 /* reset modified metadata for memory pointed to by arg */
 extern void sea_reset_modified(char *);
+/* returns true if memory pointed to by arg has been read from
+ * 1. allocation OR
+ * 2. reset_read OR
+ * 3. sea_tracking_on
+ * whichever is the latest event.
+ * NOTE: loads only record read metadata under --horn-shadow-mem-load-is-def,
+ * which makes a load a MemDef. Without it this only observes reads marked
+ * explicitly via sea_set_shadowmem(TRACK_READ_MEM, ...).
+ */
+extern bool sea_is_read(char *);
+/* reset read metadata for memory pointed to by arg */
+extern void sea_reset_read(char *);
 /* Set a shadow memory slot S at addr A with value V.
  * arg0 - S. Note that 0 is main memory and should not be used.
  * arg1 - A

--- a/lib/seahorn/BvOpSem2.cc
+++ b/lib/seahorn/BvOpSem2.cc
@@ -51,6 +51,11 @@ using namespace seahorn;
 using namespace seahorn::details;
 using gep_type_iterator = generic_gep_type_iterator<>;
 
+// Defined in sea-dsa/lib/seadsa/ShadowMem.cc. When set, ShadowMem emits loads
+// as MemDefs, which gives a load a write register and lets the opsem stamp
+// read metadata at the loaded address.
+extern llvm::cl::opt<bool> ShadowMemLoadIsDef;
+
 namespace seahorn {
 extern bool isUnifiedAssume(const Instruction &CI);
 #ifdef HAVE_CLAM
@@ -1005,9 +1010,41 @@ public:
     m_ctx.setMemWriteRegister(Expr());
   }
 
-  void visitIsRead(CallBase &CB) {}
+  void visitIsRead(CallBase &CB) {
+    if (!m_ctx.getMemReadRegister()) {
+      LOG("opsem", ERR << "No read register found - check if corresponding"
+                          "shadow instruction is present.");
+      m_ctx.setMemReadRegister(Expr());
+      return;
+    }
+    Expr ptr = lookup(*CB.getOperand(0));
+    auto memIn = m_ctx.read(m_ctx.getMemReadRegister());
+    OpSemMemManager &memManager = m_ctx.mem();
+    auto res = memManager.isMetadataSet(MetadataKind::READ, ptr, memIn);
+    setValue(CB, res);
+    m_ctx.setMemReadRegister(Expr());
+  }
 
-  void visitResetRead(CallBase &CB) {}
+  void visitResetRead(CallBase &CB) {
+    if (!m_ctx.getMemReadRegister() || !m_ctx.getMemWriteRegister()) {
+      LOG("opsem",
+          ERR << "No read/write register found - check if corresponding"
+                 "shadow instruction is present.");
+      m_ctx.setMemReadRegister(Expr());
+      m_ctx.setMemWriteRegister(Expr());
+      return;
+    }
+    Expr ptr = lookup(*CB.getOperand(0));
+    auto memIn = m_ctx.read(m_ctx.getMemReadRegister());
+    OpSemMemManager &memManager = m_ctx.mem();
+    auto res = memManager.setMetadata(
+        MetadataKind::READ, ptr, memIn,
+        m_ctx.alu().num(0, memManager.getMetadataMemWordSzInBits()));
+    m_ctx.write(m_ctx.getMemWriteRegister(), res);
+
+    m_ctx.setMemReadRegister(Expr());
+    m_ctx.setMemWriteRegister(Expr());
+  }
 
   void visitIsAlloc(CallBase &CB) {
     if (!m_ctx.getMemReadRegister()) {
@@ -2469,6 +2506,20 @@ public:
     // XXX avoid reading address if current read is from a scalar
     Expr op0 = ctx.isMemScalar() ? Expr(nullptr) : lookup(addr);
     res = ctx.loadValueFromMem(op0, *ty, alignment);
+
+    // Under --horn-shadow-mem-load-is-def a load is a MemDef, so it has a
+    // write register. Stamp read metadata at the loaded address, making the
+    // address observable to sea_is_read().
+    if (ShadowMemLoadIsDef && op0 && ctx.getMemWriteRegister()) {
+      auto memIn = ctx.read(ctx.getMemReadRegister());
+      OpSemMemManager &memManager = ctx.mem();
+      auto memOut = memManager.setMetadata(
+          MetadataKind::READ, op0, memIn,
+          ctx.alu().num(1U, memManager.getMetadataMemWordSzInBits()));
+      ctx.write(ctx.getMemWriteRegister(), memOut);
+      ctx.setMemWriteRegister(Expr());
+    }
+
     ctx.setMemReadRegister(Expr());
     return res;
   }

--- a/lib/seahorn/BvOpSem2.cc
+++ b/lib/seahorn/BvOpSem2.cc
@@ -2507,15 +2507,25 @@ public:
     Expr op0 = ctx.isMemScalar() ? Expr(nullptr) : lookup(addr);
     res = ctx.loadValueFromMem(op0, *ty, alignment);
 
-    // Under --horn-shadow-mem-load-is-def a load is a MemDef, so it has a
-    // write register. Stamp read metadata at the loaded address, making the
-    // address observable to sea_is_read().
-    if (ShadowMemLoadIsDef && op0 && ctx.getMemWriteRegister()) {
-      auto memIn = ctx.read(ctx.getMemReadRegister());
-      OpSemMemManager &memManager = ctx.mem();
-      auto memOut = memManager.setMetadata(
-          MetadataKind::READ, op0, memIn,
-          ctx.alu().num(1U, memManager.getMetadataMemWordSzInBits()));
+    // Under --horn-shadow-mem-load-is-def a load is emitted as a MemDef, so it
+    // has a write register. Stamp read metadata at the loaded address, making
+    // the address observable to sea_is_read().
+    //
+    // Once that write register exists it MUST be defined on every path: it
+    // names a fresh memory version that later instructions read. Leaving it
+    // undefined makes the version unconstrained, so subsequent loads return
+    // arbitrary values and already-verified programs report spurious
+    // counterexamples. A scalar access has no address to stamp (op0 is null);
+    // define the new version as an unchanged copy rather than skipping it.
+    if (ShadowMemLoadIsDef && ctx.getMemWriteRegister()) {
+      Expr memIn = ctx.read(ctx.getMemReadRegister());
+      Expr memOut = memIn;
+      if (op0) {
+        OpSemMemManager &memManager = ctx.mem();
+        memOut = memManager.setMetadata(
+            MetadataKind::READ, op0, memIn,
+            ctx.alu().num(1U, memManager.getMetadataMemWordSzInBits()));
+      }
       ctx.write(ctx.getMemWriteRegister(), memOut);
       ctx.setMemWriteRegister(Expr());
     }

--- a/lib/seahorn/BvOpSem2ExtraWideMemMgr.cc
+++ b/lib/seahorn/BvOpSem2ExtraWideMemMgr.cc
@@ -662,8 +662,8 @@ typename ExtraWideMemManagerCore<T>::MemValTy
 ExtraWideMemManagerCore<T>::memsetMetadata(
     MetadataKind kind, ExtraWideMemManagerCore::PtrTy ptr, unsigned int len,
     ExtraWideMemManagerCore::MemValTy memIn, unsigned int val) {
-  auto rawOut =
-      m_main.memsetMetadata(kind, ptr.getBase(), len, memIn.getRaw(), val);
+  auto rawOut = m_main.memsetMetadata(kind, metadataPtr(kind, ptr), len,
+                                      memIn.getRaw(), val);
   return MemValTy(rawOut, memIn.getOffset(), memIn.getSize());
 }
 template <class T>
@@ -671,16 +671,23 @@ typename ExtraWideMemManagerCore<T>::MemValTy
 ExtraWideMemManagerCore<T>::memsetMetadata(
     MetadataKind kind, ExtraWideMemManagerCore::PtrTy ptr, Expr len,
     ExtraWideMemManagerCore::MemValTy memIn, unsigned int val) {
-  auto rawOut =
-      m_main.memsetMetadata(kind, ptr.getBase(), len, memIn.getRaw(), val);
+  auto rawOut = m_main.memsetMetadata(kind, metadataPtr(kind, ptr), len,
+                                      memIn.getRaw(), val);
   return MemValTy(rawOut, memIn.getOffset(), memIn.getSize());
+}
+
+template <class T>
+typename ExtraWideMemManagerCore<T>::RawPtrTy
+ExtraWideMemManagerCore<T>::metadataPtr(MetadataKind kind, PtrTy p) const {
+  return kind == MetadataKind::READ ? getAddressable(p) : p.getBase();
 }
 
 template <class T>
 Expr ExtraWideMemManagerCore<T>::getMetadata(MetadataKind kind, PtrTy ptr,
                                              MemValTy memIn,
                                              unsigned int byteSz) {
-  return m_main.getMetadata(kind, ptr.getBase(), memIn.getRaw(), byteSz);
+  return m_main.getMetadata(kind, metadataPtr(kind, ptr), memIn.getRaw(),
+                            byteSz);
 }
 
 template <class T>
@@ -702,7 +709,8 @@ ExtraWideMemManagerCore<T>::setMetadata(MetadataKind kind,
              << "\n";);
     return mem;
   }
-  auto rawOut = m_main.setMetadata(kind, ptr.getBase(), mem.getRaw(), val);
+  auto rawOut =
+      m_main.setMetadata(kind, metadataPtr(kind, ptr), mem.getRaw(), val);
   return MemValTy(rawOut, mem.getOffset(), mem.getSize());
   ;
 }

--- a/lib/seahorn/BvOpSem2ExtraWideMemMgr.hh
+++ b/lib/seahorn/BvOpSem2ExtraWideMemMgr.hh
@@ -299,6 +299,15 @@ public:
 
   RawPtrTy getAddressable(PtrTy p) const;
 
+  /// \brief Pointer at which metadata of \p kind for \p p is stored.
+  ///
+  /// READ is keyed by the addressable pointer (base+offset) so that distinct
+  /// elements of one object are distinguished -- an address channel needs to
+  /// know *which* element was read. Every other kind is keyed by the base, so
+  /// that e.g. sea_is_modified(p) keeps meaning "was anything in this object
+  /// modified" regardless of which member the store targeted.
+  RawPtrTy metadataPtr(MetadataKind kind, PtrTy p) const;
+
   bool isPtrTyVal(Expr e) const;
 
   bool isMemVal(Expr e) const;

--- a/lib/seahorn/DfCoiAnalysis.cc
+++ b/lib/seahorn/DfCoiAnalysis.cc
@@ -12,10 +12,10 @@ namespace seahorn {
 
 void DfCoiAnalysis::analyze(User &user) {
   constexpr auto shadowStoreSucc = boost::hana::make_set(
-      "sea.reset_modified", "sea.free", "sea.set_shadowmem");
+      "sea.reset_modified", "sea.reset_read", "sea.free", "sea.set_shadowmem");
 
   constexpr auto shadowLoadSucc = boost::hana::make_set(
-      "sea.is_modified", "sea.is_alloc", "sea.get_shadowmem");
+      "sea.is_modified", "sea.is_read", "sea.is_alloc", "sea.get_shadowmem");
 
   if (m_coi.count(&user))
     return;

--- a/test/opsem2/trackingmem/isread_metadata_sat.c
+++ b/test/opsem2/trackingmem/isread_metadata_sat.c
@@ -1,0 +1,29 @@
+//; RUN: %sea "%s" --horn-bv2-extra-widemem --horn-bv2-tracking-mem 2>&1 | filecheck %s
+// CHECK: {{^sat$}}
+
+// Read metadata is set, so sea_is_read() must observe it and the assertion
+// must fail. Guards the visitIsRead implementation in BvOpSem2 and the
+// "sea.is_read" entry in DfCoiAnalysis: without the latter the preceding
+// shadow.mem.load is pruned under COI, sea_is_read yields no register, and
+// the result is a vacuous sat rather than this one.
+
+#include "seahorn/seahorn.h"
+#include <stdbool.h>
+#include <stdlib.h>
+
+extern bool sea_is_read(char *);
+extern void sea_set_shadowmem(char, char *, size_t);
+extern void sea_tracking_on();
+extern void sea_tracking_off();
+extern void memhavoc(void *, size_t);
+
+int main(int argc, char **argv) {
+  sea_tracking_on();
+  char *buf = (char *)malloc(8);
+  memhavoc(buf, 8);
+  sea_set_shadowmem(TRACK_READ_MEM, buf, 1);
+  // this assert will fail
+  sassert(!sea_is_read(buf));
+  sea_tracking_off();
+  return 0;
+}

--- a/test/opsem2/trackingmem/isread_metadata_unsat.c
+++ b/test/opsem2/trackingmem/isread_metadata_unsat.c
@@ -1,0 +1,27 @@
+//; RUN: %sea "%s" --horn-bv2-extra-widemem --horn-bv2-tracking-mem 2>&1 | filecheck %s
+// CHECK: {{^unsat$}}
+
+// Negative control for isread_metadata_sat.c: read metadata is cleared, so
+// sea_is_read() must report false and the assertion must hold. Together the
+// pair shows sea_is_read tracks the metadata rather than returning a constant
+// or an unconstrained value.
+
+#include "seahorn/seahorn.h"
+#include <stdbool.h>
+#include <stdlib.h>
+
+extern bool sea_is_read(char *);
+extern void sea_set_shadowmem(char, char *, size_t);
+extern void sea_tracking_on();
+extern void sea_tracking_off();
+extern void memhavoc(void *, size_t);
+
+int main(int argc, char **argv) {
+  sea_tracking_on();
+  char *buf = (char *)malloc(8);
+  memhavoc(buf, 8);
+  sea_set_shadowmem(TRACK_READ_MEM, buf, 0);
+  sassert(!sea_is_read(buf));
+  sea_tracking_off();
+  return 0;
+}

--- a/test/opsem2/trackingmem/isread_symbolic_index_unsat.c
+++ b/test/opsem2/trackingmem/isread_symbolic_index_unsat.c
@@ -1,0 +1,51 @@
+//; RUN: %sea "%s" --horn-bv2-extra-widemem --horn-bv2-tracking-mem --horn-shadow-mem-load-is-def 2>&1 | filecheck %s
+// CHECK: {{^unsat$}}
+
+// Read metadata must be keyed per ADDRESS, not per allocation: a load at a
+// symbolic index must mark only the element it actually touched.
+//
+// The other tests here index with constants, which are folded so each element
+// presents a distinct pointer base -- they pass even when metadata is keyed by
+// the allocation base, and so cannot observe this class of defect. A symbolic
+// index keeps the displacement in the pointer's offset field, which is exactly
+// where the information used to be dropped, collapsing every element of the
+// object onto one metadata slot.
+//
+// Here t[i] is loaded with i pinned to 2, so t[0] must remain unread. If
+// metadata degrades to allocation granularity this assertion fails and the
+// test reports sat.
+
+#include "seahorn/seahorn.h"
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+extern bool sea_is_read(char *);
+extern void sea_reset_read(char *);
+extern void sea_tracking_on();
+extern void sea_tracking_off();
+extern void memhavoc(void *, size_t);
+extern uint32_t nd_u32();
+
+// keeps the load live; a load outside the assertion's cone of influence is
+// optimized away before it can stamp anything
+volatile uint32_t g_sink;
+
+int main(int argc, char **argv) {
+  uint32_t t[8];
+  sea_tracking_on();
+  memhavoc(t, sizeof(t));
+
+  uint32_t i = nd_u32();
+  assume(i < 8);
+  assume(i == 2);
+
+  for (unsigned k = 0; k < 8; ++k)
+    sea_reset_read((char *)&t[k]);
+
+  g_sink = t[i];
+
+  sassert(!sea_is_read((char *)&t[0]));
+  sea_tracking_off();
+  return 0;
+}

--- a/test/opsem2/trackingmem/load_is_def_memory_unsat.c
+++ b/test/opsem2/trackingmem/load_is_def_memory_unsat.c
@@ -1,0 +1,65 @@
+//; RUN: %sea "%s" --horn-bv2-extra-widemem --horn-bv2-tracking-mem --horn-shadow-mem-load-is-def 2>&1 | filecheck %s
+// CHECK: {{^unsat$}}
+
+// Ordinary memory semantics must survive --horn-shadow-mem-load-is-def: a value
+// stored is the value loaded back, on a buffer whose read metadata is observed
+// and on one that is not.
+//
+// Regression test for a real defect. The first implementation made EVERY load a
+// MemDef, including loads on DSA nodes that the interprocedural mod/ref summary
+// classified read-only. Their call sites still passed the node as
+// shadow.mem.arg.ref (in-only) while the callee now produced a new memory
+// version, leaving shadow SSA inconsistent across the boundary. Two
+// already-verified verify-c-common jobs (hash_table_create, hash_table_put)
+// silently flipped unsat -> sat: spurious counterexamples on correct code, with
+// no diagnostic. Loads are now emitted as MemDefs only for nodes whose read
+// metadata is actually observed, and such nodes are additionally marked
+// modified so the summary matches the defs emitted.
+//
+// `plain` exercises the untracked path (no MemDefs) and `tracked` the gated one
+// (MemDefs), in one program so the two cannot drift apart.
+//
+// Indices are symbolic and only assumed equal, so the store/load pair cannot be
+// discharged by store-to-load forwarding in the front end -- with constant
+// indices the assertions fold away and seahorn reports "no assertion was found"
+// rather than unsat.
+
+#include "seahorn/seahorn.h"
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+extern bool sea_is_read(char *);
+extern void sea_reset_read(char *);
+extern void sea_tracking_on();
+extern void sea_tracking_off();
+extern void memhavoc(void *, size_t);
+extern uint32_t nd_u32();
+
+int main(int argc, char **argv) {
+  uint32_t *tracked = (uint32_t *)malloc(4 * sizeof(uint32_t));
+  uint32_t *plain = (uint32_t *)malloc(4 * sizeof(uint32_t));
+  memhavoc(tracked, 4 * sizeof(uint32_t));
+  memhavoc(plain, 4 * sizeof(uint32_t));
+
+  sea_tracking_on();
+  // observing this buffer is what makes its node read-tracked, so only its
+  // loads become MemDefs
+  sea_reset_read((char *)tracked);
+
+  uint32_t v = nd_u32();
+  uint32_t i = nd_u32();
+  uint32_t j = nd_u32();
+  assume(i < 4);
+  assume(j < 4);
+  assume(i == j);
+
+  plain[i] = v;
+  sassert(plain[j] == v);
+
+  tracked[i] = v;
+  sassert(tracked[j] == v);
+
+  sea_tracking_off();
+  return 0;
+}

--- a/test/opsem2/trackingmem/load_is_def_sat.c
+++ b/test/opsem2/trackingmem/load_is_def_sat.c
@@ -1,0 +1,34 @@
+//; RUN: %sea "%s" --horn-bv2-extra-widemem --horn-bv2-tracking-mem --horn-shadow-mem-load-is-def 2>&1 | filecheck %s
+// CHECK: {{^sat$}}
+
+// Under --horn-shadow-mem-load-is-def a load is emitted as a MemDef, so it
+// has a write register and the opsem stamps read metadata at the loaded
+// address. The load of buf[0] therefore makes sea_is_read(buf) true and the
+// assertion fails.
+//
+// NOTE: the loaded value must appear INSIDE the assertion. If it does not,
+// the load is not in the assertion's cone of influence and is optimized away
+// before it can be observed, which yields unsat and looks exactly like the
+// feature being absent.
+
+#include "seahorn/seahorn.h"
+#include <stdbool.h>
+#include <stdlib.h>
+
+extern bool sea_is_read(char *);
+extern void sea_reset_read(char *);
+extern void sea_tracking_on();
+extern void sea_tracking_off();
+extern void memhavoc(void *, size_t);
+
+int main(int argc, char **argv) {
+  sea_tracking_on();
+  char *buf = (char *)malloc(8);
+  memhavoc(buf, 8);
+  sea_reset_read(buf);
+  char v = buf[0];
+  // this assert will fail: buf[0] was read, so the disjunct requires v == 0
+  sassert(v == 0 || !sea_is_read(buf));
+  sea_tracking_off();
+  return 0;
+}

--- a/test/opsem2/trackingmem/load_is_def_unsat.c
+++ b/test/opsem2/trackingmem/load_is_def_unsat.c
@@ -1,0 +1,29 @@
+//; RUN: %sea "%s" --horn-bv2-extra-widemem --horn-bv2-tracking-mem 2>&1 | filecheck %s
+// CHECK: {{^unsat$}}
+
+// Same program as load_is_def_sat.c but WITHOUT
+// --horn-shadow-mem-load-is-def. Loads stay MemUses, no read metadata is
+// stamped, sea_is_read(buf) is false and the assertion holds. This pins the
+// default: making every load a MemDef adds a memory version per load and
+// grows the VC, so it must stay opt-in.
+
+#include "seahorn/seahorn.h"
+#include <stdbool.h>
+#include <stdlib.h>
+
+extern bool sea_is_read(char *);
+extern void sea_reset_read(char *);
+extern void sea_tracking_on();
+extern void sea_tracking_off();
+extern void memhavoc(void *, size_t);
+
+int main(int argc, char **argv) {
+  sea_tracking_on();
+  char *buf = (char *)malloc(8);
+  memhavoc(buf, 8);
+  sea_reset_read(buf);
+  char v = buf[0];
+  sassert(v == 0 || !sea_is_read(buf));
+  sea_tracking_off();
+  return 0;
+}


### PR DESCRIPTION
## Summary

Makes `sea_is_read` / `sea_reset_read` work in the tracking-memory OpSem, and fixes two defects that made the read channel unusable for observing a load at a specific address. Previously the visitors were empty stubs: the call produced no register, the engine degraded to havoc, and `sea_is_read()` returned a vacuous `sat` while verifying nothing.

## Changes

- **Read channel** (`BvOpSem2.cc`): implement `visitIsRead`/`visitResetRead` as the `MetadataKind::READ` mirrors of the modified-channel visitors.
- **COI** (`DfCoiAnalysis.cc`): add `sea.is_read`/`sea.reset_read` to the intrinsic sets that keep the feeding `shadow.mem.load` alive, so `--horn-bmc-coi` no longer prunes the read register.
- **Load stamping** (`BvOpSem2.cc`): under `--horn-shadow-mem-load-is-def`, stamp read metadata at the loaded address so it's observable to `sea_is_read()`.
- **Key READ by address, not base** (`BvOpSem2ExtraWideMemMgr.{cc,hh}`): `metadataPtr()` uses `getAddressable(p)` for `MetadataKind::READ` and `p.getBase()` otherwise, so reads are per-element while `sea_is_modified` stays object-wide.
- **Always define the load MemDef** (`BvOpSem2.cc`): a scalar access previously left the memory version unconstrained; now defined on every path (stamped, else pass-through copy).
- **`seahorn.h`**: declare `sea_is_read`/`sea_reset_read`.

## Tests

Neither intrinsic had prior coverage. Adds six lit tests under `test/opsem2/trackingmem/`: `isread_metadata_{sat,unsat}`, `isread_symbolic_index_unsat` (precision under a symbolic index), and `load_is_def_{sat,unsat}` / `load_is_def_memory_unsat` (load stamping, flag on and off).

## Dependencies

⚠️ Requires the companion **sea-dsa** commit(s) adding `--horn-shadow-mem-load-is-def` and gating load MemDefs to read-tracked nodes.

## Validation

`lit test/opsem2` 50/50 · `test/opsem` 125 + 1 expected failure · `verify-c-common` 228/228 with the flag on and off.

## Clients
This is needed for information flow proofs in https://github.com/for-all-dev/aisec-invariants-mlir/tree/master/prototypes/proofs_l2_seabmc